### PR TITLE
feat(llm): confirm MiniLM path and live LLM health in /status

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -12,6 +12,7 @@ JUNO_API_PORT=8787
 JUNO_API_TOKEN=change-me
 
 # LLM
+# ollama | openai_compat | offline (retrieve-only fallback)
 LLM_PROVIDER=ollama
 OLLAMA_BASE_URL=http://127.0.0.1:11434
 OLLAMA_MODEL=llama3.2
@@ -22,4 +23,5 @@ OPENAI_MODEL=gpt-4o-mini
 # Embeddings (pinned — changing requires reindex)
 EMBEDDING_MODEL=all-MiniLM-L6-v2
 # Use stub embedder in CI / tests: stub | sentence_transformers
+# Local MiniLM: uv sync --extra embeddings  (falls back to stub if missing)
 EMBEDDING_BACKEND=sentence_transformers

--- a/README.md
+++ b/README.md
@@ -24,6 +24,8 @@ Personal knowledge-graph agent: passively (and manually) capture what you read, 
 ```powershell
 cd apps/core
 uv sync --extra dev
+# Local MiniLM embeddings (optional; without this, serve falls back to the stub):
+uv sync --extra dev --extra embeddings
 copy ..\..\.env.example ..\..\.env   # from repo root: copy .env.example .env
 # Edit .env: TELEGRAM_BOT_TOKEN, ALLOWED_TELEGRAM_USER_IDS, JUNO_API_TOKEN
 uv run juno db-init
@@ -31,6 +33,7 @@ uv run juno serve
 ```
 
 - API: `http://127.0.0.1:8787/health`
+- Token-gated `GET /status` reports the live embedder (model / backend / dimensions) and LLM health (`llm_healthy`, `llm_provider`, `llm_model`). If Ollama is down, `llm_healthy` is false and answers should stay retrieve-only.
 - Bot runs only while this process (and PC) is on. Telegram queues updates ~24h; longer downtime can drop messages — `/status` will surface this once fully wired.
 
 ### Tests

--- a/apps/core/src/juno/api/__init__.py
+++ b/apps/core/src/juno/api/__init__.py
@@ -18,12 +18,14 @@ def create_app(
     embedder: Any = None,
     vectors: Any = None,
     pipeline: Any = None,
+    chat: Any = None,
 ) -> FastAPI:
     app = FastAPI(title="Juno", version="0.1.0")
     app.state.settings = settings
     app.state.db = db
     app.state.embedder = embedder
     app.state.vectors = vectors
+    app.state.chat = chat
     app.state.capture_paused = False
     app.state.llm_healthy = False
     if pipeline is not None:
@@ -58,14 +60,34 @@ def create_app(
     async def status() -> dict[str, Any]:
         embedder = app.state.embedder
         vectors = app.state.vectors
+        chat = getattr(app.state, "chat", None)
         chroma_count = 0
         if vectors is not None:
             chroma_count = await asyncio.to_thread(vectors.count)
+
+        llm_healthy = bool(getattr(app.state, "llm_healthy", False))
+        llm_provider = getattr(chat, "name", None) or settings.llm_provider
+        llm_model = getattr(chat, "model", None) or settings.llm_model
+        if chat is not None:
+            llm_healthy = await chat.healthy(timeout=1.5)
+            app.state.llm_healthy = llm_healthy
+
+        actual_backend = (
+            getattr(embedder, "backend", settings.embedding_backend)
+            if embedder is not None
+            else settings.embedding_backend
+        )
         return {
             "capture_paused": app.state.capture_paused,
-            "llm_healthy": app.state.llm_healthy,
+            "llm_healthy": llm_healthy,
+            "llm_provider": llm_provider,
+            "llm_model": llm_model,
             "embedding_model": getattr(embedder, "model_id", settings.embedding_model),
-            "embedding_backend": settings.embedding_backend,
+            "embedding_backend": actual_backend,
+            "embedding_dimensions": getattr(embedder, "dimensions", None),
+            "embedding_fallback": bool(
+                embedder is not None and actual_backend != settings.embedding_backend
+            ),
             "chroma_collection": getattr(vectors, "collection_name", None),
             "chroma_count": chroma_count,
             "api_host": settings.juno_api_host,

--- a/apps/core/src/juno/config.py
+++ b/apps/core/src/juno/config.py
@@ -24,7 +24,7 @@ class Settings(BaseSettings):
     juno_api_port: int = 8787
     juno_api_token: str = "change-me"
 
-    llm_provider: str = "ollama"  # ollama | openai_compat
+    llm_provider: str = "ollama"  # ollama | openai_compat | offline
     ollama_base_url: str = "http://127.0.0.1:11434"
     ollama_model: str = "llama3.2"
     openai_api_key: str = ""
@@ -46,6 +46,14 @@ class Settings(BaseSettings):
     @property
     def chroma_path(self) -> Path:
         return self.juno_data_dir / "chroma"
+
+    @property
+    def llm_model(self) -> str:
+        if self.llm_provider == "openai_compat":
+            return self.openai_model
+        if self.llm_provider == "offline":
+            return ""
+        return self.ollama_model
 
 
 def get_settings() -> Settings:

--- a/apps/core/src/juno/llm/__init__.py
+++ b/apps/core/src/juno/llm/__init__.py
@@ -1,6 +1,12 @@
 """LLM package."""
 
-from juno.llm.chat import ChatProvider, create_chat_provider
+from juno.llm.chat import ChatProvider, OfflineProvider, create_chat_provider
 from juno.llm.embedder import Embedder, create_embedder
 
-__all__ = ["ChatProvider", "Embedder", "create_chat_provider", "create_embedder"]
+__all__ = [
+    "ChatProvider",
+    "Embedder",
+    "OfflineProvider",
+    "create_chat_provider",
+    "create_embedder",
+]

--- a/apps/core/src/juno/llm/chat.py
+++ b/apps/core/src/juno/llm/chat.py
@@ -8,8 +8,26 @@ from typing import Any
 import httpx
 
 
+def _ollama_model_present(names: list[str], want: str) -> bool:
+    """True if Ollama's /api/tags list includes the configured model (tag optional)."""
+    want = (want or "").strip()
+    if not want:
+        return False
+    want_base = want.split(":", 1)[0]
+    for name in names:
+        raw = (name or "").strip()
+        if not raw:
+            continue
+        if raw == want or raw.startswith(f"{want}:"):
+            return True
+        if raw.split(":", 1)[0] == want_base:
+            return True
+    return False
+
+
 class ChatProvider(ABC):
     name: str
+    model: str
 
     @abstractmethod
     async def complete(
@@ -22,7 +40,7 @@ class ChatProvider(ABC):
         raise NotImplementedError
 
     @abstractmethod
-    async def healthy(self) -> bool:
+    async def healthy(self, *, timeout: float = 3.0) -> bool:
         raise NotImplementedError
 
 
@@ -51,11 +69,15 @@ class OllamaProvider(ChatProvider):
             data: dict[str, Any] = resp.json()
             return str(data.get("message", {}).get("content", ""))
 
-    async def healthy(self) -> bool:
+    async def healthy(self, *, timeout: float = 3.0) -> bool:
         try:
-            async with httpx.AsyncClient(timeout=3.0) as client:
+            async with httpx.AsyncClient(timeout=timeout) as client:
                 resp = await client.get(f"{self.base_url}/api/tags")
-                return resp.status_code == 200
+                if resp.status_code != 200:
+                    return False
+                models = resp.json().get("models") or []
+                names = [str(m.get("name", "")) for m in models if isinstance(m, dict)]
+                return _ollama_model_present(names, self.model)
         except Exception:
             return False
 
@@ -90,14 +112,30 @@ class OpenAICompatProvider(ChatProvider):
             data = resp.json()
             return str(data["choices"][0]["message"]["content"])
 
-    async def healthy(self) -> bool:
-        return bool(self.api_key)
+    async def healthy(self, *, timeout: float = 3.0) -> bool:
+        if not self.api_key:
+            return False
+        try:
+            async with httpx.AsyncClient(timeout=timeout) as client:
+                resp = await client.get(
+                    f"{self.base_url}/models",
+                    headers={"Authorization": f"Bearer {self.api_key}"},
+                )
+                if resp.status_code == 404:
+                    # Some local OpenAI-compat servers omit /models.
+                    return True
+                return resp.status_code == 200
+        except Exception:
+            return False
 
 
 class OfflineProvider(ChatProvider):
     """Fallback when no LLM is available — callers should use retrieve-only mode."""
 
     name = "offline"
+
+    def __init__(self, model: str = "") -> None:
+        self.model = model
 
     async def complete(
         self,
@@ -108,7 +146,7 @@ class OfflineProvider(ChatProvider):
     ) -> str:
         raise RuntimeError("LLM offline — use retrieve-only fallback")
 
-    async def healthy(self) -> bool:
+    async def healthy(self, *, timeout: float = 3.0) -> bool:
         return False
 
 
@@ -121,6 +159,8 @@ def create_chat_provider(
     openai_api_key: str,
     openai_model: str,
 ) -> ChatProvider:
+    if provider == "offline":
+        return OfflineProvider()
     if provider == "ollama":
         return OllamaProvider(ollama_base_url, ollama_model)
     if provider == "openai_compat":

--- a/apps/core/src/juno/llm/embedder.py
+++ b/apps/core/src/juno/llm/embedder.py
@@ -8,6 +8,7 @@ from abc import ABC, abstractmethod
 
 
 class Embedder(ABC):
+    backend: str
     model_id: str
     dimensions: int
 
@@ -18,6 +19,8 @@ class Embedder(ABC):
 
 class StubEmbedder(Embedder):
     """Deterministic hash-based vectors for tests/CI (no torch download)."""
+
+    backend = "stub"
 
     def __init__(self, model_id: str = "stub-hash-v1", dimensions: int = 64) -> None:
         self.model_id = model_id
@@ -46,16 +49,29 @@ class StubEmbedder(Embedder):
 
 
 class SentenceTransformerEmbedder(Embedder):
+    backend = "sentence_transformers"
+
     def __init__(self, model_id: str = "all-MiniLM-L6-v2") -> None:
-        from sentence_transformers import SentenceTransformer
+        try:
+            from sentence_transformers import SentenceTransformer
+        except ImportError as exc:
+            raise ImportError(
+                "sentence-transformers is not installed. "
+                "From apps/core run: uv sync --extra embeddings"
+            ) from exc
 
         self.model_id = model_id
         self._model = SentenceTransformer(model_id)
         self.dimensions = int(self._model.get_sentence_embedding_dimension())
 
     def embed(self, texts: list[str]) -> list[list[float]]:
+        if not texts:
+            return []
         vectors = self._model.encode(texts, normalize_embeddings=True)
-        return [v.tolist() for v in vectors]
+        rows = vectors.tolist() if hasattr(vectors, "tolist") else [list(v) for v in vectors]
+        if rows and isinstance(rows[0], (int, float)):
+            return [list(rows)]
+        return [list(row) for row in rows]
 
 
 def create_embedder(backend: str, model_id: str) -> Embedder:

--- a/apps/core/src/juno/runtime.py
+++ b/apps/core/src/juno/runtime.py
@@ -9,9 +9,11 @@ from __future__ import annotations
 import asyncio
 import logging
 from contextlib import asynccontextmanager
+from datetime import UTC, datetime
 
 import uvicorn
 from fastapi import FastAPI
+from sqlalchemy.ext.asyncio import AsyncSession
 from telegram.ext import Application, CommandHandler, MessageHandler, filters
 
 from juno.api import create_app
@@ -21,8 +23,9 @@ from juno.graph.db import Database
 from juno.graph.vectors import VectorStore
 from juno.ingest.pipeline import IngestPipeline
 from juno.ingest.watcher import InboxWatcher
-from juno.llm.chat import create_chat_provider
-from juno.llm.embedder import create_embedder
+from juno.llm.chat import ChatProvider, create_chat_provider
+from juno.llm.embedder import Embedder, create_embedder
+from juno.models import AppSetting, ModuleHealth
 
 logger = logging.getLogger("juno.runtime")
 
@@ -39,12 +42,53 @@ def build_telegram_application(settings: Settings) -> Application | None:
     return app
 
 
+async def persist_embedder_settings(db: Database, embedder: Embedder) -> None:
+    """Record the live embedding model id so a later reindex can see what was used."""
+
+    async def write(session: AsyncSession) -> None:
+        pairs = {
+            "embedding_model": embedder.model_id,
+            "embedding_backend": embedder.backend,
+            "embedding_dimensions": str(embedder.dimensions),
+        }
+        for key, value in pairs.items():
+            row = await session.get(AppSetting, key)
+            if row is None:
+                session.add(AppSetting(key=key, value=value))
+            else:
+                row.value = value
+
+    await db.write(write)
+
+
+async def persist_llm_health(db: Database, chat: ChatProvider, *, ok: bool) -> None:
+    async def write(session: AsyncSession) -> None:
+        row = await session.get(ModuleHealth, "llm")
+        if row is None:
+            row = ModuleHealth(module="llm")
+            session.add(row)
+        now = datetime.now(UTC)
+        row.detail = f"{chat.name}:{chat.model}" if chat.model else chat.name
+        if ok:
+            row.last_success_at = now
+            row.last_error = None
+        else:
+            row.last_error_at = now
+            row.last_error = "health probe failed"
+
+    await db.write(write)
+
+
 def attach_lifespan(fastapi_app: FastAPI) -> FastAPI:
     @asynccontextmanager
     async def lifespan(app: FastAPI):
         settings: Settings = app.state.settings
         db: Database = app.state.db
         await db.migrate()
+
+        embedder: Embedder | None = getattr(app.state, "embedder", None)
+        if embedder is not None:
+            await persist_embedder_settings(db, embedder)
 
         chat = create_chat_provider(
             settings.llm_provider,
@@ -54,8 +98,16 @@ def attach_lifespan(fastapi_app: FastAPI) -> FastAPI:
             openai_api_key=settings.openai_api_key,
             openai_model=settings.openai_model,
         )
-        app.state.llm_healthy = await chat.healthy()
+        llm_healthy = await chat.healthy()
+        if not llm_healthy:
+            logger.warning(
+                "LLM provider %s is unhealthy — /status will keep probing; "
+                "answers should use retrieve-only fallback",
+                chat.name,
+            )
+        app.state.llm_healthy = llm_healthy
         app.state.chat = chat
+        await persist_llm_health(db, chat, ok=llm_healthy)
 
         pipeline = getattr(app.state, "pipeline", None)
         if pipeline is not None:
@@ -107,7 +159,13 @@ async def run_server(settings: Settings | None = None) -> None:
 
     vectors = VectorStore(settings, embedder)
     pipeline = IngestPipeline(db=db, vectors=vectors)
-    fastapi_app = create_app(settings, db=db, embedder=embedder, vectors=vectors, pipeline=pipeline)
+    fastapi_app = create_app(
+        settings,
+        db=db,
+        embedder=embedder,
+        vectors=vectors,
+        pipeline=pipeline,
+    )
     fastapi_app.state.settings = settings
     fastapi_app.state.db = db
     fastapi_app.state.embedder = embedder

--- a/apps/core/tests/test_chat.py
+++ b/apps/core/tests/test_chat.py
@@ -1,0 +1,200 @@
+from __future__ import annotations
+
+from typing import Any
+
+import httpx
+import pytest
+
+from juno.graph.db import Database
+from juno.llm.chat import (
+    OfflineProvider,
+    OllamaProvider,
+    OpenAICompatProvider,
+    _ollama_model_present,
+    create_chat_provider,
+)
+from juno.models import ModuleHealth
+from juno.runtime import persist_llm_health
+
+_RealAsyncClient = httpx.AsyncClient
+
+
+def _patch_client(monkeypatch: pytest.MonkeyPatch, handler):
+    def factory(*args: Any, **kwargs: Any) -> httpx.AsyncClient:
+        def transport_handler(request: httpx.Request) -> httpx.Response:
+            headers = dict(request.headers)
+            return handler(request.method, str(request.url), headers=headers)
+
+        kwargs["transport"] = httpx.MockTransport(transport_handler)
+        return _RealAsyncClient(*args, **kwargs)
+
+    monkeypatch.setattr("juno.llm.chat.httpx.AsyncClient", factory)
+
+
+def test_create_chat_provider_switches_on_name():
+    ollama = create_chat_provider(
+        "ollama",
+        ollama_base_url="http://127.0.0.1:11434",
+        ollama_model="llama3.2",
+        openai_base_url="https://api.openai.com/v1",
+        openai_api_key="sk-test",
+        openai_model="gpt-4o-mini",
+    )
+    assert isinstance(ollama, OllamaProvider)
+    assert ollama.model == "llama3.2"
+
+    openai = create_chat_provider(
+        "openai_compat",
+        ollama_base_url="http://127.0.0.1:11434",
+        ollama_model="llama3.2",
+        openai_base_url="http://127.0.0.1:1234/v1",
+        openai_api_key="local",
+        openai_model="local-model",
+    )
+    assert isinstance(openai, OpenAICompatProvider)
+    assert openai.model == "local-model"
+
+    offline = create_chat_provider(
+        "offline",
+        ollama_base_url="http://127.0.0.1:11434",
+        ollama_model="llama3.2",
+        openai_base_url="https://api.openai.com/v1",
+        openai_api_key="",
+        openai_model="gpt-4o-mini",
+    )
+    assert isinstance(offline, OfflineProvider)
+
+
+def test_create_chat_provider_unknown():
+    with pytest.raises(ValueError, match="Unknown LLM provider"):
+        create_chat_provider(
+            "anthropic",
+            ollama_base_url="",
+            ollama_model="",
+            openai_base_url="",
+            openai_api_key="",
+            openai_model="",
+        )
+
+
+def test_ollama_model_present_matches_tags():
+    names = ["llama3.2:latest", "nomic-embed-text:latest"]
+    assert _ollama_model_present(names, "llama3.2") is True
+    assert _ollama_model_present(names, "llama3.2:latest") is True
+    assert _ollama_model_present(names, "mistral") is False
+
+
+@pytest.mark.asyncio
+async def test_ollama_healthy_when_model_listed(monkeypatch):
+    def handler(method: str, url: str, **kwargs: Any) -> httpx.Response:
+        assert method == "GET"
+        assert url.endswith("/api/tags")
+        return httpx.Response(200, json={"models": [{"name": "llama3.2:latest"}]})
+
+    _patch_client(monkeypatch, handler)
+    assert await OllamaProvider("http://127.0.0.1:11434", "llama3.2").healthy() is True
+
+
+@pytest.mark.asyncio
+async def test_ollama_unhealthy_when_down(monkeypatch):
+    def handler(method: str, url: str, **kwargs: Any) -> httpx.Response:
+        raise RuntimeError("offline")
+
+    _patch_client(monkeypatch, handler)
+    assert await OllamaProvider("http://127.0.0.1:11434", "llama3.2").healthy() is False
+
+
+@pytest.mark.asyncio
+async def test_ollama_complete(monkeypatch):
+    def handler(method: str, url: str, **kwargs: Any) -> httpx.Response:
+        assert method == "POST"
+        assert url.endswith("/api/chat")
+        return httpx.Response(200, json={"message": {"content": "hello graph"}})
+
+    _patch_client(monkeypatch, handler)
+    text = await OllamaProvider("http://127.0.0.1:11434", "llama3.2").complete(
+        "sys", [{"role": "user", "content": "hi"}]
+    )
+    assert text == "hello graph"
+
+
+@pytest.mark.asyncio
+async def test_openai_healthy_requires_key_and_models():
+    assert (
+        await OpenAICompatProvider("https://api.openai.com/v1", "", "gpt-4o-mini").healthy()
+        is False
+    )
+
+
+@pytest.mark.asyncio
+async def test_openai_healthy_models_ok(monkeypatch):
+    def handler(method: str, url: str, **kwargs: Any) -> httpx.Response:
+        assert method == "GET"
+        assert url.endswith("/models")
+        auth = kwargs["headers"].get("Authorization") or kwargs["headers"].get("authorization")
+        assert auth == "Bearer sk-test"
+        return httpx.Response(200, json={"data": []})
+
+    _patch_client(monkeypatch, handler)
+    assert (
+        await OpenAICompatProvider("https://api.openai.com/v1", "sk-test", "gpt-4o-mini").healthy()
+        is True
+    )
+
+
+@pytest.mark.asyncio
+async def test_openai_healthy_404_compat(monkeypatch):
+    def handler(method: str, url: str, **kwargs: Any) -> httpx.Response:
+        return httpx.Response(404)
+
+    _patch_client(monkeypatch, handler)
+    assert await OpenAICompatProvider("http://127.0.0.1:1234/v1", "local", "m").healthy() is True
+
+
+@pytest.mark.asyncio
+async def test_offline_fallback():
+    chat = OfflineProvider()
+    assert await chat.healthy() is False
+    with pytest.raises(RuntimeError, match="retrieve-only"):
+        await chat.complete("sys", [{"role": "user", "content": "q"}])
+
+
+@pytest.mark.asyncio
+async def test_persist_llm_health(settings):
+    db = Database(settings)
+    await db.create_all()
+    chat = OfflineProvider()
+    await persist_llm_health(db, chat, ok=False)
+
+    async def fetch(session):
+        return await session.get(ModuleHealth, "llm")
+
+    row = await db.read(fetch)
+    assert row is not None
+    assert row.last_error == "health probe failed"
+    assert row.detail == "offline"
+    await db.dispose()
+
+
+def test_status_live_llm_probe(settings):
+    from fastapi.testclient import TestClient
+
+    from juno.api import create_app
+
+    class FakeChat:
+        name = "ollama"
+        model = "llama3.2"
+        calls = 0
+
+        async def healthy(self, *, timeout: float = 3.0) -> bool:
+            self.calls += 1
+            return True
+
+    chat = FakeChat()
+    app = create_app(settings, chat=chat)
+    client = TestClient(app)
+    body = client.get("/status", headers={"Authorization": "Bearer test-token"}).json()
+    assert body["llm_healthy"] is True
+    assert body["llm_provider"] == "ollama"
+    assert body["llm_model"] == "llama3.2"
+    assert chat.calls == 1

--- a/apps/core/tests/test_embedder.py
+++ b/apps/core/tests/test_embedder.py
@@ -1,0 +1,107 @@
+from __future__ import annotations
+
+import sys
+from types import ModuleType
+
+import pytest
+from sqlalchemy import select
+
+from juno.graph.db import Database
+from juno.llm.embedder import StubEmbedder, create_embedder
+from juno.models import AppSetting
+from juno.runtime import persist_embedder_settings
+
+
+def test_stub_embedder_batch():
+    emb = StubEmbedder()
+    vecs = emb.embed(["alpha", "beta", "gamma"])
+    assert len(vecs) == 3
+    assert all(len(v) == 64 for v in vecs)
+    assert vecs[0] != vecs[1]
+    assert emb.embed(["alpha"])[0] == vecs[0]
+
+
+def test_stub_embedder_empty_batch():
+    assert StubEmbedder().embed([]) == []
+
+
+def test_create_embedder_unknown_backend():
+    with pytest.raises(ValueError, match="Unknown embedding backend"):
+        create_embedder("mystery", "x")
+
+
+def test_minilm_path_batch_embed(monkeypatch):
+    """sentence_transformers factory + batch encode without downloading MiniLM."""
+
+    class FakeVectors:
+        def __init__(self, rows: list[list[float]]) -> None:
+            self._rows = rows
+
+        def tolist(self) -> list[list[float]]:
+            return self._rows
+
+    class FakeSentenceTransformer:
+        def __init__(self, model_id: str) -> None:
+            assert model_id == "all-MiniLM-L6-v2"
+            self.model_id = model_id
+
+        def get_sentence_embedding_dimension(self) -> int:
+            return 384
+
+        def encode(self, texts: list[str], normalize_embeddings: bool = True) -> FakeVectors:
+            assert normalize_embeddings is True
+            return FakeVectors([[0.01 * (i + 1)] * 384 for i, _ in enumerate(texts)])
+
+    fake = ModuleType("sentence_transformers")
+    fake.SentenceTransformer = FakeSentenceTransformer  # type: ignore[attr-defined]
+    monkeypatch.setitem(sys.modules, "sentence_transformers", fake)
+
+    emb = create_embedder("sentence_transformers", "all-MiniLM-L6-v2")
+    assert emb.backend == "sentence_transformers"
+    assert emb.model_id == "all-MiniLM-L6-v2"
+    assert emb.dimensions == 384
+    assert emb.embed([]) == []
+    vecs = emb.embed(["rust ownership", "borrowing"])
+    assert len(vecs) == 2
+    assert len(vecs[0]) == 384
+    assert vecs[0] != vecs[1]
+
+
+def test_minilm_missing_extra_has_install_hint(monkeypatch):
+    monkeypatch.setitem(sys.modules, "sentence_transformers", None)
+    with pytest.raises(ImportError, match="uv sync --extra embeddings"):
+        create_embedder("sentence_transformers", "all-MiniLM-L6-v2")
+
+
+@pytest.mark.asyncio
+async def test_persist_embedder_model_id_in_settings(settings):
+    db = Database(settings)
+    await db.create_all()
+    await persist_embedder_settings(db, StubEmbedder())
+
+    async def fetch(session):
+        result = await session.execute(select(AppSetting))
+        return {row.key: row.value for row in result.scalars()}
+
+    rows = await db.read(fetch)
+    assert rows["embedding_model"] == "stub-hash-v1"
+    assert rows["embedding_backend"] == "stub"
+    assert rows["embedding_dimensions"] == "64"
+    await db.dispose()
+
+
+def test_status_reports_actual_embedder_not_settings_backend(settings):
+    from fastapi.testclient import TestClient
+
+    from juno.api import create_app
+
+    # Requested MiniLM, but serve fell back to stub — /status must not lie.
+    settings = settings.model_copy(update={"embedding_backend": "sentence_transformers"})
+    embedder = StubEmbedder()
+    app = create_app(settings, embedder=embedder)
+    client = TestClient(app)
+    body = client.get("/status", headers={"Authorization": "Bearer test-token"}).json()
+    assert body["embedding_backend"] == "stub"
+    assert body["embedding_model"] == "stub-hash-v1"
+    assert body["embedding_dimensions"] == 64
+    assert body["embedding_fallback"] is True

--- a/apps/core/tests/test_vectors.py
+++ b/apps/core/tests/test_vectors.py
@@ -69,3 +69,8 @@ def test_status_reports_chroma_collection(settings):
     assert body["chroma_collection"] == vectors.collection_name
     assert body["chroma_count"] == 1
     assert body["embedding_model"] == "stub-hash-v1"
+    assert body["embedding_backend"] == "stub"
+    assert body["embedding_dimensions"] == 64
+    assert body["embedding_fallback"] is False
+    assert body["llm_healthy"] is False
+    assert "llm_provider" in body

--- a/docs/next-work.md
+++ b/docs/next-work.md
@@ -29,7 +29,7 @@ Prefer one open issue ≈ one PR (`Closes #N`).
 | 1 | #13 | Chroma persistent client — **merged** ([PR #29](https://github.com/Anna-Hax/JUNO/pull/29), `Closes #13`) |
 | 2 | #11 | First Alembic revision — **merged** (`Closes #11`) |
 | 3 | #16 | Ingest pipeline + extractors + inbox watcher — **merged** ([PR #31](https://github.com/Anna-Hax/JUNO/pull/31), `Closes #16`) |
-| 4 | #14 / #15 | Confirm MiniLM path + LLM health in `/status` — **done on `feat/embedder-llm-status`** (PR / `Closes #14` `#15` not opened yet) |
+| 4 | #14 / #15 | Confirm MiniLM path + LLM health in `/status` — **PR opened** ([PR #32](https://github.com/Anna-Hax/JUNO/pull/32), `Closes #14` `#15`) |
 | 5 | #17 | Retrieve-only → sourced RAG + confidence |
 | 6 | #18–#19 | Bot query + forward-to-capture + digest/pause/status |
 | 7 | #20 | HITL `/review` inline buttons |
@@ -38,7 +38,7 @@ Prefer one open issue ≈ one PR (`Closes #N`).
 
 **Next coding issue:** #17.
 
-Already partially landed (keep issues open until acceptance fully met): #12 write queue, #18 allowlist handlers, #21 basic routes. Ingest now upserts into the #13 `VectorStore`. MiniLM + LLM health are confirmed on this branch (#14 / #15).
+Already partially landed (keep issues open until acceptance fully met): #12 write queue, #18 allowlist handlers, #21 basic routes. Ingest upserts into the #13 `VectorStore`. MiniLM + LLM health are in [PR #32](https://github.com/Anna-Hax/JUNO/pull/32).
 
 ---
 

--- a/docs/next-work.md
+++ b/docs/next-work.md
@@ -1,6 +1,6 @@
 # Next work (after M0 bootstrap)
 
-**Last updated:** 2026-08-22  
+**Last updated:** 2026-08-26  
 **Track issues on:** https://github.com/Anna-Hax/JUNO/issues
 
 ---
@@ -26,15 +26,19 @@ Prefer one open issue ≈ one PR (`Closes #N`).
 
 | Order | Issue | Work |
 |-------|-------|------|
-| 3 | #16 | Ingest pipeline + extractors + inbox watcher — **done on `feat/ingest-pipeline`** (PR / `Closes #16` not opened yet) |
-| 4 | #14 / #15 | Confirm MiniLM path + LLM health in `/status` |
+| 1 | #13 | Chroma persistent client — **merged** ([PR #29](https://github.com/Anna-Hax/JUNO/pull/29), `Closes #13`) |
+| 2 | #11 | First Alembic revision — **merged** (`Closes #11`) |
+| 3 | #16 | Ingest pipeline + extractors + inbox watcher — **merged** ([PR #31](https://github.com/Anna-Hax/JUNO/pull/31), `Closes #16`) |
+| 4 | #14 / #15 | Confirm MiniLM path + LLM health in `/status` — **done on `feat/embedder-llm-status`** (PR / `Closes #14` `#15` not opened yet) |
 | 5 | #17 | Retrieve-only → sourced RAG + confidence |
 | 6 | #18–#19 | Bot query + forward-to-capture + digest/pause/status |
 | 7 | #20 | HITL `/review` inline buttons |
-| 8 | #21 | Harden API (already stubbed) |
+| 8 | #21 | Harden API (already stubbed; `/ingest` now persists) |
 | 9 | #22–#24 | Integration tests, export/wipe, v1.0 gate |
 
-Already partially landed (keep issues open until acceptance fully met): #13 Chroma wrapper (branch, unmerged), #16 ingest (branch, unmerged), #12 write queue, #14 stub embedder, #15 chat adapters, #18 allowlist handlers, #21 basic routes.
+**Next coding issue:** #17.
+
+Already partially landed (keep issues open until acceptance fully met): #12 write queue, #18 allowlist handlers, #21 basic routes. Ingest now upserts into the #13 `VectorStore`. MiniLM + LLM health are confirmed on this branch (#14 / #15).
 
 ---
 

--- a/docs/sessions/02-codebase-map.md
+++ b/docs/sessions/02-codebase-map.md
@@ -1,6 +1,6 @@
 # Codebase map (as of M0 / early M1)
 
-**Last updated:** 2026-08-25
+**Last updated:** 2026-08-26
 
 ---
 
@@ -36,7 +36,7 @@ JUNO/
 | Vectors | `graph/vectors.py` | Persistent Chroma; one collection per embedding model ([ADR-04](../adr/004-chroma-collections.md)) |
 | Models | `models/__init__.py` | SQLAlchemy tables |
 | Alembic | `alembic/` + `alembic.ini` | Revision `0001` = current ORM ([ADR-03](../adr/003-alembic.md)) |
-| LLM | `llm/embedder.py`, `llm/chat.py` | Embeddings + chat providers |
+| LLM | `llm/embedder.py`, `llm/chat.py` | MiniLM (optional extra) + stub embedder; Ollama / OpenAI-compat / offline chat; health probes |
 | Ingest | `ingest/extractors.py`, `chunking.py`, `pipeline.py`, `watcher.py` | File/URL extract, chunk, persist, inbox watch ([#16](https://github.com/Anna-Hax/JUNO/issues/16)) |
 | Jobs | `jobs/` | Placeholder (M4) |
 
@@ -44,7 +44,7 @@ JUNO/
 
 - `uv run juno serve` → `runtime.main_sync()`
 - `uv run juno db-init` → `Database.migrate()` (Alembic `upgrade head`, or stamp legacy `create_all` DBs)
-- Tests: `apps/core/tests/test_foundation.py`, `test_migrations.py`, `test_ingest.py`, `test_vectors.py`
+- Tests: `apps/core/tests/test_foundation.py`, `test_migrations.py`, `test_ingest.py`, `test_vectors.py`, `test_embedder.py`, `test_chat.py`
 
 ### Dependencies
 
@@ -78,5 +78,6 @@ Optional: `--extra embeddings` for sentence-transformers; `--extra dev` for pyte
 3. Migrations via Alembic (ADR-03); `db-init` / serve run `upgrade head` (stamp pre-Alembic files).
 4. Empty Telegram allowlist ⇒ reject all users (secure default).
 5. API token required even on localhost.
-6. Stub embedder so CI never downloads torch.
+6. Stub embedder so CI never downloads torch; MiniLM is `--extra embeddings`. `/status` reports the live backend (and `embedding_fallback` if serve dropped to stub).
 7. Chroma collections are per embedding model; Juno supplies embeddings (no Chroma default ONNX). Blocking Chroma I/O uses `asyncio.to_thread`.
+8. Chat adapters switch on `LLM_PROVIDER` (`ollama` / `openai_compat` / `offline`). `/status` live-probes `llm_healthy` + provider/model. Unhealthy LLM ⇒ retrieve-only (#17).

--- a/docs/sessions/07-session-embedder-llm.md
+++ b/docs/sessions/07-session-embedder-llm.md
@@ -1,0 +1,91 @@
+# Session log: MiniLM embedder + LLM health (#14 / #15)
+
+**Date:** 2026-08-26  
+**Repo:** [https://github.com/Anna-Hax/JUNO](https://github.com/Anna-Hax/JUNO)  
+**Plan:** Personal Knowledge Graph (local-first Python + Telegram)  
+**Scope of this session:** M1 issues **#14** (MiniLM path + model id in settings) and **#15** (chat adapters + LLM health in `/status`).
+
+---
+
+## Summary
+
+Confirmed the local MiniLM embedder path without pulling torch in CI (mocked `sentence_transformers` + stub for tests). Serve still falls back to the hash stub if the extra is missing, and `/status` reports the **live** backend so a fallback cannot look like MiniLM.
+
+Chat adapters now include an explicit `offline` provider. `/status` live-probes the attached LLM (`llm_healthy`, `llm_provider`, `llm_model`) instead of a one-shot startup flag. Unhealthy Ollama/OpenAI is retrieve-only for #17.
+
+Work is on branch `feat/embedder-llm-status` (from `main`). PR / `Closes #14` `Closes #15` not opened yet.
+
+---
+
+## What changed
+
+### Code
+
+| Path | Role |
+|------|------|
+| `apps/core/src/juno/llm/embedder.py` | `backend` on embedders; empty-batch MiniLM; clear missing-extra error |
+| `apps/core/src/juno/llm/chat.py` | `offline` factory; Ollama model-in-tags probe; OpenAI `/models` probe |
+| `apps/core/src/juno/runtime.py` | Persist `embedding_*` in `settings`; `module_health` row `llm`; warn when unhealthy |
+| `apps/core/src/juno/api/__init__.py` | `/status` live LLM probe + actual embedder fields |
+| `apps/core/src/juno/config.py` | `llm_provider=offline`; `Settings.llm_model` |
+| `apps/core/tests/test_embedder.py` | Batch stub, mocked MiniLM 384-d, persist model id, fallback flag |
+| `apps/core/tests/test_chat.py` | Provider switch, health probes, offline complete, `/status` live probe |
+
+Rules encoded in code:
+
+- CI keeps `EMBEDDING_BACKEND=stub` (no torch)
+- MiniLM is `uv sync --extra embeddings`; missing extra → ImportError with install hint; `juno serve` catches and uses stub
+- `/status.embedding_backend` is the **live** embedder, not the requested env value
+- `/status` re-probes chat health (1.5s timeout) so Ollama coming up later is visible without restart
+- `LLM_PROVIDER=offline` is a first-class retrieve-only mode
+
+### Docs
+
+- This session file
+- README MiniLM extra + `/status` fields
+- `.env.example` offline provider + embeddings extra
+- Codebase map + [`docs/next-work.md`](../next-work.md)
+
+---
+
+## Not in this session
+
+- PR / merge to `main` (`Closes #14` / `#15`)
+- RAG `/search` sourced answers (#17) — next
+- Telegram `/status` command (#19)
+- Live MiniLM download / Ollama smoke (#4)
+
+---
+
+## How to verify
+
+From `apps/core`:
+
+```powershell
+$env:EMBEDDING_BACKEND="stub"
+uv run pytest
+uv run ruff check src tests
+```
+
+Expect **47** tests passing (foundation + ingest + migrations + vectors + embedder + chat).
+
+Manual (after `juno serve`):
+
+```powershell
+curl http://127.0.0.1:8787/health
+curl -H "Authorization: Bearer <token>" http://127.0.0.1:8787/status
+```
+
+`/status` should include `embedding_model`, `embedding_backend`, `embedding_dimensions`, `embedding_fallback`, `llm_healthy`, `llm_provider`, `llm_model`. With Ollama stopped, `llm_healthy` is `false`. With `--extra embeddings` and `EMBEDDING_BACKEND=sentence_transformers`, backend should be `sentence_transformers` and model `all-MiniLM-L6-v2` (first run downloads MiniLM).
+
+---
+
+## Related docs
+
+| File | Contents |
+|------|----------|
+| [07-session-embedder-llm.md](07-session-embedder-llm.md) | This file |
+| [06-session-ingest.md](06-session-ingest.md) | M1 #16 ingest |
+| [next-work.md](../next-work.md) | Global next-work tracker |
+| [02-codebase-map.md](02-codebase-map.md) | LLM modules on the map |
+| [../adr/004-chroma-collections.md](../adr/004-chroma-collections.md) | Collection per embedding model |

--- a/docs/sessions/07-session-embedder-llm.md
+++ b/docs/sessions/07-session-embedder-llm.md
@@ -13,7 +13,7 @@ Confirmed the local MiniLM embedder path without pulling torch in CI (mocked `se
 
 Chat adapters now include an explicit `offline` provider. `/status` live-probes the attached LLM (`llm_healthy`, `llm_provider`, `llm_model`) instead of a one-shot startup flag. Unhealthy Ollama/OpenAI is retrieve-only for #17.
 
-Work is on branch `feat/embedder-llm-status` (from `main`). PR / `Closes #14` `Closes #15` not opened yet.
+Work is on branch `feat/embedder-llm-status` (from `main`). PR: [https://github.com/Anna-Hax/JUNO/pull/32](https://github.com/Anna-Hax/JUNO/pull/32) (`Closes #14` `#15`).
 
 ---
 
@@ -50,7 +50,7 @@ Rules encoded in code:
 
 ## Not in this session
 
-- PR / merge to `main` (`Closes #14` / `#15`)
+- Merge of [PR #32](https://github.com/Anna-Hax/JUNO/pull/32) (`Closes #14` / `#15`)
 - RAG `/search` sourced answers (#17) — next
 - Telegram `/status` command (#19)
 - Live MiniLM download / Ollama smoke (#4)

--- a/docs/sessions/README.md
+++ b/docs/sessions/README.md
@@ -12,5 +12,6 @@ Living notes for what was implemented, how GitHub is set up, and what to do next
 | [04-session-chroma-client.md](04-session-chroma-client.md) | **M1 #13** — persistent Chroma client |
 | [05-session-alembic.md](05-session-alembic.md) | **M1 #11** — first Alembic revision |
 | [06-session-ingest.md](06-session-ingest.md) | **M1 #16** — ingest pipeline, extractors, inbox watcher |
+| [07-session-embedder-llm.md](07-session-embedder-llm.md) | **M1 #14 / #15** — MiniLM path + LLM health in `/status` |
 
 Architecture decisions live in [`../adr/`](../adr/). Product requirements: [`../../personal-knowledge-graph-prd.md`](../../personal-knowledge-graph-prd.md).


### PR DESCRIPTION
## Summary
- Confirm the MiniLM embedder path (mocked 384-d batch encode in CI; stub remains the default for tests) and persist the live model id in `settings`.
- `GET /status` now reports the actual embedder (including `embedding_fallback`) and live-probes LLM health (`llm_healthy`, `llm_provider`, `llm_model`).
- `LLM_PROVIDER` switches `ollama` / `openai_compat` / `offline`; unhealthy chat is retrieve-only for #17.

## Linked issue
Closes #14
Closes #15

## Test plan
- [x] `uv run pytest` (apps/core) — 47 passing
- [x] `uv run ruff check src tests`
- [ ] Manual: `juno serve` then `GET /status` with `JUNO_API_TOKEN` — check embedding + LLM fields; Ollama down => `llm_healthy: false`