### PR TITLE
feat(rag): retrieve sourced answers with citations

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ uv run juno db-init
 uv run juno serve
 ```
 
-- API: `http://127.0.0.1:8787/health`
+- API: `http://127.0.0.1:8787/health` — token-gated `GET /search?q=` returns citations + confidence (sourced answer when the LLM is healthy)
 - Bot runs only while this process (and PC) is on. Telegram queues updates ~24h; longer downtime can drop messages — `/status` will surface this once fully wired.
 
 ### Tests

--- a/apps/core/src/juno/api/__init__.py
+++ b/apps/core/src/juno/api/__init__.py
@@ -5,10 +5,11 @@ from __future__ import annotations
 import asyncio
 from typing import Any
 
-from fastapi import Depends, FastAPI, Header, HTTPException, Request
+from fastapi import Depends, FastAPI, Header, HTTPException, Query, Request
 from fastapi.responses import JSONResponse
 
 from juno.config import Settings
+from juno.rag.engine import search as rag_search
 
 
 def create_app(
@@ -18,12 +19,14 @@ def create_app(
     embedder: Any = None,
     vectors: Any = None,
     pipeline: Any = None,
+    chat: Any = None,
 ) -> FastAPI:
     app = FastAPI(title="Juno", version="0.1.0")
     app.state.settings = settings
     app.state.db = db
     app.state.embedder = embedder
     app.state.vectors = vectors
+    app.state.chat = chat
     app.state.capture_paused = False
     app.state.llm_healthy = False
     if pipeline is not None:
@@ -83,7 +86,19 @@ def create_app(
         return result.to_dict()
 
     @app.get("/search", dependencies=[Depends(require_token)])
-    async def search(q: str) -> dict[str, Any]:
-        return {"query": q, "results": [], "note": "RAG retrieve not fully wired yet"}
+    async def search(
+        q: str = Query(..., min_length=1),
+        k: int = Query(8, ge=1, le=32),
+        mode: str = Query("auto"),
+    ) -> dict[str, Any]:
+        outcome = await rag_search(
+            q,
+            vectors=app.state.vectors,
+            db=app.state.db,
+            chat=getattr(app.state, "chat", None),
+            n_results=k,
+            mode=mode,
+        )
+        return outcome.to_dict()
 
     return app

--- a/apps/core/src/juno/rag/__init__.py
+++ b/apps/core/src/juno/rag/__init__.py
@@ -1,0 +1,5 @@
+"""Retrieve + sourced RAG (issue #17)."""
+
+from juno.rag.engine import SearchOutcome, SourcedHit, retrieve, search
+
+__all__ = ["SearchOutcome", "SourcedHit", "retrieve", "search"]

--- a/apps/core/src/juno/rag/engine.py
+++ b/apps/core/src/juno/rag/engine.py
@@ -1,0 +1,281 @@
+"""Query VectorStore, join SQLite captures, optionally generate a sourced answer."""
+
+from __future__ import annotations
+
+import logging
+import re
+from collections.abc import Sequence
+from dataclasses import dataclass
+from typing import Any
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from juno.graph.db import Database
+from juno.graph.vectors import VectorHit
+from juno.models import Capture, Chunk
+
+logger = logging.getLogger("juno.rag")
+
+DEFAULT_K = 8
+MAX_SOURCE_CHARS = 1200
+_CITE_RE = re.compile(r"\[(\d+)\]")
+
+RAG_SYSTEM = (
+    "You are Juno, a personal knowledge assistant. Answer using ONLY the numbered "
+    "sources. Cite sources as [1], [2], matching those numbers. If the sources do "
+    "not contain the answer, say you don't know. Do not invent facts or citations."
+)
+
+
+@dataclass(frozen=True)
+class SourcedHit:
+    chroma_id: str
+    text: str
+    score: float
+    capture_id: int | None = None
+    chunk_id: int | None = None
+    ordinal: int | None = None
+    title: str | None = None
+    uri: str | None = None
+    source_type: str | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "chroma_id": self.chroma_id,
+            "capture_id": self.capture_id,
+            "chunk_id": self.chunk_id,
+            "ordinal": self.ordinal,
+            "title": self.title,
+            "uri": self.uri,
+            "source_type": self.source_type,
+            "text": self.text,
+            "score": round(self.score, 4),
+        }
+
+
+@dataclass(frozen=True)
+class SearchOutcome:
+    query: str
+    mode: str
+    results: list[SourcedHit]
+    confidence: float
+    answer: str | None = None
+    citations: list[SourcedHit] | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        cites = self.citations if self.citations is not None else self.results
+        return {
+            "query": self.query,
+            "mode": self.mode,
+            "answer": self.answer,
+            "confidence": round(self.confidence, 4),
+            "results": [hit.to_dict() for hit in self.results],
+            "citations": [hit.to_dict() for hit in cites],
+        }
+
+
+def similarity_from_distance(distance: float | None) -> float:
+    """Chroma cosine space stores distance = 1 - cosine similarity."""
+    if distance is None:
+        return 0.0
+    return max(0.0, min(1.0, 1.0 - float(distance)))
+
+
+def _as_int(value: Any) -> int | None:
+    if value is None or isinstance(value, bool):
+        return None
+    if isinstance(value, int):
+        return value
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _confidence(hits: Sequence[SourcedHit]) -> float:
+    if not hits:
+        return 0.0
+    return max(hit.score for hit in hits)
+
+
+async def retrieve(
+    query: str,
+    *,
+    vectors: Any,
+    db: Database | None,
+    n_results: int = DEFAULT_K,
+) -> list[SourcedHit]:
+    """Vector search then join hits to `chunks` / `captures` (ADR-04)."""
+    q = (query or "").strip()
+    if not q or vectors is None or n_results < 1:
+        return []
+    hits: list[VectorHit] = await vectors.query_async(q, n_results=n_results)
+    if not hits:
+        return []
+    by_chroma = await _load_chunks(db, [hit.id for hit in hits])
+    sourced: list[SourcedHit] = []
+    for hit in hits:
+        chunk, capture = by_chroma.get(hit.id, (None, None))
+        meta = hit.metadata or {}
+        text = (chunk.text if chunk is not None else None) or hit.text or ""
+        sourced.append(
+            SourcedHit(
+                chroma_id=hit.id,
+                text=text,
+                score=similarity_from_distance(hit.distance),
+                capture_id=(
+                    capture.id if capture is not None else _as_int(meta.get("capture_id"))
+                ),
+                chunk_id=chunk.id if chunk is not None else None,
+                ordinal=(
+                    chunk.ordinal if chunk is not None else _as_int(meta.get("ordinal"))
+                ),
+                title=capture.title if capture is not None else None,
+                uri=capture.uri if capture is not None else None,
+                source_type=(
+                    capture.source_type
+                    if capture is not None
+                    else (str(meta["source_type"]) if meta.get("source_type") else None)
+                ),
+            )
+        )
+    return sourced
+
+
+async def _load_chunks(
+    db: Database | None, chroma_ids: Sequence[str]
+) -> dict[str, tuple[Chunk | None, Capture | None]]:
+    if db is None or not chroma_ids:
+        return {}
+
+    async def fetch(
+        session: AsyncSession,
+    ) -> dict[str, tuple[Chunk | None, Capture | None]]:
+        result = await session.execute(
+            select(Chunk, Capture)
+            .join(Capture, Chunk.capture_id == Capture.id)
+            .where(Chunk.chroma_id.in_(list(chroma_ids)))
+        )
+        mapped: dict[str, tuple[Chunk | None, Capture | None]] = {}
+        for chunk, capture in result.all():
+            if chunk.chroma_id:
+                mapped[chunk.chroma_id] = (chunk, capture)
+        return mapped
+
+    return await db.read(fetch)
+
+
+async def _chat_is_healthy(chat: Any) -> bool:
+    if chat is None:
+        return False
+    probe = getattr(chat, "healthy", None)
+    if probe is None:
+        return False
+    try:
+        return bool(await probe())
+    except TypeError:
+        try:
+            return bool(await probe(timeout=1.5))
+        except Exception:  # noqa: BLE001
+            return False
+    except Exception:  # noqa: BLE001
+        logger.exception("LLM health probe failed")
+        return False
+
+
+def _format_sources(hits: Sequence[SourcedHit]) -> str:
+    lines: list[str] = []
+    for i, hit in enumerate(hits, start=1):
+        label = hit.title or hit.uri or hit.chroma_id
+        body = hit.text.strip()
+        if len(body) > MAX_SOURCE_CHARS:
+            body = body[: MAX_SOURCE_CHARS - 1] + "…"
+        lines.append(f"[{i}] {label}\n{body}")
+    return "\n\n".join(lines)
+
+
+def _cited_hits(answer: str, hits: Sequence[SourcedHit]) -> list[SourcedHit]:
+    cited: list[SourcedHit] = []
+    seen: set[int] = set()
+    for match in _CITE_RE.finditer(answer):
+        idx = int(match.group(1))
+        if idx in seen or idx < 1 or idx > len(hits):
+            continue
+        seen.add(idx)
+        cited.append(hits[idx - 1])
+    return cited
+
+
+async def search(
+    query: str,
+    *,
+    vectors: Any,
+    db: Database | None,
+    chat: Any = None,
+    n_results: int = DEFAULT_K,
+    mode: str = "auto",
+) -> SearchOutcome:
+    """Retrieve hits; generate a sourced answer when an LLM is healthy."""
+    q = (query or "").strip()
+    hits = await retrieve(q, vectors=vectors, db=db, n_results=n_results)
+    retrieve_confidence = _confidence(hits)
+    requested = (mode or "auto").strip().lower()
+    want_rag = requested in {"auto", "rag"} and bool(hits)
+
+    if requested == "retrieve" or not want_rag:
+        return SearchOutcome(
+            query=q,
+            mode="retrieve",
+            results=hits,
+            confidence=retrieve_confidence,
+            answer=None,
+            citations=hits,
+        )
+
+    if not await _chat_is_healthy(chat):
+        return SearchOutcome(
+            query=q,
+            mode="retrieve",
+            results=hits,
+            confidence=retrieve_confidence,
+            answer=None,
+            citations=hits,
+        )
+
+    try:
+        answer = (await chat.complete(
+            RAG_SYSTEM,
+            [{"role": "user", "content": f"Question: {q}\n\nSources:\n{_format_sources(hits)}"}],
+        )).strip()
+    except Exception:  # noqa: BLE001
+        logger.exception("RAG generate failed; falling back to retrieve-only")
+        return SearchOutcome(
+            query=q,
+            mode="retrieve",
+            results=hits,
+            confidence=retrieve_confidence,
+            answer=None,
+            citations=hits,
+        )
+
+    if not answer:
+        return SearchOutcome(
+            query=q,
+            mode="retrieve",
+            results=hits,
+            confidence=retrieve_confidence,
+            answer=None,
+            citations=hits,
+        )
+
+    citations = _cited_hits(answer, hits) or list(hits)
+    rag_confidence = _confidence(citations)
+    return SearchOutcome(
+        query=q,
+        mode="rag",
+        results=hits,
+        confidence=rag_confidence,
+        answer=answer,
+        citations=citations,
+    )

--- a/apps/core/src/juno/rag/engine.py
+++ b/apps/core/src/juno/rag/engine.py
@@ -124,13 +124,9 @@ async def retrieve(
                 chroma_id=hit.id,
                 text=text,
                 score=similarity_from_distance(hit.distance),
-                capture_id=(
-                    capture.id if capture is not None else _as_int(meta.get("capture_id"))
-                ),
+                capture_id=(capture.id if capture is not None else _as_int(meta.get("capture_id"))),
                 chunk_id=chunk.id if chunk is not None else None,
-                ordinal=(
-                    chunk.ordinal if chunk is not None else _as_int(meta.get("ordinal"))
-                ),
+                ordinal=(chunk.ordinal if chunk is not None else _as_int(meta.get("ordinal"))),
                 title=capture.title if capture is not None else None,
                 uri=capture.uri if capture is not None else None,
                 source_type=(
@@ -244,10 +240,17 @@ async def search(
         )
 
     try:
-        answer = (await chat.complete(
-            RAG_SYSTEM,
-            [{"role": "user", "content": f"Question: {q}\n\nSources:\n{_format_sources(hits)}"}],
-        )).strip()
+        answer = (
+            await chat.complete(
+                RAG_SYSTEM,
+                [
+                    {
+                        "role": "user",
+                        "content": f"Question: {q}\n\nSources:\n{_format_sources(hits)}",
+                    }
+                ],
+            )
+        ).strip()
     except Exception:  # noqa: BLE001
         logger.exception("RAG generate failed; falling back to retrieve-only")
         return SearchOutcome(

--- a/apps/core/src/juno/rag/engine.py
+++ b/apps/core/src/juno/rag/engine.py
@@ -173,10 +173,10 @@ async def _chat_is_healthy(chat: Any) -> bool:
     if probe is None:
         return False
     try:
-        return bool(await probe())
+        return bool(await probe(timeout=1.5))
     except TypeError:
         try:
-            return bool(await probe(timeout=1.5))
+            return bool(await probe())
         except Exception:  # noqa: BLE001
             return False
     except Exception:  # noqa: BLE001

--- a/apps/core/tests/test_rag.py
+++ b/apps/core/tests/test_rag.py
@@ -7,6 +7,7 @@ from juno.api import create_app
 from juno.graph.db import Database
 from juno.graph.vectors import VectorStore
 from juno.ingest.pipeline import IngestPipeline
+from juno.llm.chat import OfflineProvider
 from juno.llm.embedder import StubEmbedder
 from juno.rag.engine import similarity_from_distance
 
@@ -28,7 +29,7 @@ class FakeChat:
         self.complete_calls = 0
         self.healthy_calls = 0
 
-    async def healthy(self) -> bool:
+    async def healthy(self, *, timeout: float = 3.0) -> bool:
         self.healthy_calls += 1
         return self._healthy
 
@@ -203,4 +204,26 @@ async def test_answer_without_markers_still_attaches_hits(settings, db, vectors,
     body = resp.json()
     assert body["mode"] == "rag"
     assert body["citations"]
+    assert body["citations"][0]["title"] == "Rust notes"
+
+
+@pytest.mark.asyncio
+async def test_offline_provider_stays_retrieve_only(settings, db, vectors, pipeline):
+    await pipeline.ingest_text(NOTE_A, source_type="upload", title="Rust notes")
+    client, _ = await _client(
+        settings,
+        db=db,
+        vectors=vectors,
+        pipeline=pipeline,
+        chat=OfflineProvider(),
+    )
+    async with client:
+        resp = await client.get(
+            "/search",
+            params={"q": NOTE_A, "mode": "auto"},
+            headers={"Authorization": "Bearer test-token"},
+        )
+    body = resp.json()
+    assert body["mode"] == "retrieve"
+    assert body["answer"] is None
     assert body["citations"][0]["title"] == "Rust notes"

--- a/apps/core/tests/test_rag.py
+++ b/apps/core/tests/test_rag.py
@@ -1,0 +1,206 @@
+from __future__ import annotations
+
+import httpx
+import pytest
+
+from juno.api import create_app
+from juno.graph.db import Database
+from juno.graph.vectors import VectorStore
+from juno.ingest.pipeline import IngestPipeline
+from juno.llm.embedder import StubEmbedder
+from juno.rag.engine import similarity_from_distance
+
+NOTE_A = (
+    "Juno retrieve citation marker rust-ownership-xyz. "
+    "Ownership in Rust means each value has a single owner."
+)
+NOTE_B = (
+    "Unrelated gardening notes about tomatoes and soil pH. "
+    "Nothing here mentions compilers or borrowing."
+)
+
+
+class FakeChat:
+    def __init__(self, *, healthy: bool = True, answer: str = "", fail: bool = False) -> None:
+        self._healthy = healthy
+        self._answer = answer
+        self.fail = fail
+        self.complete_calls = 0
+        self.healthy_calls = 0
+
+    async def healthy(self) -> bool:
+        self.healthy_calls += 1
+        return self._healthy
+
+    async def complete(self, system: str, messages: list[dict[str, str]], **kwargs):  # noqa: ANN001
+        self.complete_calls += 1
+        if self.fail:
+            raise RuntimeError("LLM offline — use retrieve-only fallback")
+        assert "Sources:" in messages[0]["content"]
+        assert "Question:" in messages[0]["content"]
+        return self._answer
+
+
+@pytest.fixture
+async def db(settings):
+    database = Database(settings)
+    await database.migrate()
+    yield database
+    await database.dispose()
+
+
+@pytest.fixture
+def vectors(settings):
+    return VectorStore(settings, StubEmbedder())
+
+
+@pytest.fixture
+def pipeline(db, vectors):
+    return IngestPipeline(db, vectors=vectors)
+
+
+async def _client(settings, *, db, vectors, pipeline, chat=None):
+    app = create_app(
+        settings,
+        db=db,
+        embedder=StubEmbedder(),
+        vectors=vectors,
+        pipeline=pipeline,
+        chat=chat,
+    )
+    transport = httpx.ASGITransport(app=app)
+    return httpx.AsyncClient(transport=transport, base_url="http://test"), app
+
+
+def test_similarity_from_distance_clamps():
+    assert similarity_from_distance(0.0) == 1.0
+    assert similarity_from_distance(1.0) == 0.0
+    assert similarity_from_distance(None) == 0.0
+    assert similarity_from_distance(-0.2) == 1.0
+    assert similarity_from_distance(1.5) == 0.0
+
+
+def test_search_requires_token(settings):
+    from fastapi.testclient import TestClient
+
+    client = TestClient(create_app(settings))
+    assert client.get("/search", params={"q": "rust"}).status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_retrieve_joins_capture_citations(settings, db, vectors, pipeline):
+    first = await pipeline.ingest_text(NOTE_A, source_type="upload", title="Rust notes")
+    await pipeline.ingest_text(NOTE_B, source_type="upload", title="Garden")
+    client, _ = await _client(settings, db=db, vectors=vectors, pipeline=pipeline)
+    async with client:
+        resp = await client.get(
+            "/search",
+            params={"q": NOTE_A, "mode": "retrieve"},
+            headers={"Authorization": "Bearer test-token"},
+        )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["mode"] == "retrieve"
+    assert body["answer"] is None
+    assert body["results"]
+    top = body["results"][0]
+    assert top["capture_id"] == first.capture_id
+    assert top["title"] == "Rust notes"
+    assert top["chroma_id"] == f"c{first.capture_id}-n0"
+    assert "rust-ownership-xyz" in top["text"]
+    assert top["score"] == pytest.approx(1.0)
+    assert body["confidence"] == pytest.approx(1.0)
+    assert body["citations"][0]["capture_id"] == first.capture_id
+
+
+@pytest.mark.asyncio
+async def test_retrieve_empty_index(settings, db, vectors, pipeline):
+    client, _ = await _client(settings, db=db, vectors=vectors, pipeline=pipeline)
+    async with client:
+        resp = await client.get(
+            "/search",
+            params={"q": "nothing ingested yet"},
+            headers={"Authorization": "Bearer test-token"},
+        )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["results"] == []
+    assert body["citations"] == []
+    assert body["confidence"] == 0.0
+    assert body["mode"] == "retrieve"
+
+
+@pytest.mark.asyncio
+async def test_rag_sourced_answer_requires_citations(settings, db, vectors, pipeline):
+    await pipeline.ingest_text(NOTE_A, source_type="upload", title="Rust notes")
+    chat = FakeChat(answer="Each value has a single owner [1].")
+    client, _ = await _client(settings, db=db, vectors=vectors, pipeline=pipeline, chat=chat)
+    async with client:
+        resp = await client.get(
+            "/search",
+            params={"q": NOTE_A, "mode": "rag"},
+            headers={"Authorization": "Bearer test-token"},
+        )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["mode"] == "rag"
+    assert body["answer"] == "Each value has a single owner [1]."
+    assert body["citations"]
+    assert body["citations"][0]["title"] == "Rust notes"
+    assert "[1]" in body["answer"]
+    assert chat.complete_calls == 1
+    assert body["confidence"] > 0
+
+
+@pytest.mark.asyncio
+async def test_unhealthy_llm_falls_back_to_retrieve(settings, db, vectors, pipeline):
+    await pipeline.ingest_text(NOTE_A, source_type="upload", title="Rust notes")
+    chat = FakeChat(healthy=False, answer="should not be used")
+    client, _ = await _client(settings, db=db, vectors=vectors, pipeline=pipeline, chat=chat)
+    async with client:
+        resp = await client.get(
+            "/search",
+            params={"q": NOTE_A, "mode": "auto"},
+            headers={"Authorization": "Bearer test-token"},
+        )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["mode"] == "retrieve"
+    assert body["answer"] is None
+    assert body["citations"]
+    assert chat.complete_calls == 0
+
+
+@pytest.mark.asyncio
+async def test_llm_error_falls_back_to_retrieve(settings, db, vectors, pipeline):
+    await pipeline.ingest_text(NOTE_A, source_type="upload", title="Rust notes")
+    chat = FakeChat(fail=True)
+    client, _ = await _client(settings, db=db, vectors=vectors, pipeline=pipeline, chat=chat)
+    async with client:
+        resp = await client.get(
+            "/search",
+            params={"q": NOTE_A, "mode": "rag"},
+            headers={"Authorization": "Bearer test-token"},
+        )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["mode"] == "retrieve"
+    assert body["answer"] is None
+    assert body["citations"][0]["title"] == "Rust notes"
+
+
+@pytest.mark.asyncio
+async def test_answer_without_markers_still_attaches_hits(settings, db, vectors, pipeline):
+    await pipeline.ingest_text(NOTE_A, source_type="upload", title="Rust notes")
+    chat = FakeChat(answer="Ownership is exclusive.")
+    client, _ = await _client(settings, db=db, vectors=vectors, pipeline=pipeline, chat=chat)
+    async with client:
+        resp = await client.get(
+            "/search",
+            params={"q": NOTE_A, "mode": "rag"},
+            headers={"Authorization": "Bearer test-token"},
+        )
+    body = resp.json()
+    assert body["mode"] == "rag"
+    assert body["citations"]
+    assert body["citations"][0]["title"] == "Rust notes"

--- a/docs/adr/004-chroma-collections.md
+++ b/docs/adr/004-chroma-collections.md
@@ -66,6 +66,6 @@ The wrapper is `VectorStore`. Runtime attaches it to `app.state.vectors`. `/stat
 ### Follow-ups
 
 - Ingest pipeline (#16) assigns `chunks.chroma_id` as `c{capture_id}-n{ordinal}` and upserts through the attached `VectorStore`.
-- RAG retrieve (#17) should query `VectorStore` then join hits to SQLite captures.
+- RAG retrieve (#17) queries `VectorStore` then joins hits to SQLite captures (`juno.rag.engine`).
 - Export/wipe (#23) should delete or recreate `data/chroma/` as well as the graph DB.
 - Optional: record active collection name in SQLite `settings` so `/status` and HITL can explain a model mismatch.

--- a/docs/next-work.md
+++ b/docs/next-work.md
@@ -1,6 +1,6 @@
 # Next work (after M0 bootstrap)
 
-**Last updated:** 2026-08-22  
+**Last updated:** 2026-08-26  
 **Track issues on:** https://github.com/Anna-Hax/JUNO/issues
 
 ---
@@ -26,15 +26,19 @@ Prefer one open issue ≈ one PR (`Closes #N`).
 
 | Order | Issue | Work |
 |-------|-------|------|
-| 3 | #16 | Ingest pipeline + extractors + inbox watcher — **done on `feat/ingest-pipeline`** (PR / `Closes #16` not opened yet) |
-| 4 | #14 / #15 | Confirm MiniLM path + LLM health in `/status` |
-| 5 | #17 | Retrieve-only → sourced RAG + confidence |
+| 1 | #13 | Chroma persistent client — **merged** ([PR #29](https://github.com/Anna-Hax/JUNO/pull/29), `Closes #13`) |
+| 2 | #11 | First Alembic revision — **merged** (`Closes #11`) |
+| 3 | #16 | Ingest pipeline + extractors + inbox watcher — **merged** ([PR #31](https://github.com/Anna-Hax/JUNO/pull/31), `Closes #16`) |
+| 4 | #14 / #15 | Confirm MiniLM path + LLM health in `/status` — **PR opened** ([PR #32](https://github.com/Anna-Hax/JUNO/pull/32), `Closes #14` `#15`) |
+| 5 | #17 | Retrieve-only → sourced RAG + confidence — **done on `feat/rag-retrieve`** (PR / `Closes #17` not opened yet) |
 | 6 | #18–#19 | Bot query + forward-to-capture + digest/pause/status |
 | 7 | #20 | HITL `/review` inline buttons |
-| 8 | #21 | Harden API (already stubbed) |
+| 8 | #21 | Harden API (already stubbed; `/ingest` now persists; `/search` now retrieves) |
 | 9 | #22–#24 | Integration tests, export/wipe, v1.0 gate |
 
-Already partially landed (keep issues open until acceptance fully met): #13 Chroma wrapper (branch, unmerged), #16 ingest (branch, unmerged), #12 write queue, #14 stub embedder, #15 chat adapters, #18 allowlist handlers, #21 basic routes.
+**Next coding issue:** #18 / #19.
+
+Already partially landed (keep issues open until acceptance fully met): #12 write queue, #18 allowlist handlers, #21 basic routes. Ingest upserts into the #13 `VectorStore`. MiniLM + LLM health are in [PR #32](https://github.com/Anna-Hax/JUNO/pull/32). `/search` joins Chroma hits to SQLite captures and cites them.
 
 ---
 

--- a/docs/next-work.md
+++ b/docs/next-work.md
@@ -29,7 +29,7 @@ Prefer one open issue ≈ one PR (`Closes #N`).
 | 1 | #13 | Chroma persistent client — **merged** ([PR #29](https://github.com/Anna-Hax/JUNO/pull/29), `Closes #13`) |
 | 2 | #11 | First Alembic revision — **merged** (`Closes #11`) |
 | 3 | #16 | Ingest pipeline + extractors + inbox watcher — **merged** ([PR #31](https://github.com/Anna-Hax/JUNO/pull/31), `Closes #16`) |
-| 4 | #14 / #15 | Confirm MiniLM path + LLM health in `/status` — **PR opened** ([PR #32](https://github.com/Anna-Hax/JUNO/pull/32), `Closes #14` `#15`) |
+| 4 | #14 / #15 | Confirm MiniLM path + LLM health in `/status` — **merged** ([PR #32](https://github.com/Anna-Hax/JUNO/pull/32), `Closes #14` `#15`) |
 | 5 | #17 | Retrieve-only → sourced RAG + confidence — **done on `feat/rag-retrieve`** (PR / `Closes #17` not opened yet) |
 | 6 | #18–#19 | Bot query + forward-to-capture + digest/pause/status |
 | 7 | #20 | HITL `/review` inline buttons |
@@ -38,7 +38,7 @@ Prefer one open issue ≈ one PR (`Closes #N`).
 
 **Next coding issue:** #18 / #19.
 
-Already partially landed (keep issues open until acceptance fully met): #12 write queue, #18 allowlist handlers, #21 basic routes. Ingest upserts into the #13 `VectorStore`. MiniLM + LLM health are in [PR #32](https://github.com/Anna-Hax/JUNO/pull/32). `/search` joins Chroma hits to SQLite captures and cites them.
+Already partially landed (keep issues open until acceptance fully met): #12 write queue, #18 allowlist handlers, #21 basic routes. Ingest upserts into the #13 `VectorStore`. MiniLM + LLM health landed in [PR #32](https://github.com/Anna-Hax/JUNO/pull/32). `/search` joins Chroma hits to SQLite captures and cites them.
 
 ---
 

--- a/docs/sessions/02-codebase-map.md
+++ b/docs/sessions/02-codebase-map.md
@@ -1,6 +1,6 @@
 # Codebase map (as of M0 / early M1)
 
-**Last updated:** 2026-08-25
+**Last updated:** 2026-08-26
 
 ---
 
@@ -38,13 +38,14 @@ JUNO/
 | Alembic | `alembic/` + `alembic.ini` | Revision `0001` = current ORM ([ADR-03](../adr/003-alembic.md)) |
 | LLM | `llm/embedder.py`, `llm/chat.py` | Embeddings + chat providers |
 | Ingest | `ingest/extractors.py`, `chunking.py`, `pipeline.py`, `watcher.py` | File/URL extract, chunk, persist, inbox watch ([#16](https://github.com/Anna-Hax/JUNO/issues/16)) |
+| RAG | `rag/engine.py` | Vector retrieve, join captures, sourced answer + confidence ([#17](https://github.com/Anna-Hax/JUNO/issues/17)) |
 | Jobs | `jobs/` | Placeholder (M4) |
 
 ### Entry points
 
 - `uv run juno serve` → `runtime.main_sync()`
 - `uv run juno db-init` → `Database.migrate()` (Alembic `upgrade head`, or stamp legacy `create_all` DBs)
-- Tests: `apps/core/tests/test_foundation.py`, `test_migrations.py`, `test_ingest.py`, `test_vectors.py`
+- Tests: `apps/core/tests/test_foundation.py`, `test_migrations.py`, `test_ingest.py`, `test_vectors.py`, `test_rag.py`
 
 ### Dependencies
 

--- a/docs/sessions/08-session-rag.md
+++ b/docs/sessions/08-session-rag.md
@@ -1,0 +1,85 @@
+# Session log: retrieve-only + sourced RAG (#17)
+
+**Date:** 2026-08-26  
+**Repo:** [https://github.com/Anna-Hax/JUNO](https://github.com/Anna-Hax/JUNO)  
+**Plan:** Personal Knowledge Graph (local-first Python + Telegram)  
+**Scope of this session:** M1 issue **#17** — retrieve-only search, sourced RAG answers, citations + confidence.
+
+---
+
+## Summary
+
+`GET /search` queries the attached `VectorStore`, joins hits to SQLite `chunks` / `captures`, and always returns citations plus a confidence score (cosine similarity). When a chat provider is healthy it generates a sourced answer (`mode=rag`); if the LLM is down, errors, or `mode=retrieve` is requested, the same hits are returned without an answer (`mode=retrieve`).
+
+Work is on branch `feat/rag-retrieve` (from `main`). PR / `Closes #17` not opened yet.
+
+---
+
+## What changed
+
+### Code
+
+| Path | Role |
+|------|------|
+| `apps/core/src/juno/rag/engine.py` | Retrieve + optional generate; join Chroma ids to captures |
+| `apps/core/src/juno/rag/__init__.py` | Package exports |
+| `apps/core/src/juno/api/__init__.py` | `/search?q=&k=&mode=` wired; `create_app(..., chat=)` |
+| `apps/core/tests/test_rag.py` | Token, join/citations, empty index, RAG mock, unhealthy/error fallback |
+
+Rules encoded in code:
+
+- Chroma I/O stays on `query_async` (ADR-01 / ADR-04)
+- Citations are required on every response (`citations` mirrors hits, or the `[n]` subset after generate)
+- Confidence is `max(score)` over the cited hits; score is `1 - cosine distance`
+- LLM generate is skipped when `chat` is missing/unhealthy, `complete` raises, or the answer is empty
+- Stub embedder tests query the **same** ingested string (hash vectors are not semantic)
+
+### Docs
+
+- This session file
+- Codebase map + [`docs/next-work.md`](../next-work.md)
+- ADR-04 follow-up for #17 marked done
+- README `/search` line
+
+---
+
+## Not in this session
+
+- PR / merge to `main` (`Closes #17`)
+- Telegram text query using RAG (#18)
+- Live MiniLM / Ollama smoke (#4, #14/#15)
+- Merge with [PR #32](https://github.com/Anna-Hax/JUNO/pull/32) (`create_app(..., chat=)` lands in both; combine `/status` + `/search`)
+
+---
+
+## How to verify
+
+From `apps/core`:
+
+```powershell
+$env:EMBEDDING_BACKEND="stub"
+uv run pytest
+uv run ruff check src tests
+```
+
+Expect **36** tests passing (28 prior + 8 RAG).
+
+Manual (after ingesting something, `juno serve`):
+
+```powershell
+curl -H "Authorization: Bearer <token>" "http://127.0.0.1:8787/search?q=your+query&mode=retrieve"
+```
+
+Response should include `results`, `citations`, and `confidence`. With Ollama healthy and `mode=auto`, `mode` becomes `rag` and `answer` is set.
+
+---
+
+## Related docs
+
+| File | Contents |
+|------|----------|
+| [08-session-rag.md](08-session-rag.md) | This file |
+| [06-session-ingest.md](06-session-ingest.md) | M1 #16 ingest |
+| PR #32 (`feat/embedder-llm-status`) | M1 #14 / #15 MiniLM + LLM health (not on this branch) |
+| [next-work.md](../next-work.md) | Global next-work tracker |
+| [../adr/004-chroma-collections.md](../adr/004-chroma-collections.md) | Query `VectorStore`, then join SQLite |

--- a/docs/sessions/08-session-rag.md
+++ b/docs/sessions/08-session-rag.md
@@ -32,7 +32,9 @@ Rules encoded in code:
 - Citations are required on every response (`citations` mirrors hits, or the `[n]` subset after generate)
 - Confidence is `max(score)` over the cited hits; score is `1 - cosine distance`
 - LLM generate is skipped when `chat` is missing/unhealthy, `complete` raises, or the answer is empty
+- Health probe uses `healthy(timeout=1.5)` (same as `/status` after PR #32)
 - Stub embedder tests query the **same** ingested string (hash vectors are not semantic)
+- `LLM_PROVIDER=offline` / `OfflineProvider` stays retrieve-only
 
 ### Docs
 
@@ -47,8 +49,9 @@ Rules encoded in code:
 
 - PR / merge to `main` (`Closes #17`)
 - Telegram text query using RAG (#18)
-- Live MiniLM / Ollama smoke (#4, #14/#15)
-- Merge with [PR #32](https://github.com/Anna-Hax/JUNO/pull/32) (`create_app(..., chat=)` lands in both; combine `/status` + `/search`)
+- Live MiniLM / Ollama smoke (#4)
+
+Merged [PR #32](https://github.com/Anna-Hax/JUNO/pull/32) into this branch; `/status` live probe and `/search` both remain.
 
 ---
 
@@ -62,7 +65,7 @@ uv run pytest
 uv run ruff check src tests
 ```
 
-Expect **36** tests passing (28 prior + 8 RAG).
+Expect **56** tests passing (foundation + ingest + migrations + vectors + embedder + chat + 9 RAG).
 
 Manual (after ingesting something, `juno serve`):
 
@@ -80,6 +83,6 @@ Response should include `results`, `citations`, and `confidence`. With Ollama he
 |------|----------|
 | [08-session-rag.md](08-session-rag.md) | This file |
 | [06-session-ingest.md](06-session-ingest.md) | M1 #16 ingest |
-| PR #32 (`feat/embedder-llm-status`) | M1 #14 / #15 MiniLM + LLM health (not on this branch) |
+| [07-session-embedder-llm.md](07-session-embedder-llm.md) | M1 #14 / #15 MiniLM + LLM health (PR #32, now on this branch) |
 | [next-work.md](../next-work.md) | Global next-work tracker |
 | [../adr/004-chroma-collections.md](../adr/004-chroma-collections.md) | Query `VectorStore`, then join SQLite |

--- a/docs/sessions/README.md
+++ b/docs/sessions/README.md
@@ -12,5 +12,6 @@ Living notes for what was implemented, how GitHub is set up, and what to do next
 | [04-session-chroma-client.md](04-session-chroma-client.md) | **M1 #13** — persistent Chroma client |
 | [05-session-alembic.md](05-session-alembic.md) | **M1 #11** — first Alembic revision |
 | [06-session-ingest.md](06-session-ingest.md) | **M1 #16** — ingest pipeline, extractors, inbox watcher |
+| [08-session-rag.md](08-session-rag.md) | **M1 #17** — retrieve-only + sourced RAG with citations |
 
 Architecture decisions live in [`../adr/`](../adr/). Product requirements: [`../../personal-knowledge-graph-prd.md`](../../personal-knowledge-graph-prd.md).


### PR DESCRIPTION
## Summary
- Wire `GET /search` to query the persistent Chroma store and join hits to SQLite captures so every response includes citations and a confidence score.
- Generate a sourced LLM answer when the chat provider is healthy; fall back to retrieve-only if the LLM is offline, unhealthy, or errors (including `OfflineProvider` from #14/#15).
- Merges current `main` (PR #32 MiniLM + live `/status` probe) so `/search` and `/status` coexist.

## Linked issue
Closes #17

## Test plan
- [x] `uv run pytest` (apps/core) — 56 passed
- [x] `uv run ruff check src tests`
- [ ] Manual: ingest a note, then `GET /search?q=...&mode=retrieve` with the API token; with Ollama up, `mode=auto` should set `answer`