### PR TITLE
feat(hitl): add /review with Approve Reject Skip buttons

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Personal knowledge-graph agent: passively (and manually) capture what you read, 
 - **Chroma** for vectors — persistent client, one collection per embedding model ([ADR-04](docs/adr/004-chroma-collections.md)); **stub embedder** in CI
 - **Browser extension** (`apps/extension`): stub until Phase 2
 - **Inbox** (`inbox/`): drop `.txt` / `.md` / `.pdf` / `.url` (or a one-line http(s) text file). `juno serve` watches the folder; good files move to `inbox/.processed/`, unreadable PDFs to `inbox/.failed/`.
+- **HITL** (`/review`): inline Approve / Reject / Skip for pending graph merges
 
 ## Prerequisites
 

--- a/apps/core/src/juno/bot/handlers.py
+++ b/apps/core/src/juno/bot/handlers.py
@@ -5,12 +5,30 @@ from __future__ import annotations
 from telegram import Update
 from telegram.ext import ContextTypes
 
-from juno.config import get_settings
+from juno.bot.review import review_callback, review_cmd
+from juno.config import Settings, get_settings
+
+__all__ = [
+    "help_cmd",
+    "review_callback",
+    "review_cmd",
+    "start_cmd",
+    "text_query",
+]
 
 
-def _allowed(user_id: int | None) -> bool:
-    settings = get_settings()
-    allow = settings.allowed_user_id_set()
+def _settings(context: ContextTypes.DEFAULT_TYPE) -> Settings:
+    stored = context.application.bot_data.get("settings")
+    if stored is not None:
+        return stored
+    services = context.application.bot_data.get("juno")
+    if services is not None and getattr(services, "settings", None) is not None:
+        return services.settings
+    return get_settings()
+
+
+def _allowed(user_id: int | None, context: ContextTypes.DEFAULT_TYPE) -> bool:
+    allow = _settings(context).allowed_user_id_set()
     if not allow:
         # Empty allowlist = reject everyone until configured (security default)
         return False
@@ -18,7 +36,9 @@ def _allowed(user_id: int | None) -> bool:
 
 
 async def start_cmd(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
-    if not update.effective_user or not _allowed(update.effective_user.id):
+    if not update.effective_user or not _allowed(update.effective_user.id, context):
+        return
+    if update.message is None:
         return
     await update.message.reply_text(
         "Juno online. Ask a question, or /help for commands.\n"
@@ -27,7 +47,9 @@ async def start_cmd(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
 
 
 async def help_cmd(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
-    if not update.effective_user or not _allowed(update.effective_user.id):
+    if not update.effective_user or not _allowed(update.effective_user.id, context):
+        return
+    if update.message is None:
         return
     await update.message.reply_text(
         "Commands:\n"
@@ -36,13 +58,15 @@ async def help_cmd(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
         "/digest today|week — (coming)\n"
         "/pause /resume — (coming)\n"
         "/status — (coming)\n"
-        "/review — HITL queue (coming)\n"
+        "/review — HITL queue (Approve / Reject / Skip)\n"
         "Or send a link/doc/text to capture."
     )
 
 
 async def text_query(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
-    if not update.effective_user or not _allowed(update.effective_user.id):
+    if not update.effective_user or not _allowed(update.effective_user.id, context):
+        return
+    if update.message is None:
         return
     text = (update.message.text or "").strip()
     if not text:

--- a/apps/core/src/juno/bot/review.py
+++ b/apps/core/src/juno/bot/review.py
@@ -1,0 +1,139 @@
+"""Telegram HITL surface: /review plus Approve / Reject / Skip inline buttons."""
+
+from __future__ import annotations
+
+from telegram import InlineKeyboardButton, InlineKeyboardMarkup, Update
+from telegram.ext import ContextTypes
+
+from juno.config import Settings, get_settings
+from juno.hitl.queue import Decision, ReviewCard, ReviewQueue
+
+_VERBS = {"approve": "Approved", "reject": "Rejected", "skip": "Skipped"}
+
+
+def _settings(context: ContextTypes.DEFAULT_TYPE) -> Settings:
+    stored = context.application.bot_data.get("settings")
+    if stored is not None:
+        return stored
+    services = context.application.bot_data.get("juno")
+    if services is not None and getattr(services, "settings", None) is not None:
+        return services.settings
+    return get_settings()
+
+
+def _allowed(user_id: int | None, context: ContextTypes.DEFAULT_TYPE) -> bool:
+    allow = _settings(context).allowed_user_id_set()
+    if not allow:
+        return False
+    return user_id is not None and user_id in allow
+
+
+def review_queue_from_context(context: ContextTypes.DEFAULT_TYPE) -> ReviewQueue | None:
+    queue = context.application.bot_data.get("review")
+    if isinstance(queue, ReviewQueue):
+        return queue
+    services = context.application.bot_data.get("juno")
+    db = getattr(services, "db", None) if services is not None else None
+    if db is not None:
+        queue = ReviewQueue(db)
+        context.application.bot_data["review"] = queue
+        return queue
+    return None
+
+
+def review_keyboard(item_id: int) -> InlineKeyboardMarkup:
+    return InlineKeyboardMarkup(
+        [
+            [
+                InlineKeyboardButton("Approve", callback_data=f"rev:{item_id}:approve"),
+                InlineKeyboardButton("Reject", callback_data=f"rev:{item_id}:reject"),
+                InlineKeyboardButton("Skip", callback_data=f"rev:{item_id}:skip"),
+            ]
+        ]
+    )
+
+
+def parse_review_callback(data: str) -> tuple[int, Decision] | None:
+    parts = data.split(":")
+    if len(parts) != 3 or parts[0] != "rev":
+        return None
+    try:
+        item_id = int(parts[1])
+    except ValueError:
+        return None
+    action = parts[2]
+    if action not in {"approve", "reject", "skip"}:
+        return None
+    return item_id, action  # type: ignore[return-value]
+
+
+def _card_text(card: ReviewCard) -> str:
+    return card.summary()
+
+
+async def review_cmd(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+    if not update.effective_user or not _allowed(update.effective_user.id, context):
+        return
+    if update.message is None:
+        return
+    queue = review_queue_from_context(context)
+    if queue is None:
+        await update.message.reply_text("Review queue is not available.")
+        return
+    card = await queue.next_open()
+    if card is None:
+        await update.message.reply_text("Review queue empty.")
+        return
+    await update.message.reply_text(_card_text(card), reply_markup=review_keyboard(card.id))
+
+
+async def review_callback(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+    query = update.callback_query
+    if query is None:
+        return
+    if not update.effective_user or not _allowed(update.effective_user.id, context):
+        await query.answer()
+        return
+    parsed = parse_review_callback(query.data or "")
+    if parsed is None:
+        await query.answer("Unknown button")
+        return
+    item_id, decision = parsed
+    queue = review_queue_from_context(context)
+    if queue is None:
+        await query.answer("Review queue is not available.")
+        return
+    try:
+        result = await queue.decide(item_id, decision)
+    except LookupError:
+        await query.answer("That review item is gone.")
+        await query.edit_message_text("Review item not found.")
+        return
+
+    await query.answer()
+    verb = _VERBS[decision]
+    if result.already_decided:
+        text = f"Review #{item_id} was already {result.card.decision}."
+    else:
+        text = f"{verb} review #{item_id}."
+        if result.card.kind == "merge" and decision == "approve":
+            text += " Merge is now committed."
+        elif result.card.kind == "merge" and decision == "reject":
+            text += " Merge was not applied."
+        elif decision == "skip":
+            text += " Left in the queue."
+
+    nxt = result.next_card
+    if nxt is None:
+        await query.edit_message_text(text + "\n\nReview queue empty.")
+        return
+    if nxt.id == item_id and decision == "skip":
+        await query.edit_message_text(
+            text + "\n\nNo other items — this one stays in the queue.",
+            reply_markup=review_keyboard(item_id),
+        )
+        return
+    await query.edit_message_text(
+        text + f"\n\nNext:\n{_card_text(nxt)}",
+        reply_markup=review_keyboard(nxt.id),
+    )

--- a/apps/core/src/juno/hitl/__init__.py
+++ b/apps/core/src/juno/hitl/__init__.py
@@ -1,0 +1,5 @@
+"""Human-in-the-loop review queue (Telegram is the approval surface)."""
+
+from juno.hitl.queue import DecideResult, ReviewCard, ReviewQueue
+
+__all__ = ["DecideResult", "ReviewCard", "ReviewQueue"]

--- a/apps/core/src/juno/hitl/queue.py
+++ b/apps/core/src/juno/hitl/queue.py
@@ -1,0 +1,289 @@
+"""Review queue: proposed merges stay pending until an Approve tap."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from typing import Any, Literal
+
+from sqlalchemy import case, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from juno.graph.db import Database
+from juno.models import Edge, Node, ReviewItem
+
+Decision = Literal["approve", "reject", "skip"]
+
+KIND_MERGE = "merge"
+STATUS_PENDING = "pending"
+STATUS_SKIPPED = "skipped"
+STATUS_DECIDED = "decided"
+EDGE_PENDING = "pending"
+EDGE_COMMITTED = "committed"
+EDGE_REJECTED = "rejected"
+
+_ALLOWED_DECISIONS: frozenset[str] = frozenset({"approve", "reject", "skip"})
+
+
+@dataclass(frozen=True)
+class ReviewCard:
+    id: int
+    kind: str
+    confidence: float
+    payload: dict[str, Any]
+    status: str
+    decision: str | None
+
+    def summary(self) -> str:
+        lines = [
+            f"Review #{self.id} · {self.kind}",
+            f"Confidence: {self.confidence:.2f}",
+        ]
+        if self.kind == KIND_MERGE:
+            src = str(self.payload.get("from_name") or "?")
+            dst = str(self.payload.get("to_name") or "?")
+            lines.append(f'Merge "{src}" → "{dst}"')
+            reason = self.payload.get("reason")
+            if reason:
+                lines.append(str(reason))
+            lines.append("This merge stays pending until you Approve.")
+        else:
+            preview = str(self.payload)[:500]
+            if preview:
+                lines.append(preview)
+        return "\n".join(lines)
+
+
+@dataclass(frozen=True)
+class DecideResult:
+    card: ReviewCard
+    applied: bool
+    already_decided: bool
+    next_card: ReviewCard | None
+
+
+class ReviewQueue:
+    """Persist HITL items and apply merge payloads only on approve."""
+
+    def __init__(self, db: Database) -> None:
+        self.db = db
+
+    async def enqueue(
+        self,
+        *,
+        kind: str,
+        payload: dict[str, Any],
+        confidence: float = 0.5,
+    ) -> ReviewCard:
+        async def write(session: AsyncSession) -> ReviewCard:
+            item = ReviewItem(
+                kind=kind,
+                confidence=confidence,
+                payload=payload,
+                status=STATUS_PENDING,
+            )
+            session.add(item)
+            await session.flush()
+            return _card(item)
+
+        return await self.db.write(write)
+
+    async def propose_merge(
+        self,
+        *,
+        from_name: str,
+        to_name: str,
+        confidence: float,
+        reason: str | None = None,
+        relation: str = "same_as",
+        from_kind: str = "topic",
+        to_kind: str = "topic",
+    ) -> ReviewCard:
+        """Create nodes (if needed) plus a *pending* edge and a review item.
+
+        The edge is not committed here — that requires ``decide(..., "approve")``.
+        """
+
+        async def write(session: AsyncSession) -> ReviewCard:
+            src = await _get_or_create_node(session, from_name.strip(), from_kind)
+            dst = await _get_or_create_node(session, to_name.strip(), to_kind)
+            edge = await _pending_edge(
+                session,
+                from_id=src.id,
+                to_id=dst.id,
+                relation=relation,
+                confidence=confidence,
+            )
+            item = ReviewItem(
+                kind=KIND_MERGE,
+                confidence=confidence,
+                payload={
+                    "from_name": src.canonical_name,
+                    "to_name": dst.canonical_name,
+                    "from_node_id": src.id,
+                    "to_node_id": dst.id,
+                    "edge_id": edge.id,
+                    "relation": relation,
+                    "reason": reason,
+                },
+                status=STATUS_PENDING,
+            )
+            session.add(item)
+            await session.flush()
+            return _card(item)
+
+        return await self.db.write(write)
+
+    async def next_open(self) -> ReviewCard | None:
+        async def load(session: AsyncSession) -> ReviewCard | None:
+            row = await _next_row(session)
+            return _card(row) if row is not None else None
+
+        return await self.db.read(load)
+
+    async def get(self, item_id: int) -> ReviewCard | None:
+        async def load(session: AsyncSession) -> ReviewCard | None:
+            row = await session.get(ReviewItem, item_id)
+            return _card(row) if row is not None else None
+
+        return await self.db.read(load)
+
+    async def decide(self, item_id: int, decision: Decision) -> DecideResult:
+        if decision not in _ALLOWED_DECISIONS:
+            raise ValueError(f"unknown decision: {decision}")
+
+        async def write(session: AsyncSession) -> DecideResult:
+            row = await session.get(ReviewItem, item_id)
+            if row is None:
+                raise LookupError(f"review item {item_id} not found")
+
+            already = row.status == STATUS_DECIDED
+            applied = False
+            if not already:
+                if decision == "skip":
+                    row.status = STATUS_SKIPPED
+                    row.decision = None
+                    row.decided_at = None
+                else:
+                    row.status = STATUS_DECIDED
+                    row.decision = decision
+                    row.decided_at = datetime.now(UTC)
+                    if decision == "approve":
+                        applied = await _apply(session, row)
+                    else:
+                        await _reject(session, row)
+
+            card = _card(row)
+            nxt = await _next_row(session, exclude_id=row.id)
+            if nxt is not None:
+                next_card = _card(nxt)
+            elif row.status != STATUS_DECIDED:
+                next_card = card
+            else:
+                next_card = None
+            return DecideResult(
+                card=card,
+                applied=applied,
+                already_decided=already,
+                next_card=next_card,
+            )
+
+        return await self.db.write(write)
+
+
+def _card(row: ReviewItem) -> ReviewCard:
+    payload = row.payload if isinstance(row.payload, dict) else {}
+    return ReviewCard(
+        id=row.id,
+        kind=row.kind,
+        confidence=row.confidence,
+        payload=dict(payload),
+        status=row.status,
+        decision=row.decision,
+    )
+
+
+async def _next_row(
+    session: AsyncSession,
+    *,
+    exclude_id: int | None = None,
+) -> ReviewItem | None:
+    priority = case((ReviewItem.status == STATUS_PENDING, 0), else_=1)
+    stmt = (
+        select(ReviewItem)
+        .where(ReviewItem.status.in_((STATUS_PENDING, STATUS_SKIPPED)))
+        .order_by(priority, ReviewItem.created_at, ReviewItem.id)
+    )
+    if exclude_id is not None:
+        stmt = stmt.where(ReviewItem.id != exclude_id)
+    result = await session.execute(stmt.limit(1))
+    return result.scalar_one_or_none()
+
+
+async def _get_or_create_node(session: AsyncSession, name: str, kind: str) -> Node:
+    result = await session.execute(select(Node).where(Node.canonical_name == name))
+    node = result.scalar_one_or_none()
+    if node is not None:
+        return node
+    node = Node(canonical_name=name, kind=kind, status="committed")
+    session.add(node)
+    await session.flush()
+    return node
+
+
+async def _pending_edge(
+    session: AsyncSession,
+    *,
+    from_id: int,
+    to_id: int,
+    relation: str,
+    confidence: float,
+) -> Edge:
+    result = await session.execute(
+        select(Edge).where(
+            Edge.from_id == from_id,
+            Edge.to_id == to_id,
+            Edge.relation == relation,
+            Edge.status != EDGE_REJECTED,
+        )
+    )
+    existing = result.scalar_one_or_none()
+    if existing is not None:
+        if existing.status != EDGE_COMMITTED:
+            existing.status = EDGE_PENDING
+            existing.confidence = confidence
+        return existing
+    edge = Edge(
+        from_id=from_id,
+        to_id=to_id,
+        relation=relation,
+        confidence=confidence,
+        status=EDGE_PENDING,
+    )
+    session.add(edge)
+    await session.flush()
+    return edge
+
+
+async def _apply(session: AsyncSession, row: ReviewItem) -> bool:
+    if row.kind != KIND_MERGE:
+        return False
+    edge_id = (row.payload or {}).get("edge_id")
+    if edge_id is None:
+        return False
+    edge = await session.get(Edge, int(edge_id))
+    if edge is None:
+        return False
+    edge.status = EDGE_COMMITTED
+    return True
+
+
+async def _reject(session: AsyncSession, row: ReviewItem) -> None:
+    if row.kind != KIND_MERGE:
+        return
+    edge_id = (row.payload or {}).get("edge_id")
+    if edge_id is None:
+        return
+    edge = await session.get(Edge, int(edge_id))
+    if edge is not None and edge.status != EDGE_COMMITTED:
+        edge.status = EDGE_REJECTED

--- a/apps/core/src/juno/runtime.py
+++ b/apps/core/src/juno/runtime.py
@@ -12,13 +12,15 @@ from contextlib import asynccontextmanager
 
 import uvicorn
 from fastapi import FastAPI
-from telegram.ext import Application, CommandHandler, MessageHandler, filters
+from telegram.ext import Application, CallbackQueryHandler, CommandHandler, MessageHandler, filters
 
 from juno.api import create_app
 from juno.bot.handlers import help_cmd, start_cmd, text_query
+from juno.bot.review import review_callback, review_cmd
 from juno.config import Settings, get_settings
 from juno.graph.db import Database
 from juno.graph.vectors import VectorStore
+from juno.hitl.queue import ReviewQueue
 from juno.ingest.pipeline import IngestPipeline
 from juno.ingest.watcher import InboxWatcher
 from juno.llm.chat import create_chat_provider
@@ -27,14 +29,22 @@ from juno.llm.embedder import create_embedder
 logger = logging.getLogger("juno.runtime")
 
 
-def build_telegram_application(settings: Settings) -> Application | None:
+def build_telegram_application(
+    settings: Settings,
+    db: Database | None = None,
+) -> Application | None:
     if not settings.telegram_bot_token:
         logger.warning("TELEGRAM_BOT_TOKEN empty — bot disabled")
         return None
 
     app = Application.builder().token(settings.telegram_bot_token).build()
+    app.bot_data["settings"] = settings
+    if db is not None:
+        app.bot_data["review"] = ReviewQueue(db)
     app.add_handler(CommandHandler("start", start_cmd))
     app.add_handler(CommandHandler("help", help_cmd))
+    app.add_handler(CommandHandler("review", review_cmd))
+    app.add_handler(CallbackQueryHandler(review_callback, pattern=r"^rev:"))
     app.add_handler(MessageHandler(filters.TEXT & ~filters.COMMAND, text_query))
     return app
 
@@ -69,6 +79,8 @@ def attach_lifespan(fastapi_app: FastAPI) -> FastAPI:
 
         ptb: Application | None = app.state.ptb
         if ptb is not None:
+            ptb.bot_data["settings"] = settings
+            ptb.bot_data["review"] = ReviewQueue(db)
             await ptb.initialize()
             await ptb.start()
             if ptb.updater is not None:
@@ -113,7 +125,7 @@ async def run_server(settings: Settings | None = None) -> None:
     fastapi_app.state.embedder = embedder
     fastapi_app.state.vectors = vectors
     fastapi_app.state.pipeline = pipeline
-    fastapi_app.state.ptb = build_telegram_application(settings)
+    fastapi_app.state.ptb = build_telegram_application(settings, db=db)
     attach_lifespan(fastapi_app)
 
     config = uvicorn.Config(

--- a/apps/core/tests/test_bot_review.py
+++ b/apps/core/tests/test_bot_review.py
@@ -1,0 +1,162 @@
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from telegram.ext import CallbackQueryHandler, CommandHandler
+
+from juno.bot.review import parse_review_callback, review_callback, review_cmd, review_keyboard
+from juno.graph.db import Database
+from juno.hitl.queue import EDGE_COMMITTED, EDGE_PENDING, ReviewQueue
+from juno.models import Edge
+from juno.runtime import build_telegram_application
+
+
+@pytest.fixture
+def allowed_settings(settings):
+    return settings.model_copy(update={"allowed_telegram_user_ids": "42"})
+
+
+@pytest.fixture
+async def queue(allowed_settings):
+    db = Database(allowed_settings)
+    await db.migrate()
+    q = ReviewQueue(db)
+    yield q
+    await db.dispose()
+
+
+def _message_update(user_id: int) -> MagicMock:
+    update = MagicMock()
+    update.effective_user.id = user_id
+    update.message.reply_text = AsyncMock()
+    update.callback_query = None
+    return update
+
+
+def _callback_update(user_id: int, data: str) -> MagicMock:
+    update = MagicMock()
+    update.effective_user.id = user_id
+    update.message = None
+    update.callback_query = MagicMock()
+    update.callback_query.data = data
+    update.callback_query.answer = AsyncMock()
+    update.callback_query.edit_message_text = AsyncMock()
+    return update
+
+
+def _context(settings, queue: ReviewQueue | None) -> MagicMock:
+    ctx = MagicMock()
+    ctx.application.bot_data = {"settings": settings, "review": queue}
+    return ctx
+
+
+def test_parse_review_callback():
+    assert parse_review_callback("rev:12:approve") == (12, "approve")
+    assert parse_review_callback("rev:12:reject") == (12, "reject")
+    assert parse_review_callback("rev:12:skip") == (12, "skip")
+    assert parse_review_callback("rev:nope:approve") is None
+    assert parse_review_callback("other:1:approve") is None
+
+
+def test_review_keyboard_callback_data():
+    markup = review_keyboard(7)
+    labels = [btn.text for row in markup.inline_keyboard for btn in row]
+    data = [btn.callback_data for row in markup.inline_keyboard for btn in row]
+    assert labels == ["Approve", "Reject", "Skip"]
+    assert data == ["rev:7:approve", "rev:7:reject", "rev:7:skip"]
+
+
+@pytest.mark.asyncio
+async def test_review_cmd_ignores_strangers(allowed_settings, queue):
+    update = _message_update(99)
+    await review_cmd(update, _context(allowed_settings, queue))
+    update.message.reply_text.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_review_cmd_empty_queue(allowed_settings, queue):
+    update = _message_update(42)
+    await review_cmd(update, _context(allowed_settings, queue))
+    update.message.reply_text.assert_awaited_once_with("Review queue empty.")
+
+
+@pytest.mark.asyncio
+async def test_review_cmd_shows_pending_merge(allowed_settings, queue):
+    card = await queue.propose_merge(from_name="Foo", to_name="Bar", confidence=0.33)
+    update = _message_update(42)
+    await review_cmd(update, _context(allowed_settings, queue))
+    kwargs = update.message.reply_text.await_args
+    text = kwargs.args[0]
+    markup = kwargs.kwargs["reply_markup"]
+    assert f"Review #{card.id}" in text
+    assert "Foo" in text
+    assert "Bar" in text
+    assert "stays pending until you Approve" in text
+    data = [btn.callback_data for row in markup.inline_keyboard for btn in row]
+    assert f"rev:{card.id}:approve" in data
+
+
+@pytest.mark.asyncio
+async def test_approve_callback_commits_merge(allowed_settings, queue):
+    card = await queue.propose_merge(from_name="Src", to_name="Dst", confidence=0.7)
+    edge_id = int(card.payload["edge_id"])
+    update = _callback_update(42, f"rev:{card.id}:approve")
+    await review_callback(update, _context(allowed_settings, queue))
+
+    update.callback_query.answer.assert_awaited()
+    edited = update.callback_query.edit_message_text.await_args.args[0]
+    assert "Approved" in edited
+    assert "Merge is now committed" in edited
+
+    async def load(session):
+        edge = await session.get(Edge, edge_id)
+        assert edge is not None
+        return edge.status
+
+    assert await queue.db.read(load) == EDGE_COMMITTED
+
+
+@pytest.mark.asyncio
+async def test_skip_callback_does_not_commit(allowed_settings, queue):
+    card = await queue.propose_merge(from_name="Left", to_name="Right", confidence=0.4)
+    edge_id = int(card.payload["edge_id"])
+    update = _callback_update(42, f"rev:{card.id}:skip")
+    await review_callback(update, _context(allowed_settings, queue))
+    edited = update.callback_query.edit_message_text.await_args.args[0]
+    assert "Skipped" in edited
+    assert "stays in the queue" in edited
+
+    async def load(session):
+        edge = await session.get(Edge, edge_id)
+        assert edge is not None
+        return edge.status
+
+    assert await queue.db.read(load) == EDGE_PENDING
+
+
+@pytest.mark.asyncio
+async def test_review_queue_falls_back_to_juno_bot_data(allowed_settings, queue):
+    card = await queue.propose_merge(from_name="X", to_name="Y", confidence=0.5)
+    services = MagicMock()
+    services.settings = allowed_settings
+    services.db = queue.db
+    ctx = MagicMock()
+    ctx.application.bot_data = {"juno": services}
+    update = _message_update(42)
+    await review_cmd(update, ctx)
+    text = update.message.reply_text.await_args.args[0]
+    assert f"Review #{card.id}" in text
+
+
+def test_telegram_app_registers_review_handlers(allowed_settings):
+    settings = allowed_settings.model_copy(update={"telegram_bot_token": "1:test-token"})
+    app = build_telegram_application(settings)
+    assert app is not None
+    handlers = [handler for group in app.handlers.values() for handler in group]
+    commands: set[str] = set()
+    for handler in handlers:
+        if isinstance(handler, CommandHandler):
+            commands.update(handler.commands)
+    assert "review" in commands
+    assert any(isinstance(handler, CallbackQueryHandler) for handler in handlers)

--- a/apps/core/tests/test_review.py
+++ b/apps/core/tests/test_review.py
@@ -1,0 +1,132 @@
+from __future__ import annotations
+
+import pytest
+from sqlalchemy import func, select
+
+from juno.graph.db import Database
+from juno.hitl.queue import EDGE_COMMITTED, EDGE_PENDING, EDGE_REJECTED, ReviewQueue
+from juno.models import Edge
+
+
+@pytest.fixture
+async def queue(settings):
+    db = Database(settings)
+    await db.migrate()
+    q = ReviewQueue(db)
+    yield q
+    await db.dispose()
+
+
+async def _edge_status(db: Database, edge_id: int) -> str | None:
+    async def load(session):
+        edge = await session.get(Edge, edge_id)
+        return None if edge is None else edge.status
+
+    return await db.read(load)
+
+
+async def _committed_edge_count(db: Database) -> int:
+    async def load(session):
+        result = await session.execute(
+            select(func.count()).select_from(Edge).where(Edge.status == EDGE_COMMITTED)
+        )
+        return int(result.scalar_one())
+
+    return await db.read(load)
+
+
+@pytest.mark.asyncio
+async def test_propose_merge_stays_pending_until_approve(queue):
+    card = await queue.propose_merge(
+        from_name="Rust ownership",
+        to_name="Rust",
+        confidence=0.41,
+        reason="same topic cluster",
+    )
+    assert card.kind == "merge"
+    assert card.status == "pending"
+    assert card.decision is None
+    edge_id = int(card.payload["edge_id"])
+    assert await _edge_status(queue.db, edge_id) == EDGE_PENDING
+    assert await _committed_edge_count(queue.db) == 0
+
+    result = await queue.decide(card.id, "approve")
+    assert result.already_decided is False
+    assert result.applied is True
+    assert result.card.status == "decided"
+    assert result.card.decision == "approve"
+    assert await _edge_status(queue.db, edge_id) == EDGE_COMMITTED
+    assert await _committed_edge_count(queue.db) == 1
+
+
+@pytest.mark.asyncio
+async def test_reject_does_not_commit_merge(queue):
+    card = await queue.propose_merge(from_name="Alpha", to_name="Beta", confidence=0.2)
+    edge_id = int(card.payload["edge_id"])
+
+    result = await queue.decide(card.id, "reject")
+    assert result.applied is False
+    assert result.card.decision == "reject"
+    assert await _edge_status(queue.db, edge_id) == EDGE_REJECTED
+    assert await _committed_edge_count(queue.db) == 0
+
+
+@pytest.mark.asyncio
+async def test_skip_leaves_merge_pending(queue):
+    card = await queue.propose_merge(from_name="One", to_name="Two", confidence=0.5)
+    edge_id = int(card.payload["edge_id"])
+
+    result = await queue.decide(card.id, "skip")
+    assert result.applied is False
+    assert result.already_decided is False
+    assert result.card.status == "skipped"
+    assert result.card.decision is None
+    assert await _edge_status(queue.db, edge_id) == EDGE_PENDING
+    assert await _committed_edge_count(queue.db) == 0
+
+    later = await queue.decide(card.id, "approve")
+    assert later.applied is True
+    assert await _edge_status(queue.db, edge_id) == EDGE_COMMITTED
+
+
+@pytest.mark.asyncio
+async def test_approve_is_idempotent(queue):
+    card = await queue.propose_merge(from_name="A", to_name="B", confidence=0.9)
+    first = await queue.decide(card.id, "approve")
+    second = await queue.decide(card.id, "reject")
+    assert first.applied is True
+    assert second.already_decided is True
+    assert second.applied is False
+    assert second.card.decision == "approve"
+    assert await _committed_edge_count(queue.db) == 1
+
+
+@pytest.mark.asyncio
+async def test_next_open_prefers_pending_then_skipped(queue):
+    first = await queue.propose_merge(from_name="a", to_name="b", confidence=0.1)
+    second = await queue.propose_merge(from_name="c", to_name="d", confidence=0.2)
+    await queue.decide(first.id, "skip")
+
+    nxt = await queue.next_open()
+    assert nxt is not None
+    assert nxt.id == second.id
+
+    await queue.decide(second.id, "reject")
+    leftover = await queue.next_open()
+    assert leftover is not None
+    assert leftover.id == first.id
+    assert leftover.status == "skipped"
+
+
+@pytest.mark.asyncio
+async def test_decide_missing_item(queue):
+    with pytest.raises(LookupError):
+        await queue.decide(999, "approve")
+
+
+@pytest.mark.asyncio
+async def test_generic_enqueue_has_no_graph_side_effect(queue):
+    card = await queue.enqueue(kind="ingest_batch", payload={"batch": "mobile"}, confidence=0.3)
+    result = await queue.decide(card.id, "approve")
+    assert result.applied is False
+    assert await _committed_edge_count(queue.db) == 0

--- a/docs/next-work.md
+++ b/docs/next-work.md
@@ -1,6 +1,6 @@
 # Next work (after M0 bootstrap)
 
-**Last updated:** 2026-08-22  
+**Last updated:** 2026-08-26  
 **Track issues on:** https://github.com/Anna-Hax/JUNO/issues
 
 ---
@@ -26,15 +26,19 @@ Prefer one open issue ≈ one PR (`Closes #N`).
 
 | Order | Issue | Work |
 |-------|-------|------|
-| 3 | #16 | Ingest pipeline + extractors + inbox watcher — **done on `feat/ingest-pipeline`** (PR / `Closes #16` not opened yet) |
-| 4 | #14 / #15 | Confirm MiniLM path + LLM health in `/status` |
-| 5 | #17 | Retrieve-only → sourced RAG + confidence |
-| 6 | #18–#19 | Bot query + forward-to-capture + digest/pause/status |
-| 7 | #20 | HITL `/review` inline buttons |
-| 8 | #21 | Harden API (already stubbed) |
+| 1 | #13 | Chroma persistent client — **merged** ([PR #29](https://github.com/Anna-Hax/JUNO/pull/29)) |
+| 2 | #11 | First Alembic revision — **merged** ([PR #30](https://github.com/Anna-Hax/JUNO/pull/30)) |
+| 3 | #16 | Ingest pipeline + extractors + inbox watcher — **merged** ([PR #31](https://github.com/Anna-Hax/JUNO/pull/31)) |
+| 4 | #14 / #15 | Confirm MiniLM path + LLM health in `/status` — **done on `feat/embedder-llm-status`** |
+| 5 | #17 | Retrieve-only → sourced RAG + confidence — in progress (`feat/rag-retrieve`) |
+| 6 | #18–#19 | Bot query + forward-to-capture + digest/pause/status — in progress (worktree) |
+| 7 | #20 | HITL `/review` inline buttons — **done on `feat/hitl-review`** (PR / `Closes #20` not opened yet) |
+| 8 | #21 | Harden API (already stubbed; `/ingest` now persists) |
 | 9 | #22–#24 | Integration tests, export/wipe, v1.0 gate |
 
-Already partially landed (keep issues open until acceptance fully met): #13 Chroma wrapper (branch, unmerged), #16 ingest (branch, unmerged), #12 write queue, #14 stub embedder, #15 chat adapters, #18 allowlist handlers, #21 basic routes.
+**Next coding issue:** #17 / #18–#19 (parallel); then merge #20 after those land (expect `handlers.py` / `runtime.py` conflicts).
+
+Already partially landed (keep issues open until acceptance fully met): #12 write queue, #14/#15 on `feat/embedder-llm-status`, #18 allowlist handlers, #21 basic routes. Ingest upserts into the #13 `VectorStore`. HITL queue + `/review` buttons are on this branch (#20).
 
 ---
 

--- a/docs/sessions/02-codebase-map.md
+++ b/docs/sessions/02-codebase-map.md
@@ -1,6 +1,6 @@
 # Codebase map (as of M0 / early M1)
 
-**Last updated:** 2026-08-25
+**Last updated:** 2026-08-26
 
 ---
 
@@ -31,20 +31,21 @@ JUNO/
 | CLI | `cli.py` | `juno serve` / `db-init` / `version` |
 | Runtime | `runtime.py` | Shared asyncio: uvicorn + PTB + inbox watcher lifespan |
 | API | `api/__init__.py` | FastAPI routes + token + loopback middleware |
-| Bot | `bot/handlers.py` | Telegram commands / text stub |
+| Bot | `bot/handlers.py`, `bot/review.py` | Telegram commands / HITL `/review` buttons ([#20](https://github.com/Anna-Hax/JUNO/issues/20)) |
 | Graph DB | `graph/db.py`, `graph/migrations.py` | Engine, WAL, write queue, Alembic upgrade/stamp |
 | Vectors | `graph/vectors.py` | Persistent Chroma; one collection per embedding model ([ADR-04](../adr/004-chroma-collections.md)) |
 | Models | `models/__init__.py` | SQLAlchemy tables |
 | Alembic | `alembic/` + `alembic.ini` | Revision `0001` = current ORM ([ADR-03](../adr/003-alembic.md)) |
 | LLM | `llm/embedder.py`, `llm/chat.py` | Embeddings + chat providers |
 | Ingest | `ingest/extractors.py`, `chunking.py`, `pipeline.py`, `watcher.py` | File/URL extract, chunk, persist, inbox watch ([#16](https://github.com/Anna-Hax/JUNO/issues/16)) |
+| HITL | `hitl/queue.py` | Review queue; merges stay pending until Approve |
 | Jobs | `jobs/` | Placeholder (M4) |
 
 ### Entry points
 
 - `uv run juno serve` → `runtime.main_sync()`
 - `uv run juno db-init` → `Database.migrate()` (Alembic `upgrade head`, or stamp legacy `create_all` DBs)
-- Tests: `apps/core/tests/test_foundation.py`, `test_migrations.py`, `test_ingest.py`, `test_vectors.py`
+- Tests: `apps/core/tests/test_foundation.py`, `test_migrations.py`, `test_ingest.py`, `test_vectors.py`, `test_review.py`, `test_bot_review.py`
 
 ### Dependencies
 
@@ -80,3 +81,4 @@ Optional: `--extra embeddings` for sentence-transformers; `--extra dev` for pyte
 5. API token required even on localhost.
 6. Stub embedder so CI never downloads torch.
 7. Chroma collections are per embedding model; Juno supplies embeddings (no Chroma default ONNX). Blocking Chroma I/O uses `asyncio.to_thread`.
+8. Proposed merges stay `pending` until a Telegram Approve tap ([#20](https://github.com/Anna-Hax/JUNO/issues/20)).

--- a/docs/sessions/08-session-hitl-review.md
+++ b/docs/sessions/08-session-hitl-review.md
@@ -1,0 +1,78 @@
+# Session log: HITL review queue (#20)
+
+**Date:** 2026-08-26  
+**Repo:** [https://github.com/Anna-Hax/JUNO](https://github.com/Anna-Hax/JUNO)  
+**Plan:** Personal Knowledge Graph (local-first Python + Telegram)  
+**Scope of this session:** M1 issue **#20** — `review_items` queue + Telegram `/review` inline Approve / Reject / Skip.
+
+---
+
+## Summary
+
+Proposed graph merges now land as a `pending` edge plus a `review_items` row. They do not become `committed` until an allowlisted user taps **Approve**. `/review` shows the oldest open item with inline buttons; Reject leaves the edge unapplied; Skip keeps it in the queue.
+
+Work is on branch `feat/hitl-review` (from `main` after ingest #16). PR / `Closes #20` not opened yet.
+
+---
+
+## What changed
+
+### Code
+
+| Path | Role |
+|------|------|
+| `apps/core/src/juno/hitl/queue.py` | `ReviewQueue.propose_merge` / `decide` — merge needs a tap |
+| `apps/core/src/juno/bot/review.py` | `/review` + callback handler (`rev:{id}:approve\|reject\|skip`) |
+| `apps/core/src/juno/bot/handlers.py` | Help text; re-exports review handlers |
+| `apps/core/src/juno/runtime.py` | Registers `/review` + callback; attaches queue on `bot_data` |
+| `apps/core/tests/test_review.py` | Merge stays pending until approve |
+| `apps/core/tests/test_bot_review.py` | Keyboard, allowlist, callback commits |
+
+Rules encoded in code:
+
+- Writes go through `Database.write()` (ADR-02)
+- `Edge.status` stays `pending` until Approve; Reject sets `rejected`; Skip does not commit
+- Empty Telegram allowlist still rejects everyone
+- Queue also reads `bot_data["juno"].db` so it can attach next to the #18–#19 `BotServices` object without owning that issue
+
+### Docs
+
+- This session file
+- Codebase map + [`docs/next-work.md`](../next-work.md)
+
+---
+
+## Not in this session
+
+- PR / merge to `main` (`Closes #20`)
+- Auto-enqueue from ingest or RAG (nothing on `main` proposes merges yet; call `ReviewQueue.propose_merge`)
+- `/digest` `/pause` `/status` (#19) — in progress on another worktree; `/review` is still marked "(coming)" there
+- RAG answers (#17)
+- Live Telegram smoke (#4)
+
+---
+
+## How to verify
+
+From `apps/core`:
+
+```powershell
+$env:EMBEDDING_BACKEND="stub"
+uv run pytest
+uv run ruff check src tests
+```
+
+Expect **44** tests passing.
+
+Manual (after `juno serve` with a bot token): send `/review`. With an empty queue the bot replies `Review queue empty.` Enqueue a merge in a Python shell against the same SQLite file via `ReviewQueue.propose_merge`, then `/review` again and tap Approve — the `edges` row should move to `committed`.
+
+---
+
+## Related docs
+
+| File | Contents |
+|------|----------|
+| [08-session-hitl-review.md](08-session-hitl-review.md) | This file |
+| [next-work.md](../next-work.md) | Global next-work tracker (kept as-is across merges) |
+| [02-codebase-map.md](02-codebase-map.md) | HITL + bot review modules |
+| [../../personal-knowledge-graph-prd.md](../../personal-knowledge-graph-prd.md) | §8 HITL layer |

--- a/docs/sessions/README.md
+++ b/docs/sessions/README.md
@@ -12,5 +12,6 @@ Living notes for what was implemented, how GitHub is set up, and what to do next
 | [04-session-chroma-client.md](04-session-chroma-client.md) | **M1 #13** — persistent Chroma client |
 | [05-session-alembic.md](05-session-alembic.md) | **M1 #11** — first Alembic revision |
 | [06-session-ingest.md](06-session-ingest.md) | **M1 #16** — ingest pipeline, extractors, inbox watcher |
+| [08-session-hitl-review.md](08-session-hitl-review.md) | **M1 #20** — HITL review queue + `/review` buttons |
 
 Architecture decisions live in [`../adr/`](../adr/). Product requirements: [`../../personal-knowledge-graph-prd.md`](../../personal-knowledge-graph-prd.md).


### PR DESCRIPTION
## Summary
- Proposed graph merges land as a pending `same_as` edge plus a `review_items` row; they stay uncommitted until an allowlisted user taps Approve.
- `/review` shows the oldest open item with inline Approve / Reject / Skip buttons (`rev:{id}:approve|reject|skip`).
- Wired onto the merged Telegram bot (`BotServices` / `user_allowed`) next to `/digest` `/pause` `/status`.

## Linked issue
Closes #20

## Test plan
- [x] `uv run pytest` (apps/core) — 88 passed
- [x] `uv run ruff check src tests`
- [ ] Manual: `juno serve` with token + allowlist — `/review` on an empty queue, then `ReviewQueue.propose_merge` and Approve commits the edge