### PR TITLE
feat(api): fail closed on bad tokens and non-loopback binds

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,9 +6,10 @@ ALLOWED_TELEGRAM_USER_IDS=
 JUNO_DATA_DIR=./data
 JUNO_INBOX_DIR=./inbox
 
-# Local API (loopback only)
+# Local API (loopback only — 127.0.0.1 / ::1 / localhost)
 JUNO_API_HOST=127.0.0.1
 JUNO_API_PORT=8787
+# Required. Do not leave as change-me — juno serve will refuse to start.
 JUNO_API_TOKEN=change-me
 
 # LLM

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Personal knowledge-graph agent: passively (and manually) capture what you read, code, and discuss — query it from **Telegram**. Local-first on your PC.
 
-**Status:** M0 / early M1 scaffold. Not a daily driver yet.
+**Status:** M1 — local API + Telegram query/capture/HITL. Not a daily driver yet.
 
 ## Architecture (v1)
 
@@ -33,7 +33,7 @@ uv run juno db-init
 uv run juno serve
 ```
 
-- API: `http://127.0.0.1:8787/health`
+- API: `http://127.0.0.1:8787/health` (no token). `/status` `/ingest` `/search` need `Authorization: Bearer <JUNO_API_TOKEN>`. Serve refuses the example `change-me` token and any non-loopback `JUNO_API_HOST`.
 - Token-gated `GET /status` reports the live embedder (model / backend / dimensions) and LLM health (`llm_healthy`, `llm_provider`, `llm_model`). If Ollama is down, `llm_healthy` is false and answers stay retrieve-only.
 - Token-gated `GET /search?q=` returns citations + confidence (sourced answer when the LLM is healthy).
 - Bot runs only while this process (and PC) is on. Telegram queues updates ~24h; longer downtime can drop messages. Commands: `/start` `/help` `/digest today|week` `/pause` `/resume` `/status` `/review`. Forward a message, send a link, or attach a doc to capture; other text queries the graph.

--- a/apps/core/src/juno/api/__init__.py
+++ b/apps/core/src/juno/api/__init__.py
@@ -3,13 +3,31 @@
 from __future__ import annotations
 
 import asyncio
+import hmac
 from typing import Any
 
 from fastapi import Depends, FastAPI, Header, HTTPException, Query, Request
 from fastapi.responses import JSONResponse
 
-from juno.config import Settings
+from juno.config import Settings, api_token_is_configured, is_loopback_client_host
 from juno.rag.engine import search as rag_search
+
+_AUTH_DETAIL = "Invalid or missing API token"
+
+
+def _bearer_token(authorization: str | None) -> str:
+    if not authorization:
+        return ""
+    scheme, _, remainder = authorization.partition(" ")
+    if scheme.lower() != "bearer":
+        return ""
+    return remainder.strip()
+
+
+def token_matches(provided: str, expected: str) -> bool:
+    if not provided or not api_token_is_configured(expected):
+        return False
+    return hmac.compare_digest(provided, expected.strip())
 
 
 def create_app(
@@ -21,7 +39,13 @@ def create_app(
     pipeline: Any = None,
     chat: Any = None,
 ) -> FastAPI:
-    app = FastAPI(title="Juno", version="0.1.0")
+    app = FastAPI(
+        title="Juno",
+        version="0.1.0",
+        docs_url=None,
+        redoc_url=None,
+        openapi_url=None,
+    )
     app.state.settings = settings
     app.state.db = db
     app.state.embedder = embedder
@@ -40,16 +64,13 @@ def create_app(
 
     def require_token(authorization: str | None = Header(default=None)) -> None:
         expected = settings.juno_api_token
-        if not expected or expected == "change-me":
-            # Still require a matching token so misconfig is obvious
-            pass
-        if authorization != f"Bearer {expected}":
-            raise HTTPException(status_code=401, detail="Invalid or missing API token")
+        if not token_matches(_bearer_token(authorization), expected):
+            raise HTTPException(status_code=401, detail=_AUTH_DETAIL)
 
     @app.middleware("http")
     async def loopback_only(request: Request, call_next):  # noqa: ANN001
         client = request.client.host if request.client else ""
-        if client not in {"127.0.0.1", "::1", "localhost", "testclient"}:
+        if not is_loopback_client_host(client):
             return JSONResponse(status_code=403, content={"detail": "Loopback only"})
         return await call_next(request)
 
@@ -101,7 +122,7 @@ def create_app(
             raise HTTPException(status_code=423, detail="Capture paused")
         pipeline = app.state.pipeline
         if pipeline is None:
-            return {"accepted": True, "source_type": payload.get("source_type", "api")}
+            raise HTTPException(status_code=503, detail="Ingest pipeline not ready")
         result = await pipeline.ingest_payload(payload)
         return result.to_dict()
 

--- a/apps/core/src/juno/config.py
+++ b/apps/core/src/juno/config.py
@@ -6,6 +6,28 @@ from pathlib import Path
 
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
+INSECURE_API_TOKENS = frozenset({"", "change-me"})
+LOOPBACK_BIND_HOSTS = frozenset({"127.0.0.1", "::1", "localhost"})
+LOOPBACK_CLIENT_HOSTS = LOOPBACK_BIND_HOSTS | {"testclient"}
+
+
+def api_token_is_configured(token: str | None) -> bool:
+    """True when JUNO_API_TOKEN is set to something other than the example default."""
+    return (token or "").strip().lower() not in INSECURE_API_TOKENS
+
+
+def is_loopback_bind_host(host: str | None) -> bool:
+    return (host or "").strip().lower() in LOOPBACK_BIND_HOSTS
+
+
+def is_loopback_client_host(host: str | None) -> bool:
+    h = (host or "").strip().lower()
+    if h in LOOPBACK_CLIENT_HOSTS:
+        return True
+    if h.startswith("::ffff:"):
+        return h[7:] == "127.0.0.1"
+    return False
+
 
 class Settings(BaseSettings):
     model_config = SettingsConfigDict(
@@ -58,3 +80,16 @@ class Settings(BaseSettings):
 
 def get_settings() -> Settings:
     return Settings()
+
+
+def validate_serve_settings(settings: Settings) -> None:
+    """Refuse to listen if the API would be misconfigured for a local-first agent."""
+    if not api_token_is_configured(settings.juno_api_token):
+        raise ValueError(
+            "JUNO_API_TOKEN is unset or still 'change-me'. Set a secret in .env before serving."
+        )
+    if not is_loopback_bind_host(settings.juno_api_host):
+        raise ValueError(
+            "JUNO_API_HOST must be loopback (127.0.0.1 / ::1 / localhost), "
+            f"got {settings.juno_api_host!r}"
+        )

--- a/apps/core/src/juno/runtime.py
+++ b/apps/core/src/juno/runtime.py
@@ -29,7 +29,7 @@ from juno.bot.handlers import (
 )
 from juno.bot.review import review_callback, review_cmd
 from juno.bot.services import BOT_DATA_KEY, BotServices, load_capture_paused
-from juno.config import Settings, get_settings
+from juno.config import Settings, get_settings, validate_serve_settings
 from juno.graph.db import Database
 from juno.graph.vectors import VectorStore
 from juno.hitl.queue import ReviewQueue
@@ -180,6 +180,7 @@ def attach_lifespan(fastapi_app: FastAPI) -> FastAPI:
 
 async def run_server(settings: Settings | None = None) -> None:
     settings = settings or get_settings()
+    validate_serve_settings(settings)
     settings.juno_data_dir.mkdir(parents=True, exist_ok=True)
     settings.juno_inbox_dir.mkdir(parents=True, exist_ok=True)
 

--- a/apps/core/tests/test_api.py
+++ b/apps/core/tests/test_api.py
@@ -1,0 +1,133 @@
+from __future__ import annotations
+
+import pytest
+from fastapi.testclient import TestClient
+from httpx import ASGITransport, AsyncClient
+
+from juno.api import create_app, token_matches
+from juno.config import (
+    Settings,
+    api_token_is_configured,
+    is_loopback_bind_host,
+    is_loopback_client_host,
+    validate_serve_settings,
+)
+
+AUTH = {"Authorization": "Bearer test-token"}
+
+
+def _client(settings) -> TestClient:
+    return TestClient(create_app(settings))
+
+
+def test_token_helpers_reject_defaults():
+    assert api_token_is_configured("test-token")
+    assert not api_token_is_configured("")
+    assert not api_token_is_configured("change-me")
+    assert not api_token_is_configured("CHANGE-ME")
+    assert not token_matches("change-me", "change-me")
+    assert token_matches("test-token", "test-token")
+    assert not token_matches("nope", "test-token")
+    assert not token_matches("test-token", "test-token-extra")
+
+
+def test_loopback_host_helpers():
+    assert is_loopback_bind_host("127.0.0.1")
+    assert is_loopback_bind_host("::1")
+    assert is_loopback_bind_host("localhost")
+    assert not is_loopback_bind_host("0.0.0.0")
+    assert not is_loopback_bind_host("192.168.1.10")
+    assert is_loopback_client_host("testclient")
+    assert is_loopback_client_host("::ffff:127.0.0.1")
+    assert not is_loopback_client_host("8.8.8.8")
+
+
+def test_serve_settings_refuse_default_token_and_non_loopback(settings):
+    validate_serve_settings(settings)
+    with pytest.raises(ValueError, match="JUNO_API_TOKEN"):
+        validate_serve_settings(
+            Settings(juno_data_dir=settings.juno_data_dir, juno_api_token="change-me")
+        )
+    with pytest.raises(ValueError, match="JUNO_API_HOST"):
+        validate_serve_settings(
+            Settings(
+                juno_data_dir=settings.juno_data_dir,
+                juno_api_token="test-token",
+                juno_api_host="0.0.0.0",
+            )
+        )
+
+
+def test_health_is_public(settings):
+    client = _client(settings)
+    assert client.get("/health").json() == {"status": "ok"}
+    assert client.get("/health", headers={"Authorization": "Bearer nope"}).json() == {
+        "status": "ok"
+    }
+
+
+def test_openapi_docs_are_disabled(settings):
+    client = _client(settings)
+    assert client.get("/docs").status_code == 404
+    assert client.get("/redoc").status_code == 404
+    assert client.get("/openapi.json").status_code == 404
+
+
+@pytest.mark.parametrize(
+    "path,method",
+    [("/status", "GET"), ("/search", "GET"), ("/ingest", "POST")],
+)
+def test_protected_routes_reject_bad_token(settings, path, method):
+    client = _client(settings)
+    kw: dict = {}
+    if path == "/search":
+        kw["params"] = {"q": "rust"}
+    if path == "/ingest":
+        kw["json"] = {"source_type": "api", "text": "hi"}
+
+    missing = client.request(method, path, **kw)
+    wrong = client.request(method, path, headers={"Authorization": "Bearer wrong"}, **kw)
+    not_bearer = client.request(method, path, headers={"Authorization": "test-token"}, **kw)
+    assert missing.status_code == 401
+    assert wrong.status_code == 401
+    assert not_bearer.status_code == 401
+    assert missing.json()["detail"] == "Invalid or missing API token"
+
+
+def test_default_example_token_never_authorizes(settings):
+    app = create_app(
+        Settings(
+            juno_data_dir=settings.juno_data_dir,
+            juno_inbox_dir=settings.juno_inbox_dir,
+            juno_api_token="change-me",
+            embedding_backend="stub",
+        )
+    )
+    client = TestClient(app)
+    resp = client.get("/status", headers={"Authorization": "Bearer change-me"})
+    assert resp.status_code == 401
+
+
+def test_status_ok_with_good_token(settings):
+    resp = _client(settings).get("/status", headers=AUTH)
+    assert resp.status_code == 200
+    assert "capture_paused" in resp.json()
+
+
+def test_ingest_without_pipeline_is_503_not_stub_success(settings):
+    client = _client(settings)
+    resp = client.post("/ingest", json={"source_type": "api", "text": "hi"}, headers=AUTH)
+    assert resp.status_code == 503
+    assert "pipeline" in resp.json()["detail"].lower()
+
+
+@pytest.mark.asyncio
+async def test_non_loopback_client_is_forbidden(settings):
+    app = create_app(settings)
+    transport = ASGITransport(app=app, client=("8.8.8.8", 12345))
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        health = await client.get("/health")
+        status = await client.get("/status", headers=AUTH)
+    assert health.status_code == 403
+    assert status.status_code == 403
+    assert health.json()["detail"] == "Loopback only"

--- a/apps/core/tests/test_foundation.py
+++ b/apps/core/tests/test_foundation.py
@@ -71,13 +71,14 @@ def test_ingest_requires_token(settings):
     app = create_app(settings)
     client = TestClient(app)
     assert client.post("/ingest", json={"source_type": "browser"}).status_code == 401
+    # Pipeline is not attached in this smoke test — auth still fails closed (401),
+    # and a valid token does not get a fake accepted stub (503 instead).
     ok = client.post(
         "/ingest",
         json={"source_type": "browser"},
         headers={"Authorization": "Bearer test-token"},
     )
-    assert ok.status_code == 200
-    assert ok.json()["accepted"] is True
+    assert ok.status_code == 503
 
 
 def test_status_requires_token(settings):

--- a/docs/next-work.md
+++ b/docs/next-work.md
@@ -32,13 +32,14 @@ Prefer one open issue ≈ one PR (`Closes #N`).
 | 4 | #14 / #15 | Confirm MiniLM path + LLM health in `/status` — **merged** ([PR #32](https://github.com/Anna-Hax/JUNO/pull/32), `Closes #14` `#15`) |
 | 5 | #17 | Retrieve-only → sourced RAG + confidence — **merged** ([PR #33](https://github.com/Anna-Hax/JUNO/pull/33), `Closes #17`) |
 | 6 | #18–#19 | Bot query + forward-to-capture + digest/pause/status — **merged** ([PR #34](https://github.com/Anna-Hax/JUNO/pull/34), `Closes #18` `#19`) |
-| 7 | #20 | HITL `/review` inline buttons — **done on `feat/hitl-review`** (PR / `Closes #20` not opened yet) |
-| 8 | #21 | Harden API (already stubbed; `/ingest` persists; `/search` retrieves) |
-| 9 | #22–#24 | Integration tests, export/wipe, v1.0 gate |
+| 7 | #20 | HITL `/review` inline buttons — **merged** ([PR #35](https://github.com/Anna-Hax/JUNO/pull/35), `Closes #20`) |
+| 8 | #21 | Harden API — **done on `feat/api-harden-21`** (PR / `Closes #21` not opened yet) |
+| 9 | #12 | Concurrent ingest through the write queue (WAL already on; lock landed) |
+| 10 | #22–#24 | Integration tests, export/wipe, v1.0 gate |
 
-**Next coding issue:** #21 after #20 is merged.
+**Next coding issue:** #12 after #21 is merged.
 
-Already partially landed (keep issues open until acceptance fully met): #12 write queue, #21 basic routes. Telegram query/capture/pause: [PR #34](https://github.com/Anna-Hax/JUNO/pull/34). MiniLM + LLM health: [PR #32](https://github.com/Anna-Hax/JUNO/pull/32). `/search`: [PR #33](https://github.com/Anna-Hax/JUNO/pull/33). HITL `/review`: this branch.
+Already partially landed (keep issues open until acceptance fully met): #12 write queue. Telegram query/capture/pause: [PR #34](https://github.com/Anna-Hax/JUNO/pull/34). MiniLM + LLM health: [PR #32](https://github.com/Anna-Hax/JUNO/pull/32). `/search`: [PR #33](https://github.com/Anna-Hax/JUNO/pull/33). HITL `/review`: [PR #35](https://github.com/Anna-Hax/JUNO/pull/35). API harden: this branch.
 
 ---
 

--- a/docs/sessions/02-codebase-map.md
+++ b/docs/sessions/02-codebase-map.md
@@ -46,7 +46,7 @@ JUNO/
 
 - `uv run juno serve` → `runtime.main_sync()`
 - `uv run juno db-init` → `Database.migrate()` (Alembic `upgrade head`, or stamp legacy `create_all` DBs)
-- Tests: `test_foundation.py`, `test_migrations.py`, `test_ingest.py`, `test_vectors.py`, `test_embedder.py`, `test_chat.py`, `test_rag.py`, `test_bot.py`, `test_review.py`, `test_bot_review.py`
+- Tests: `test_foundation.py`, `test_migrations.py`, `test_ingest.py`, `test_vectors.py`, `test_embedder.py`, `test_chat.py`, `test_rag.py`, `test_bot.py`, `test_review.py`, `test_bot_review.py`, `test_api.py`
 
 ### Dependencies
 
@@ -79,7 +79,7 @@ Optional: `--extra embeddings` for sentence-transformers; `--extra dev` for pyte
 2. Serialized SQLite writes (ADR-02).
 3. Migrations via Alembic (ADR-03); `db-init` / serve run `upgrade head` (stamp pre-Alembic files).
 4. Empty Telegram allowlist ⇒ reject all users (secure default).
-5. API token required even on localhost.
+5. API token required even on localhost. Empty / `change-me` never authorize; `juno serve` refuses a non-loopback bind. `/docs` is disabled ([#21](https://github.com/Anna-Hax/JUNO/issues/21)).
 6. Stub embedder so CI never downloads torch; MiniLM is `--extra embeddings`. `/status` reports the live backend (and `embedding_fallback` if serve dropped to stub).
 7. Chroma collections are per embedding model; Juno supplies embeddings (no Chroma default ONNX). Blocking Chroma I/O uses `asyncio.to_thread`.
 8. Chat adapters switch on `LLM_PROVIDER` (`ollama` / `openai_compat` / `offline`). `/status` live-probes `llm_healthy` + provider/model. Unhealthy LLM ⇒ retrieve-only (#17).

--- a/docs/sessions/10-session-hitl-review.md
+++ b/docs/sessions/10-session-hitl-review.md
@@ -13,7 +13,7 @@ Proposed graph merges now land as a `pending` edge plus a `review_items` row. Th
 
 This branch was rebased onto `main` after PRs **#32–#34** (#14/#15, #17, #18/#19). `/review` is registered next to the merged bot commands and uses `BotServices` / `user_allowed`.
 
-Work is on branch `feat/hitl-review`. PR / `Closes #20` not opened yet.
+Work landed on `main` via [PR #35](https://github.com/Anna-Hax/JUNO/pull/35) (`Closes #20`).
 
 ---
 
@@ -46,7 +46,6 @@ Rules encoded in code:
 
 ## Not in this session
 
-- PR / merge to `main` (`Closes #20`)
 - Auto-enqueue from ingest or RAG (call `ReviewQueue.propose_merge`)
 - Live Telegram smoke (#4)
 

--- a/docs/sessions/11-session-api-harden.md
+++ b/docs/sessions/11-session-api-harden.md
@@ -1,0 +1,87 @@
+# Session log: harden local API (#21)
+
+**Date:** 2026-08-26  
+**Repo:** [https://github.com/Anna-Hax/JUNO](https://github.com/Anna-Hax/JUNO)  
+**Plan:** Personal Knowledge Graph (local-first Python + Telegram)  
+**Scope of this session:** M1 issue **#21** — loopback FastAPI `/health` `/status` `/ingest` `/search` + token auth (bad token 401).
+
+---
+
+## Summary
+
+Routes were already stubbed (ingest persists; search retrieves). This pass fails closed: a missing, wrong, or example `change-me` token is **401**; `juno serve` refuses to bind a non-loopback host or start with the example token; `/docs` is off; `/ingest` no longer returns a fake `{accepted: true}` when the pipeline is missing (503 instead).
+
+Work is on branch `feat/api-harden-21`. PR / `Closes #21` not opened yet.
+
+---
+
+## What changed
+
+### Code
+
+| Path | Role |
+|------|------|
+| `apps/core/src/juno/config.py` | Token / loopback helpers; `validate_serve_settings` |
+| `apps/core/src/juno/api/__init__.py` | Timing-safe Bearer check; loopback middleware; no OpenAPI; ingest 503 |
+| `apps/core/src/juno/runtime.py` | Serve calls `validate_serve_settings` before listen |
+| `apps/core/tests/test_api.py` | 401 / 403 / default-token / 503 coverage |
+| `apps/core/tests/test_foundation.py` | Ingest smoke expects 503 without a pipeline |
+
+Rules encoded in code:
+
+- `/health` stays unauthenticated (liveness); `/status` `/ingest` `/search` require `Authorization: Bearer …`
+- Empty token and `change-me` never authorize, even if the header matches
+- Client hosts other than loopback (`127.0.0.1` / `::1` / `localhost` / IPv4-mapped) get **403**
+- `JUNO_API_HOST=0.0.0.0` (or any non-loopback) is rejected at serve start
+- OpenAPI `/docs` `/redoc` `/openapi.json` are disabled
+
+### Docs
+
+- This session file
+- Codebase map + [`docs/next-work.md`](../next-work.md) + README / `.env.example`
+
+---
+
+## Not in this session
+
+- PR / merge to `main` (`Closes #21`)
+- Concurrent ingest lock test (#12)
+- Integration tests (#22) and export/wipe (#23)
+
+---
+
+## How to verify
+
+From `apps/core`:
+
+```powershell
+$env:EMBEDDING_BACKEND="stub"
+uv run pytest
+uv run ruff check src tests
+```
+
+Expect **100** tests passing.
+
+Manual (after setting a real `JUNO_API_TOKEN` in `.env`):
+
+```powershell
+# missing token
+curl http://127.0.0.1:8787/status
+# expect 401
+
+curl -H "Authorization: Bearer <token>" http://127.0.0.1:8787/status
+# expect 200
+```
+
+`juno serve` with `JUNO_API_TOKEN=change-me` or `JUNO_API_HOST=0.0.0.0` should refuse to start.
+
+---
+
+## Related docs
+
+| File | Contents |
+|------|----------|
+| [11-session-api-harden.md](11-session-api-harden.md) | This file |
+| [10-session-hitl-review.md](10-session-hitl-review.md) | Merged #20 HITL |
+| [next-work.md](../next-work.md) | Global next-work tracker |
+| [02-codebase-map.md](02-codebase-map.md) | API constraints |

--- a/docs/sessions/README.md
+++ b/docs/sessions/README.md
@@ -16,5 +16,6 @@ Living notes for what was implemented, how GitHub is set up, and what to do next
 | [08-session-rag.md](08-session-rag.md) | **M1 #17** — retrieve-only + sourced RAG with citations |
 | [09-session-telegram-bot.md](09-session-telegram-bot.md) | **M1 #18 / #19** — Telegram query, capture, pause/digest/status |
 | [10-session-hitl-review.md](10-session-hitl-review.md) | **M1 #20** — HITL review queue + `/review` buttons |
+| [11-session-api-harden.md](11-session-api-harden.md) | **M1 #21** — loopback API + token auth |
 
 Architecture decisions live in [`../adr/`](../adr/). Product requirements: [`../../personal-knowledge-graph-prd.md](../../personal-knowledge-graph-prd.md).


### PR DESCRIPTION
## Summary
- Protected `/status` `/ingest` `/search` reject missing, wrong, and example `change-me` tokens with 401 (timing-safe Bearer compare).
- `juno serve` refuses a non-loopback bind and the example token; OpenAPI docs are off; `/ingest` returns 503 instead of a fake accepted stub when the pipeline is missing.
- Loopback middleware still returns 403 for non-local clients, including IPv4-mapped addresses.

## Linked issue
Closes #21

## Test plan
- [x] `uv run pytest` (apps/core) — 100 passed
- [x] `uv run ruff check src tests`
- [ ] Manual: `juno serve` with a real `JUNO_API_TOKEN` — `GET /status` 401 without header, 200 with Bearer; `change-me` / `0.0.0.0` refuse to start