### PR TITLE
test(core): prove concurrent ingest does not lock SQLite

### DIFF
--- a/apps/core/src/juno/graph/db.py
+++ b/apps/core/src/juno/graph/db.py
@@ -49,7 +49,7 @@ class Database:
         return action
 
     async def write(self, fn: Callable[[AsyncSession], Awaitable[T]]) -> T:
-        """Serialize all write transactions through one lock."""
+        """Serialize all write transactions (the ADR-02 write queue)."""
         async with self._write_lock:
             async with self.session_factory() as session:
                 async with session.begin():
@@ -58,6 +58,13 @@ class Database:
     async def read(self, fn: Callable[[AsyncSession], Awaitable[T]]) -> T:
         async with self.session_factory() as session:
             return await fn(session)
+
+    async def journal_mode(self) -> str:
+        async def query(session: AsyncSession) -> str:
+            result = await session.execute(text("PRAGMA journal_mode"))
+            return str(result.scalar_one())
+
+        return await self.read(query)
 
     async def dispose(self) -> None:
         await self.engine.dispose()

--- a/apps/core/tests/test_write_queue.py
+++ b/apps/core/tests/test_write_queue.py
@@ -1,0 +1,87 @@
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+from sqlalchemy import func, select, text
+from sqlalchemy.exc import OperationalError
+
+from juno.graph.db import Database
+from juno.ingest.pipeline import IngestPipeline
+from juno.models import Capture, Chunk
+
+
+@pytest.fixture
+async def db(settings):
+    database = Database(settings)
+    await database.migrate()
+    yield database
+    await database.dispose()
+
+
+@pytest.mark.asyncio
+async def test_sqlite_uses_wal(db):
+    assert (await db.journal_mode()).lower() == "wal"
+
+    async def busy(session):
+        return int((await session.execute(text("PRAGMA busy_timeout"))).scalar_one())
+
+    assert await db.read(busy) >= 5000
+
+
+@pytest.mark.asyncio
+async def test_concurrent_ingest_does_not_lock(db):
+    pipeline = IngestPipeline(db)
+    n = 24
+    try:
+        results = await asyncio.gather(
+            *[
+                pipeline.ingest_text(
+                    f"concurrent note {i} rust ownership borrowing",
+                    source_type="upload",
+                    title=f"note-{i}",
+                )
+                for i in range(n)
+            ]
+        )
+    except OperationalError as exc:
+        pytest.fail(f"SQLite locked under concurrent ingest: {exc}")
+
+    assert all(item.status == "committed" for item in results)
+    ids = [item.capture_id for item in results]
+    assert None not in ids
+    assert len(set(ids)) == n
+
+    async def counts(session):
+        captures = int(
+            (await session.execute(select(func.count()).select_from(Capture))).scalar_one()
+        )
+        chunks = int((await session.execute(select(func.count()).select_from(Chunk))).scalar_one())
+        return captures, chunks
+
+    captures, chunks = await db.read(counts)
+    assert captures == n
+    assert chunks == n
+
+
+@pytest.mark.asyncio
+async def test_reads_proceed_during_serialized_writes(db):
+    started = asyncio.Event()
+    release = asyncio.Event()
+
+    async def slow_write(session):
+        session.add(Capture(source_type="upload", text="held", status="committed"))
+        started.set()
+        await release.wait()
+
+    async def count(session):
+        return int((await session.execute(select(func.count()).select_from(Capture))).scalar_one())
+
+    writer = asyncio.create_task(db.write(slow_write))
+    await started.wait()
+    seen = await db.read(count)
+    release.set()
+    await writer
+    after = await db.read(count)
+    assert seen == 0
+    assert after == 1

--- a/docs/adr/002-sqlite-write-queue.md
+++ b/docs/adr/002-sqlite-write-queue.md
@@ -17,3 +17,7 @@ Multiple producers write the graph: Telegram handlers, inbox watcher, FastAPI
 ## Consequences
 Write throughput is limited to one transaction at a time (fine for personal use).
 Callers must use `db.write` / `db.read` instead of opening ad-hoc sessions for writes.
+
+`PRAGMA journal_mode` is WAL after migrate; `Database.journal_mode()` exposes that for tests.
+Concurrent ingest (`asyncio.gather` of many `IngestPipeline.ingest_text` calls) must not raise
+`database is locked` — covered by `tests/test_write_queue.py` ([#12](https://github.com/Anna-Hax/JUNO/issues/12)).

--- a/docs/next-work.md
+++ b/docs/next-work.md
@@ -33,13 +33,13 @@ Prefer one open issue ≈ one PR (`Closes #N`).
 | 5 | #17 | Retrieve-only → sourced RAG + confidence — **merged** ([PR #33](https://github.com/Anna-Hax/JUNO/pull/33), `Closes #17`) |
 | 6 | #18–#19 | Bot query + forward-to-capture + digest/pause/status — **merged** ([PR #34](https://github.com/Anna-Hax/JUNO/pull/34), `Closes #18` `#19`) |
 | 7 | #20 | HITL `/review` inline buttons — **merged** ([PR #35](https://github.com/Anna-Hax/JUNO/pull/35), `Closes #20`) |
-| 8 | #21 | Harden API — **done on `feat/api-harden-21`** (PR / `Closes #21` not opened yet) |
-| 9 | #12 | Concurrent ingest through the write queue (WAL already on; lock landed) |
+| 8 | #21 | Harden API — **merged** ([PR #36](https://github.com/Anna-Hax/JUNO/pull/36), `Closes #21`) |
+| 9 | #12 | Concurrent ingest through the write queue — **done on `feat/write-queue-12`** (PR / `Closes #12` not opened yet) |
 | 10 | #22–#24 | Integration tests, export/wipe, v1.0 gate |
 
-**Next coding issue:** #12 after #21 is merged.
+**Next coding issue:** #22 after #12 is merged.
 
-Already partially landed (keep issues open until acceptance fully met): #12 write queue. Telegram query/capture/pause: [PR #34](https://github.com/Anna-Hax/JUNO/pull/34). MiniLM + LLM health: [PR #32](https://github.com/Anna-Hax/JUNO/pull/32). `/search`: [PR #33](https://github.com/Anna-Hax/JUNO/pull/33). HITL `/review`: [PR #35](https://github.com/Anna-Hax/JUNO/pull/35). API harden: this branch.
+Telegram query/capture/pause: [PR #34](https://github.com/Anna-Hax/JUNO/pull/34). MiniLM + LLM health: [PR #32](https://github.com/Anna-Hax/JUNO/pull/32). `/search`: [PR #33](https://github.com/Anna-Hax/JUNO/pull/33). HITL `/review`: [PR #35](https://github.com/Anna-Hax/JUNO/pull/35). API harden: [PR #36](https://github.com/Anna-Hax/JUNO/pull/36). Write queue: this branch.
 
 ---
 

--- a/docs/sessions/02-codebase-map.md
+++ b/docs/sessions/02-codebase-map.md
@@ -46,7 +46,7 @@ JUNO/
 
 - `uv run juno serve` → `runtime.main_sync()`
 - `uv run juno db-init` → `Database.migrate()` (Alembic `upgrade head`, or stamp legacy `create_all` DBs)
-- Tests: `test_foundation.py`, `test_migrations.py`, `test_ingest.py`, `test_vectors.py`, `test_embedder.py`, `test_chat.py`, `test_rag.py`, `test_bot.py`, `test_review.py`, `test_bot_review.py`, `test_api.py`
+- Tests: `test_foundation.py`, `test_migrations.py`, `test_ingest.py`, `test_vectors.py`, `test_embedder.py`, `test_chat.py`, `test_rag.py`, `test_bot.py`, `test_review.py`, `test_bot_review.py`, `test_api.py`, `test_write_queue.py`
 
 ### Dependencies
 

--- a/docs/sessions/11-session-api-harden.md
+++ b/docs/sessions/11-session-api-harden.md
@@ -11,7 +11,7 @@
 
 Routes were already stubbed (ingest persists; search retrieves). This pass fails closed: a missing, wrong, or example `change-me` token is **401**; `juno serve` refuses to bind a non-loopback host or start with the example token; `/docs` is off; `/ingest` no longer returns a fake `{accepted: true}` when the pipeline is missing (503 instead).
 
-Work is on branch `feat/api-harden-21`. PR / `Closes #21` not opened yet.
+Work landed on `main` via [PR #36](https://github.com/Anna-Hax/JUNO/pull/36) (`Closes #21`).
 
 ---
 
@@ -44,7 +44,6 @@ Rules encoded in code:
 
 ## Not in this session
 
-- PR / merge to `main` (`Closes #21`)
 - Concurrent ingest lock test (#12)
 - Integration tests (#22) and export/wipe (#23)
 

--- a/docs/sessions/12-session-write-queue.md
+++ b/docs/sessions/12-session-write-queue.md
@@ -1,0 +1,66 @@
+# Session log: WAL + write-queue acceptance (#12)
+
+**Date:** 2026-08-26  
+**Repo:** [https://github.com/Anna-Hax/JUNO](https://github.com/Anna-Hax/JUNO)  
+**Plan:** Personal Knowledge Graph (local-first Python + Telegram)  
+**Scope of this session:** M1 issue **#12** — WAL + async write-queue; acceptance: concurrent ingest does not lock.
+
+---
+
+## Summary
+
+`Database.write()` already serialized commits with an `asyncio.Lock` (ADR-02) and connections already set `PRAGMA journal_mode=WAL` + `busy_timeout=5000`. This pass proves the acceptance: 24 overlapping `ingest_text` calls complete without `database is locked`, WAL is queryable, and reads proceed while a write is held.
+
+Work is on branch `feat/write-queue-12`. PR / `Closes #12` not opened yet.
+
+---
+
+## What changed
+
+### Code
+
+| Path | Role |
+|------|------|
+| `apps/core/src/juno/graph/db.py` | `Database.journal_mode()` for WAL checks |
+| `apps/core/tests/test_write_queue.py` | WAL pragma, concurrent ingest, read-during-write |
+
+Ingest, HITL, bot pause, and runtime health already go through `db.write()` — no stray write sessions.
+
+### Docs
+
+- This session file
+- ADR-02 consequences
+- Codebase map + [`docs/next-work.md`](../next-work.md)
+
+---
+
+## Not in this session
+
+- PR / merge to `main` (`Closes #12`)
+- Integration tests ingest → retrieve → review (#22)
+- Export / wipe (#23)
+
+---
+
+## How to verify
+
+From `apps/core`:
+
+```powershell
+$env:EMBEDDING_BACKEND="stub"
+uv run pytest
+uv run ruff check src tests
+```
+
+Expect **103** tests passing.
+
+---
+
+## Related docs
+
+| File | Contents |
+|------|----------|
+| [12-session-write-queue.md](12-session-write-queue.md) | This file |
+| [11-session-api-harden.md](11-session-api-harden.md) | Merged #21 API |
+| [../adr/002-sqlite-write-queue.md](../adr/002-sqlite-write-queue.md) | ADR-02 |
+| [next-work.md](../next-work.md) | Global next-work tracker |

--- a/docs/sessions/README.md
+++ b/docs/sessions/README.md
@@ -17,5 +17,6 @@ Living notes for what was implemented, how GitHub is set up, and what to do next
 | [09-session-telegram-bot.md](09-session-telegram-bot.md) | **M1 #18 / #19** — Telegram query, capture, pause/digest/status |
 | [10-session-hitl-review.md](10-session-hitl-review.md) | **M1 #20** — HITL review queue + `/review` buttons |
 | [11-session-api-harden.md](11-session-api-harden.md) | **M1 #21** — loopback API + token auth |
+| [12-session-write-queue.md](12-session-write-queue.md) | **M1 #12** — WAL + concurrent ingest write queue |
 
 Architecture decisions live in [`../adr/`](../adr/). Product requirements: [`../../personal-knowledge-graph-prd.md](../../personal-knowledge-graph-prd.md).


### PR DESCRIPTION
## Summary
- Add `Database.journal_mode()` and `tests/test_write_queue.py` to prove WAL + serialized writes under concurrent ingest.
- 24 overlapping `IngestPipeline.ingest_text` calls complete without `database is locked`; reads proceed while a write is held.

## Linked issue
Closes #12

## Test plan
- [x] `uv run pytest` (apps/core) — 103 passed
- [x] `uv run ruff check src tests`