### PR TITLE
test(core): add ingest retrieve review integration paths

### DIFF
--- a/apps/core/tests/test_integration.py
+++ b/apps/core/tests/test_integration.py
@@ -1,0 +1,178 @@
+"""End-to-end happy paths: ingest → retrieve/RAG → HITL review (mocked LLM)."""
+
+from __future__ import annotations
+
+import httpx
+import pytest
+
+from juno.api import create_app
+from juno.graph.db import Database
+from juno.graph.vectors import VectorStore
+from juno.hitl.queue import EDGE_COMMITTED, EDGE_PENDING, ReviewQueue
+from juno.ingest.pipeline import IngestPipeline
+from juno.llm.embedder import StubEmbedder
+from juno.models import Edge
+
+RUST_NOTE = (
+    "Juno integration marker alpha-42. "
+    "Ownership in Rust means each value has a single owner at a time."
+)
+GARDEN_NOTE = "Garden soil pH and tomatoes — unrelated to compilers."
+
+
+class FakeChat:
+    def __init__(self, *, healthy: bool = True, answer: str = "") -> None:
+        self._healthy = healthy
+        self._answer = answer
+        self.complete_calls = 0
+
+    async def healthy(self, *, timeout: float = 3.0) -> bool:
+        return self._healthy
+
+    async def complete(self, system: str, messages: list[dict[str, str]], **kwargs):  # noqa: ANN001
+        self.complete_calls += 1
+        assert "Sources:" in messages[0]["content"]
+        return self._answer
+
+
+@pytest.fixture
+async def db(settings):
+    database = Database(settings)
+    await database.migrate()
+    yield database
+    await database.dispose()
+
+
+@pytest.fixture
+def vectors(settings):
+    return VectorStore(settings, StubEmbedder())
+
+
+@pytest.fixture
+def pipeline(db, vectors):
+    return IngestPipeline(db, vectors=vectors)
+
+
+@pytest.fixture
+def review(db):
+    return ReviewQueue(db)
+
+
+async def _api_client(settings, *, db, vectors, pipeline, chat=None):
+    app = create_app(
+        settings,
+        db=db,
+        embedder=StubEmbedder(),
+        vectors=vectors,
+        pipeline=pipeline,
+        chat=chat,
+    )
+    transport = httpx.ASGITransport(app=app)
+    return httpx.AsyncClient(transport=transport, base_url="http://test"), app
+
+
+@pytest.mark.asyncio
+async def test_happy_path_ingest_retrieve_review(settings, db, vectors, pipeline, review):
+    """CI happy path: capture → vector search → pending merge → approve."""
+    ingest = await pipeline.ingest_text(RUST_NOTE, source_type="upload", title="Rust notes")
+    assert ingest.status == "committed"
+    assert ingest.capture_id is not None
+    assert vectors.count() == 1
+
+    client, _ = await _api_client(settings, db=db, vectors=vectors, pipeline=pipeline)
+    async with client:
+        search = await client.get(
+            "/search",
+            params={"q": RUST_NOTE, "mode": "retrieve"},
+            headers={"Authorization": "Bearer test-token"},
+        )
+    assert search.status_code == 200
+    body = search.json()
+    assert body["mode"] == "retrieve"
+    assert body["results"]
+    assert body["results"][0]["capture_id"] == ingest.capture_id
+    assert "alpha-42" in body["results"][0]["text"]
+    assert body["citations"]
+
+    card = await review.propose_merge(
+        from_name="Rust ownership",
+        to_name="Rust",
+        confidence=0.55,
+        reason="integration test cluster",
+    )
+    assert card.status == "pending"
+    edge_id = int(card.payload["edge_id"])
+    assert await _edge_status(db, edge_id) == EDGE_PENDING
+
+    result = await review.decide(card.id, "approve")
+    assert result.applied is True
+    assert result.card.decision == "approve"
+    assert await _edge_status(db, edge_id) == EDGE_COMMITTED
+
+
+@pytest.mark.asyncio
+async def test_happy_path_ingest_rag_then_review_with_mock_llm(
+    settings, db, vectors, pipeline, review
+):
+    await pipeline.ingest_text(RUST_NOTE, source_type="upload", title="Rust notes")
+    await pipeline.ingest_text(GARDEN_NOTE, source_type="upload", title="Garden")
+
+    chat = FakeChat(answer="Each value has a single owner [1].")
+    client, _ = await _api_client(
+        settings,
+        db=db,
+        vectors=vectors,
+        pipeline=pipeline,
+        chat=chat,
+    )
+    async with client:
+        search = await client.get(
+            "/search",
+            params={"q": RUST_NOTE, "mode": "auto"},
+            headers={"Authorization": "Bearer test-token"},
+        )
+    assert search.status_code == 200
+    body = search.json()
+    assert body["mode"] == "rag"
+    assert body["answer"] == "Each value has a single owner [1]."
+    assert body["citations"]
+    assert chat.complete_calls == 1
+
+    card = await review.propose_merge(from_name="Rust", to_name="Ownership", confidence=0.7)
+    skip = await review.decide(card.id, "skip")
+    assert skip.applied is False
+    assert skip.card.status == "skipped"
+    assert await _edge_status(db, int(card.payload["edge_id"])) == EDGE_PENDING
+
+    approve = await review.decide(card.id, "approve")
+    assert approve.applied is True
+    assert await _edge_status(db, int(card.payload["edge_id"])) == EDGE_COMMITTED
+
+
+@pytest.mark.asyncio
+async def test_ingest_via_api_then_search(settings, db, vectors, pipeline):
+    client, _ = await _api_client(settings, db=db, vectors=vectors, pipeline=pipeline)
+    async with client:
+        ingest = await client.post(
+            "/ingest",
+            json={"source_type": "upload", "text": RUST_NOTE, "title": "via api"},
+            headers={"Authorization": "Bearer test-token"},
+        )
+        search = await client.get(
+            "/search",
+            params={"q": RUST_NOTE, "mode": "retrieve"},
+            headers={"Authorization": "Bearer test-token"},
+        )
+    assert ingest.status_code == 200
+    assert ingest.json()["status"] == "committed"
+    assert search.status_code == 200
+    assert search.json()["results"]
+    assert search.json()["results"][0]["title"] == "via api"
+
+
+async def _edge_status(db: Database, edge_id: int) -> str | None:
+    async def load(session):
+        edge = await session.get(Edge, edge_id)
+        return None if edge is None else edge.status
+
+    return await db.read(load)

--- a/docs/next-work.md
+++ b/docs/next-work.md
@@ -34,12 +34,11 @@ Prefer one open issue ≈ one PR (`Closes #N`).
 | 6 | #18–#19 | Bot query + forward-to-capture + digest/pause/status — **merged** ([PR #34](https://github.com/Anna-Hax/JUNO/pull/34), `Closes #18` `#19`) |
 | 7 | #20 | HITL `/review` inline buttons — **merged** ([PR #35](https://github.com/Anna-Hax/JUNO/pull/35), `Closes #20`) |
 | 8 | #21 | Harden API — **merged** ([PR #36](https://github.com/Anna-Hax/JUNO/pull/36), `Closes #21`) |
-| 9 | #12 | Concurrent ingest through the write queue — **done on `feat/write-queue-12`** (PR / `Closes #12` not opened yet) |
-| 10 | #22–#24 | Integration tests, export/wipe, v1.0 gate |
+| 9 | #12 | Concurrent ingest through the write queue — **merged** ([PR #37](https://github.com/Anna-Hax/JUNO/pull/37), `Closes #12`) |
+| 10 | #22 | Integration tests ingest → retrieve → review — **done on `feat/integration-tests-22`** (PR / `Closes #22` not opened yet) |
+| 11 | #23–#24 | Export/wipe, v1.0 gate |
 
-**Next coding issue:** #22 after #12 is merged.
-
-Telegram query/capture/pause: [PR #34](https://github.com/Anna-Hax/JUNO/pull/34). MiniLM + LLM health: [PR #32](https://github.com/Anna-Hax/JUNO/pull/32). `/search`: [PR #33](https://github.com/Anna-Hax/JUNO/pull/33). HITL `/review`: [PR #35](https://github.com/Anna-Hax/JUNO/pull/35). API harden: [PR #36](https://github.com/Anna-Hax/JUNO/pull/36). Write queue: this branch.
+**Next coding issue:** #23 after #22 is merged.
 
 ---
 

--- a/docs/sessions/02-codebase-map.md
+++ b/docs/sessions/02-codebase-map.md
@@ -46,7 +46,7 @@ JUNO/
 
 - `uv run juno serve` → `runtime.main_sync()`
 - `uv run juno db-init` → `Database.migrate()` (Alembic `upgrade head`, or stamp legacy `create_all` DBs)
-- Tests: `test_foundation.py`, `test_migrations.py`, `test_ingest.py`, `test_vectors.py`, `test_embedder.py`, `test_chat.py`, `test_rag.py`, `test_bot.py`, `test_review.py`, `test_bot_review.py`, `test_api.py`, `test_write_queue.py`
+- Tests: `test_foundation.py`, `test_migrations.py`, `test_ingest.py`, `test_vectors.py`, `test_embedder.py`, `test_chat.py`, `test_rag.py`, `test_bot.py`, `test_review.py`, `test_bot_review.py`, `test_api.py`, `test_write_queue.py`, `test_integration.py`
 
 ### Dependencies
 

--- a/docs/sessions/12-session-write-queue.md
+++ b/docs/sessions/12-session-write-queue.md
@@ -11,7 +11,7 @@
 
 `Database.write()` already serialized commits with an `asyncio.Lock` (ADR-02) and connections already set `PRAGMA journal_mode=WAL` + `busy_timeout=5000`. This pass proves the acceptance: 24 overlapping `ingest_text` calls complete without `database is locked`, WAL is queryable, and reads proceed while a write is held.
 
-Work is on branch `feat/write-queue-12`. PR / `Closes #12` not opened yet.
+Work landed on `main` via [PR #37](https://github.com/Anna-Hax/JUNO/pull/37) (`Closes #12`).
 
 ---
 
@@ -36,8 +36,7 @@ Ingest, HITL, bot pause, and runtime health already go through `db.write()` — 
 
 ## Not in this session
 
-- PR / merge to `main` (`Closes #12`)
-- Integration tests ingest → retrieve → review (#22)
+- Integration tests (#22)
 - Export / wipe (#23)
 
 ---

--- a/docs/sessions/13-session-integration-tests.md
+++ b/docs/sessions/13-session-integration-tests.md
@@ -1,0 +1,53 @@
+# Session log: integration tests (#22)
+
+**Date:** 2026-08-26  
+**Repo:** [https://github.com/Anna-Hax/JUNO](https://github.com/Anna-Hax/JUNO)  
+**Plan:** Personal Knowledge Graph (local-first Python + Telegram)  
+**Scope of this session:** M1 issue **#22** — integration tests ingest → retrieve → review (mocked LLM).
+
+---
+
+## Summary
+
+Added `tests/test_integration.py` with three CI happy paths: pipeline ingest → `GET /search` retrieve → `ReviewQueue` approve; ingest + mocked RAG → skip then approve; `POST /ingest` → search. LLM is mocked via `FakeChat` (same pattern as `test_rag.py`).
+
+Work is on branch `feat/integration-tests-22`. PR / `Closes #22` not opened yet.
+
+---
+
+## What changed
+
+### Code
+
+| Path | Role |
+|------|------|
+| `apps/core/tests/test_integration.py` | End-to-end ingest, API search, HITL approve |
+
+### Docs
+
+- This session file
+- Codebase map + [`docs/next-work.md`](../next-work.md)
+
+---
+
+## How to verify
+
+From `apps/core`:
+
+```powershell
+$env:EMBEDDING_BACKEND="stub"
+uv run pytest
+uv run ruff check src tests
+```
+
+Expect **106** tests passing.
+
+---
+
+## Related docs
+
+| File | Contents |
+|------|----------|
+| [13-session-integration-tests.md](13-session-integration-tests.md) | This file |
+| [12-session-write-queue.md](12-session-write-queue.md) | Merged #12 |
+| [next-work.md](../next-work.md) | Global next-work tracker |

--- a/docs/sessions/README.md
+++ b/docs/sessions/README.md
@@ -18,5 +18,6 @@ Living notes for what was implemented, how GitHub is set up, and what to do next
 | [10-session-hitl-review.md](10-session-hitl-review.md) | **M1 #20** — HITL review queue + `/review` buttons |
 | [11-session-api-harden.md](11-session-api-harden.md) | **M1 #21** — loopback API + token auth |
 | [12-session-write-queue.md](12-session-write-queue.md) | **M1 #12** — WAL + concurrent ingest write queue |
+| [13-session-integration-tests.md](13-session-integration-tests.md) | **M1 #22** — ingest → retrieve → review integration tests |
 
 Architecture decisions live in [`../adr/`](../adr/). Product requirements: [`../../personal-knowledge-graph-prd.md](../../personal-knowledge-graph-prd.md).


### PR DESCRIPTION
## Summary
- Add `tests/test_integration.py` covering ingest → `GET /search` (retrieve + mocked RAG) → `ReviewQueue` approve/skip.
- Includes `POST /ingest` → search API path for the CI happy path.

## Linked issue
Closes #22

## Test plan
- [x] `uv run pytest` (apps/core) — 106 passed
- [x] `uv run ruff check src tests`