### PR TITLE
feat(cli): add juno export and juno wipe commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,14 @@ uv run juno db-init
 uv run juno serve
 ```
 
+Data ownership:
+
+```powershell
+uv run juno export -o ../../data/backup.json
+# Stop juno serve first on Windows, then:
+uv run juno wipe --confirm wipe-all-data
+```
+
 - API: `http://127.0.0.1:8787/health` (no token). `/status` `/ingest` `/search` need `Authorization: Bearer <JUNO_API_TOKEN>`. Serve refuses the example `change-me` token and any non-loopback `JUNO_API_HOST`.
 - Token-gated `GET /status` reports the live embedder (model / backend / dimensions) and LLM health (`llm_healthy`, `llm_provider`, `llm_model`). If Ollama is down, `llm_healthy` is false and answers stay retrieve-only.
 - Token-gated `GET /search?q=` returns citations + confidence (sourced answer when the LLM is healthy).

--- a/apps/core/src/juno/cli.py
+++ b/apps/core/src/juno/cli.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import argparse
 import asyncio
 import sys
+from pathlib import Path
 
 
 def main(argv: list[str] | None = None) -> None:
@@ -13,6 +14,23 @@ def main(argv: list[str] | None = None) -> None:
 
     sub.add_parser("serve", help="Start API + Telegram bot (shared event loop)")
     sub.add_parser("db-init", help="Create or upgrade SQLite schema (Alembic)")
+
+    export_p = sub.add_parser("export", help="Export graph + vectors to JSON")
+    export_p.add_argument(
+        "-o",
+        "--output",
+        type=Path,
+        default=None,
+        help="Output path (default: data/juno-export-<timestamp>.json)",
+    )
+
+    wipe_p = sub.add_parser("wipe", help="Delete local graph + vectors")
+    wipe_p.add_argument(
+        "--confirm",
+        required=True,
+        help='Must be exactly "wipe-all-data"',
+    )
+
     sub.add_parser("version", help="Print version")
 
     args = parser.parse_args(argv)
@@ -42,6 +60,14 @@ def main(argv: list[str] | None = None) -> None:
         asyncio.run(_db_init())
         return
 
+    if args.command == "export":
+        asyncio.run(_export(args.output))
+        return
+
+    if args.command == "wipe":
+        asyncio.run(_wipe(args.confirm))
+        return
+
     parser.print_help()
     sys.exit(1)
 
@@ -55,6 +81,56 @@ async def _db_init() -> None:
     action = await db.migrate()
     await db.dispose()
     print(f"Initialized database at {settings.sqlite_path} (alembic {action})")
+
+
+async def _export(output: Path | None) -> None:
+    from juno.config import get_settings
+    from juno.graph.db import Database
+    from juno.graph.ownership import (
+        build_export_payload,
+        default_export_path,
+        write_export_file,
+    )
+    from juno.graph.vectors import VectorStore
+    from juno.llm.embedder import create_embedder
+
+    settings = get_settings()
+    db = Database(settings)
+    await db.migrate()
+    try:
+        try:
+            embedder = create_embedder(settings.embedding_backend, settings.embedding_model)
+        except Exception:
+            embedder = create_embedder("stub", settings.embedding_model)
+        vectors = VectorStore(settings, embedder)
+        payload = await build_export_payload(
+            settings,
+            db=db,
+            vectors=vectors,
+            embedder=embedder,
+        )
+        dest = write_export_file(payload, output or default_export_path(settings))
+        n_cap = len(payload["graph"]["captures"])
+        n_vec = int((payload.get("vectors") or {}).get("count") or 0)
+        print(f"Exported {n_cap} captures and {n_vec} vectors to {dest}")
+    finally:
+        vectors.close()
+        await db.dispose()
+
+
+async def _wipe(confirm: str) -> None:
+    from juno.config import get_settings
+    from juno.graph.ownership import wipe_local_data
+
+    settings = get_settings()
+    try:
+        removed = await wipe_local_data(settings, confirm=confirm)
+    except ValueError as exc:
+        print(str(exc), file=sys.stderr)
+        sys.exit(1)
+    print(f"Wiped {len(removed)} path(s); empty schema at {settings.sqlite_path}")
+    for path in removed:
+        print(f"  removed {path}")
 
 
 if __name__ == "__main__":

--- a/apps/core/src/juno/graph/ownership.py
+++ b/apps/core/src/juno/graph/ownership.py
@@ -1,0 +1,153 @@
+"""Full local export and wipe (data ownership — PRD §9)."""
+
+from __future__ import annotations
+
+import asyncio
+import gc
+import json
+import shutil
+import time
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from juno.config import Settings
+from juno.graph.db import Database
+from juno.graph.vectors import VectorStore
+from juno.llm.embedder import Embedder
+from juno.models import (
+    AppSetting,
+    Capture,
+    Chunk,
+    Edge,
+    ModuleHealth,
+    Node,
+    ReviewItem,
+)
+
+EXPORT_FORMAT = "juno-export"
+EXPORT_VERSION = 1
+WIPE_CONFIRM_PHRASE = "wipe-all-data"
+
+TABLE_MODELS: tuple[tuple[str, type[Any]], ...] = (
+    ("captures", Capture),
+    ("nodes", Node),
+    ("edges", Edge),
+    ("chunks", Chunk),
+    ("review_items", ReviewItem),
+    ("module_health", ModuleHealth),
+    ("settings", AppSetting),
+)
+
+
+def _serialize(value: Any) -> Any:
+    if isinstance(value, datetime):
+        return value.isoformat()
+    return value
+
+
+def _row_dict(row: Any) -> dict[str, Any]:
+    return {col.name: _serialize(getattr(row, col.name)) for col in row.__table__.columns}
+
+
+async def export_graph(db: Database) -> dict[str, list[dict[str, Any]]]:
+    async def load(session: AsyncSession) -> dict[str, list[dict[str, Any]]]:
+        out: dict[str, list[dict[str, Any]]] = {}
+        for name, model in TABLE_MODELS:
+            result = await session.execute(select(model))
+            out[name] = [_row_dict(row) for row in result.scalars().all()]
+        return out
+
+    return await db.read(load)
+
+
+async def build_export_payload(
+    settings: Settings,
+    *,
+    db: Database,
+    vectors: VectorStore | None = None,
+    embedder: Embedder | None = None,
+) -> dict[str, Any]:
+    graph = await export_graph(db)
+    vector_block: dict[str, Any] | None = None
+    if vectors is not None:
+        vector_block = await asyncio.to_thread(vectors.export_snapshot)
+
+    live = embedder
+    return {
+        "format": EXPORT_FORMAT,
+        "version": EXPORT_VERSION,
+        "exported_at": datetime.now(UTC).isoformat(),
+        "paths": {
+            "sqlite": str(settings.sqlite_path),
+            "chroma": str(settings.chroma_path),
+        },
+        "embedding": {
+            "model": live.model_id if live is not None else settings.embedding_model,
+            "backend": live.backend if live is not None else settings.embedding_backend,
+            "dimensions": live.dimensions if live is not None else None,
+        },
+        "graph": graph,
+        "vectors": vector_block,
+    }
+
+
+def default_export_path(settings: Settings) -> Path:
+    stamp = datetime.now(UTC).strftime("%Y%m%dT%H%M%SZ")
+    return settings.juno_data_dir / f"juno-export-{stamp}.json"
+
+
+def write_export_file(payload: dict[str, Any], path: Path) -> Path:
+    path = path.resolve()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, indent=2, ensure_ascii=False), encoding="utf-8")
+    return path
+
+
+def _rmtree_with_retry(path: Path, *, attempts: int = 6) -> None:
+    last: OSError | None = None
+    for attempt in range(attempts):
+        try:
+            if path.exists():
+                shutil.rmtree(path)
+            return
+        except OSError as exc:
+            last = exc
+            gc.collect()
+            time.sleep(0.05 * (attempt + 1))
+    if last is not None:
+        raise last
+
+
+async def wipe_local_data(settings: Settings, *, confirm: str) -> list[str]:
+    if confirm != WIPE_CONFIRM_PHRASE:
+        raise ValueError(
+            f'Refuse wipe without --confirm "{WIPE_CONFIRM_PHRASE}" '
+            "(this deletes the SQLite graph and all Chroma collections)."
+        )
+
+    removed: list[str] = []
+    db = Database(settings)
+    await db.dispose()
+
+    sqlite = settings.sqlite_path
+    if sqlite.exists():
+        sqlite.unlink()
+        removed.append(str(sqlite.resolve()))
+
+    chroma = settings.chroma_path
+    if chroma.exists():
+        gc.collect()
+        _rmtree_with_retry(chroma)
+        removed.append(str(chroma.resolve()))
+
+    settings.juno_data_dir.mkdir(parents=True, exist_ok=True)
+    settings.chroma_path.mkdir(parents=True, exist_ok=True)
+
+    fresh = Database(settings)
+    await fresh.migrate()
+    await fresh.dispose()
+    return removed

--- a/apps/core/src/juno/graph/vectors.py
+++ b/apps/core/src/juno/graph/vectors.py
@@ -149,6 +149,36 @@ class VectorStore:
     def count(self) -> int:
         return self._collection.count()
 
+    def export_snapshot(self) -> dict[str, Any]:
+        """Full collection dump for ``juno export`` (ADR-04 / #23)."""
+        total = self.count()
+        base = {
+            "collection_name": self.collection_name,
+            "embedding_model": self._embedder.model_id,
+            "embedding_dimensions": self._embedder.dimensions,
+            "count": total,
+        }
+        if total == 0:
+            return {**base, "ids": [], "documents": [], "metadatas": [], "embeddings": []}
+        raw = self._collection.get(include=["documents", "metadatas", "embeddings"])
+        embeddings_raw = raw.get("embeddings")
+        if embeddings_raw is None:
+            embeddings: list[list[float]] = []
+        else:
+            embeddings = [[float(x) for x in row] for row in embeddings_raw]
+        return {
+            **base,
+            "ids": list(raw.get("ids") or []),
+            "documents": list(raw.get("documents") or []),
+            "metadatas": list(raw.get("metadatas") or []),
+            "embeddings": embeddings,
+        }
+
+    def close(self) -> None:
+        """Drop client handles so ``data/chroma`` can be deleted (``juno wipe``)."""
+        self._collection = None  # type: ignore[assignment]
+        self._client = None  # type: ignore[assignment]
+
     async def upsert_async(
         self,
         *,

--- a/apps/core/tests/test_export.py
+++ b/apps/core/tests/test_export.py
@@ -1,0 +1,118 @@
+from __future__ import annotations
+
+import json
+
+import pytest
+from sqlalchemy import func, select
+
+from juno.graph.db import Database
+from juno.graph.ownership import (
+    EXPORT_FORMAT,
+    WIPE_CONFIRM_PHRASE,
+    build_export_payload,
+    wipe_local_data,
+    write_export_file,
+)
+from juno.graph.vectors import VectorStore
+from juno.hitl.queue import ReviewQueue
+from juno.ingest.pipeline import IngestPipeline
+from juno.llm.embedder import StubEmbedder
+from juno.models import Capture
+
+
+@pytest.fixture
+async def db(settings):
+    database = Database(settings)
+    await database.migrate()
+    yield database
+    await database.dispose()
+
+
+@pytest.fixture
+def vectors(settings):
+    return VectorStore(settings, StubEmbedder())
+
+
+@pytest.fixture
+def pipeline(db, vectors):
+    return IngestPipeline(db, vectors=vectors)
+
+
+@pytest.mark.asyncio
+async def test_export_includes_graph_and_vectors(settings, db, vectors, pipeline):
+    await pipeline.ingest_text("export marker beta-99", source_type="upload", title="note")
+    review = ReviewQueue(db)
+    await review.propose_merge(from_name="Alpha", to_name="Beta", confidence=0.4)
+
+    payload = await build_export_payload(
+        settings,
+        db=db,
+        vectors=vectors,
+        embedder=StubEmbedder(),
+    )
+    assert payload["format"] == EXPORT_FORMAT
+    assert payload["version"] == 1
+    assert len(payload["graph"]["captures"]) == 1
+    assert len(payload["graph"]["chunks"]) == 1
+    assert len(payload["graph"]["review_items"]) == 1
+    assert payload["vectors"] is not None
+    assert payload["vectors"]["count"] == 1
+    assert "beta-99" in payload["vectors"]["documents"][0]
+    assert payload["vectors"]["embeddings"]
+
+
+@pytest.mark.asyncio
+async def test_write_export_file_roundtrip(tmp_path, settings, db):
+    payload = await build_export_payload(
+        settings,
+        db=db,
+        vectors=None,
+        embedder=StubEmbedder(),
+    )
+    path = write_export_file(payload, tmp_path / "bundle.json")
+    loaded = json.loads(path.read_text(encoding="utf-8"))
+    assert loaded["format"] == EXPORT_FORMAT
+    assert "graph" in loaded
+
+
+@pytest.mark.asyncio
+async def test_wipe_requires_exact_confirm(settings, db, pipeline):
+    await pipeline.ingest_text("keep until wipe")
+    with pytest.raises(ValueError, match=WIPE_CONFIRM_PHRASE):
+        await wipe_local_data(settings, confirm="delete-everything")
+    await db.dispose()
+
+
+@pytest.mark.asyncio
+async def test_wipe_clears_sqlite_graph_and_recreates_schema(settings, db):
+    pipeline = IngestPipeline(db)
+    await pipeline.ingest_text("will be wiped", title="temp")
+    await db.dispose()
+
+    removed = await wipe_local_data(settings, confirm=WIPE_CONFIRM_PHRASE)
+    assert any(settings.sqlite_path.name in path for path in removed)
+    assert settings.sqlite_path.is_file()
+
+    fresh = Database(settings)
+
+    async def capture_count(session):
+        return int((await session.execute(select(func.count()).select_from(Capture))).scalar_one())
+
+    assert await fresh.read(capture_count) == 0
+    await fresh.dispose()
+
+
+@pytest.mark.asyncio
+async def test_wipe_removes_chroma_directory_when_not_open(settings, db):
+    """Avoid opening PersistentClient in-process before wipe (Windows file locks)."""
+    chroma = settings.chroma_path
+    chroma.mkdir(parents=True, exist_ok=True)
+    marker = chroma / "stale-export.txt"
+    marker.write_text("leftover", encoding="utf-8")
+    await db.dispose()
+
+    removed = await wipe_local_data(settings, confirm=WIPE_CONFIRM_PHRASE)
+    assert chroma.is_dir()
+    assert not marker.exists()
+    assert any("chroma" in path for path in removed)
+    assert VectorStore(settings, StubEmbedder()).count() == 0

--- a/docs/adr/004-chroma-collections.md
+++ b/docs/adr/004-chroma-collections.md
@@ -67,5 +67,5 @@ The wrapper is `VectorStore`. Runtime attaches it to `app.state.vectors`. `/stat
 
 - Ingest pipeline (#16) assigns `chunks.chroma_id` as `c{capture_id}-n{ordinal}` and upserts through the attached `VectorStore`.
 - RAG retrieve (#17) queries `VectorStore` then joins hits to SQLite captures (`juno.rag.engine`).
-- Export/wipe (#23) should delete or recreate `data/chroma/` as well as the graph DB.
+- Export/wipe ([#23](https://github.com/Anna-Hax/JUNO/issues/23)): `juno export` writes graph tables + active Chroma collection to JSON; `juno wipe --confirm wipe-all-data` deletes `data/juno.db` and `data/chroma/` then re-runs migrations. Stop `juno serve` before wipe on Windows (Chroma file locks).
 - Optional: record active collection name in SQLite `settings` so `/status` and HITL can explain a model mismatch.

--- a/docs/next-work.md
+++ b/docs/next-work.md
@@ -35,10 +35,11 @@ Prefer one open issue ≈ one PR (`Closes #N`).
 | 7 | #20 | HITL `/review` inline buttons — **merged** ([PR #35](https://github.com/Anna-Hax/JUNO/pull/35), `Closes #20`) |
 | 8 | #21 | Harden API — **merged** ([PR #36](https://github.com/Anna-Hax/JUNO/pull/36), `Closes #21`) |
 | 9 | #12 | Concurrent ingest through the write queue — **merged** ([PR #37](https://github.com/Anna-Hax/JUNO/pull/37), `Closes #12`) |
-| 10 | #22 | Integration tests ingest → retrieve → review — **done on `feat/integration-tests-22`** (PR / `Closes #22` not opened yet) |
-| 11 | #23–#24 | Export/wipe, v1.0 gate |
+| 10 | #22 | Integration tests ingest → retrieve → review — **merged** ([PR #38](https://github.com/Anna-Hax/JUNO/pull/38), `Closes #22`) |
+| 11 | #23 | Export/wipe CLI — **done on `feat/export-wipe-23`** (PR / `Closes #23` not opened yet) |
+| 12 | #24 | v1.0 release gate checklist |
 
-**Next coding issue:** #23 after #22 is merged.
+**Next coding issue:** #24 after #23 is merged.
 
 ---
 

--- a/docs/sessions/02-codebase-map.md
+++ b/docs/sessions/02-codebase-map.md
@@ -28,11 +28,11 @@ JUNO/
 | Module | File(s) | Role |
 |--------|---------|------|
 | Config | `config.py` | pydantic-settings from `.env` |
-| CLI | `cli.py` | `juno serve` / `db-init` / `version` |
+| CLI | `cli.py` | `juno serve` / `db-init` / `export` / `wipe` / `version` |
 | Runtime | `runtime.py` | Shared asyncio: uvicorn + PTB + inbox watcher lifespan |
 | API | `api/__init__.py` | FastAPI routes + token + loopback middleware |
 | Bot | `bot/handlers.py`, `bot/services.py`, `bot/review.py` | Telegram allowlist, query, capture, pause/digest/status ([#18](https://github.com/Anna-Hax/JUNO/issues/18) / [#19](https://github.com/Anna-Hax/JUNO/issues/19)); HITL `/review` ([#20](https://github.com/Anna-Hax/JUNO/issues/20)) |
-| Graph DB | `graph/db.py`, `graph/migrations.py` | Engine, WAL, write queue, Alembic upgrade/stamp |
+| Graph DB | `graph/db.py`, `graph/migrations.py`, `graph/ownership.py` | Engine, WAL, write queue, Alembic upgrade/stamp; export/wipe ([#23](https://github.com/Anna-Hax/JUNO/issues/23)) |
 | Vectors | `graph/vectors.py` | Persistent Chroma; one collection per embedding model ([ADR-04](../adr/004-chroma-collections.md)) |
 | Models | `models/__init__.py` | SQLAlchemy tables |
 | Alembic | `alembic/` + `alembic.ini` | Revision `0001` = current ORM ([ADR-03](../adr/003-alembic.md)) |
@@ -46,7 +46,7 @@ JUNO/
 
 - `uv run juno serve` → `runtime.main_sync()`
 - `uv run juno db-init` → `Database.migrate()` (Alembic `upgrade head`, or stamp legacy `create_all` DBs)
-- Tests: `test_foundation.py`, `test_migrations.py`, `test_ingest.py`, `test_vectors.py`, `test_embedder.py`, `test_chat.py`, `test_rag.py`, `test_bot.py`, `test_review.py`, `test_bot_review.py`, `test_api.py`, `test_write_queue.py`, `test_integration.py`
+- Tests: `test_foundation.py`, `test_migrations.py`, `test_ingest.py`, `test_vectors.py`, `test_embedder.py`, `test_chat.py`, `test_rag.py`, `test_bot.py`, `test_review.py`, `test_bot_review.py`, `test_api.py`, `test_write_queue.py`, `test_integration.py`, `test_export.py`
 
 ### Dependencies
 

--- a/docs/sessions/13-session-integration-tests.md
+++ b/docs/sessions/13-session-integration-tests.md
@@ -11,7 +11,7 @@
 
 Added `tests/test_integration.py` with three CI happy paths: pipeline ingest → `GET /search` retrieve → `ReviewQueue` approve; ingest + mocked RAG → skip then approve; `POST /ingest` → search. LLM is mocked via `FakeChat` (same pattern as `test_rag.py`).
 
-Work is on branch `feat/integration-tests-22`. PR / `Closes #22` not opened yet.
+Work landed on `main` via [PR #38](https://github.com/Anna-Hax/JUNO/pull/38) (`Closes #22`).
 
 ---
 

--- a/docs/sessions/14-session-export-wipe.md
+++ b/docs/sessions/14-session-export-wipe.md
@@ -1,0 +1,72 @@
+# Session log: export + wipe CLI (#23)
+
+**Date:** 2026-08-26  
+**Repo:** [https://github.com/Anna-Hax/JUNO](https://github.com/Anna-Hax/JUNO)  
+**Plan:** Personal Knowledge Graph (local-first Python + Telegram)  
+**Scope of this session:** M1 issue **#23** — `juno export` + `juno wipe` (full export / delete local data).
+
+---
+
+## Summary
+
+`juno export` dumps all graph tables plus the active Chroma collection (ids, documents, metadatas, embeddings) to JSON under `data/`. `juno wipe --confirm wipe-all-data` deletes the SQLite file and Chroma directory, then runs Alembic `upgrade head` on a fresh database.
+
+Work is on branch `feat/export-wipe-23`. PR / `Closes #23` not opened yet.
+
+---
+
+## What changed
+
+### Code
+
+| Path | Role |
+|------|------|
+| `apps/core/src/juno/graph/ownership.py` | `build_export_payload`, `write_export_file`, `wipe_local_data` |
+| `apps/core/src/juno/graph/vectors.py` | `export_snapshot`, `close` |
+| `apps/core/src/juno/cli.py` | `juno export` / `juno wipe` commands |
+| `apps/core/tests/test_export.py` | Export payload, confirm gate, wipe paths |
+
+### Docs
+
+- This session file
+- README + codebase map + ADR-04
+- [`docs/next-work.md`](../next-work.md)
+
+---
+
+## Operational notes
+
+- **Stop `juno serve`** before `juno wipe` on Windows — an open Chroma client can lock files under `data/chroma/`.
+- Export uses the configured embedder (falls back to stub if MiniLM is unavailable).
+
+---
+
+## How to verify
+
+From `apps/core`:
+
+```powershell
+$env:EMBEDDING_BACKEND="stub"
+uv run pytest
+uv run ruff check src tests
+```
+
+Expect **111** tests passing.
+
+Manual:
+
+```powershell
+uv run juno export -o ..\..\data\backup.json
+uv run juno wipe --confirm wipe-all-data
+uv run juno db-init
+```
+
+---
+
+## Related docs
+
+| File | Contents |
+|------|----------|
+| [14-session-export-wipe.md](14-session-export-wipe.md) | This file |
+| [13-session-integration-tests.md](13-session-integration-tests.md) | Merged #22 |
+| [../adr/004-chroma-collections.md](../adr/004-chroma-collections.md) | Collection export |

--- a/docs/sessions/README.md
+++ b/docs/sessions/README.md
@@ -19,5 +19,6 @@ Living notes for what was implemented, how GitHub is set up, and what to do next
 | [11-session-api-harden.md](11-session-api-harden.md) | **M1 #21** — loopback API + token auth |
 | [12-session-write-queue.md](12-session-write-queue.md) | **M1 #12** — WAL + concurrent ingest write queue |
 | [13-session-integration-tests.md](13-session-integration-tests.md) | **M1 #22** — ingest → retrieve → review integration tests |
+| [14-session-export-wipe.md](14-session-export-wipe.md) | **M1 #23** — `juno export` + `juno wipe` |
 
 Architecture decisions live in [`../adr/`](../adr/). Product requirements: [`../../personal-knowledge-graph-prd.md](../../personal-knowledge-graph-prd.md).


### PR DESCRIPTION
## Summary
- `juno export` writes all graph tables plus the active Chroma collection (documents + embeddings) to JSON.
- `juno wipe --confirm wipe-all-data` deletes `data/juno.db` and `data/chroma/`, then re-runs Alembic migrations on a fresh database.

## Linked issue
Closes #23

## Test plan
- [x] `uv run pytest` (apps/core) — 111 passed
- [x] `uv run ruff check src tests`
- [ ] Manual: export after ingest, wipe with serve stopped