### PR TITLE
fix(config): resolve repo-root .env for Spike S1 live smoke

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ uv sync --extra dev
 uv sync --extra dev --extra embeddings
 copy ..\..\.env.example ..\..\.env   # from repo root: copy .env.example .env
 # Edit .env: TELEGRAM_BOT_TOKEN, ALLOWED_TELEGRAM_USER_IDS, JUNO_API_TOKEN
+# `juno serve` finds that repo-root `.env` even when the cwd is apps/core.
 uv run juno db-init
 uv run juno serve
 ```

--- a/apps/core/src/juno/config.py
+++ b/apps/core/src/juno/config.py
@@ -11,6 +11,16 @@ LOOPBACK_BIND_HOSTS = frozenset({"127.0.0.1", "::1", "localhost"})
 LOOPBACK_CLIENT_HOSTS = LOOPBACK_BIND_HOSTS | {"testclient"}
 
 
+def resolve_env_file(*, start: Path | None = None) -> Path | None:
+    """Find `.env`: cwd first, then parents (repo root when run from apps/core)."""
+    here = (start or Path.cwd()).resolve()
+    for base in (here, *here.parents):
+        candidate = base / ".env"
+        if candidate.is_file():
+            return candidate
+    return None
+
+
 def api_token_is_configured(token: str | None) -> bool:
     """True when JUNO_API_TOKEN is set to something other than the example default."""
     return (token or "").strip().lower() not in INSECURE_API_TOKENS
@@ -31,6 +41,7 @@ def is_loopback_client_host(host: str | None) -> bool:
 
 class Settings(BaseSettings):
     model_config = SettingsConfigDict(
+        # Prefer get_settings() which re-resolves; this covers direct Settings().
         env_file=".env",
         env_file_encoding="utf-8",
         extra="ignore",
@@ -79,6 +90,10 @@ class Settings(BaseSettings):
 
 
 def get_settings() -> Settings:
+    """Load settings from the environment and the nearest `.env` (cwd or parents)."""
+    env_file = resolve_env_file()
+    if env_file is not None:
+        return Settings(_env_file=env_file)
     return Settings()
 
 

--- a/apps/core/tests/test_api.py
+++ b/apps/core/tests/test_api.py
@@ -10,6 +10,7 @@ from juno.config import (
     api_token_is_configured,
     is_loopback_bind_host,
     is_loopback_client_host,
+    resolve_env_file,
     validate_serve_settings,
 )
 
@@ -29,6 +30,17 @@ def test_token_helpers_reject_defaults():
     assert token_matches("test-token", "test-token")
     assert not token_matches("nope", "test-token")
     assert not token_matches("test-token", "test-token-extra")
+
+
+def test_resolve_env_file_walks_parents(tmp_path):
+    nested = tmp_path / "apps" / "core"
+    nested.mkdir(parents=True)
+    env = tmp_path / ".env"
+    env.write_text("JUNO_API_TOKEN=parent-token\n", encoding="utf-8")
+    assert resolve_env_file(start=nested) == env.resolve()
+    local = nested / ".env"
+    local.write_text("JUNO_API_TOKEN=local-token\n", encoding="utf-8")
+    assert resolve_env_file(start=nested) == local.resolve()
 
 
 def test_loopback_host_helpers():

--- a/apps/core/uv.lock
+++ b/apps/core/uv.lock
@@ -1070,7 +1070,7 @@ wheels = [
 
 [[package]]
 name = "juno"
-version = "0.1.0"
+version = "1.0.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiosqlite" },

--- a/docs/adr/001-shared-event-loop.md
+++ b/docs/adr/001-shared-event-loop.md
@@ -6,7 +6,8 @@ Accepted (v1)
 
 ## Date
 
-2026-08-20 (M0 scaffold)
+2026-08-20 (M0 scaffold)  
+**Last reviewed:** 2026-08-26 (after M1 / v1.0 foundation)
 
 ## Context
 
@@ -14,11 +15,11 @@ Juno is a **local-first** personal knowledge-graph agent. In v1 it must run on t
 
 1. Serves a **loopback FastAPI** API (`127.0.0.1`) for health, status, ingest, and search.
 2. Runs a **Telegram bot** via long polling so the user can capture and query from their phone.
-3. Later hosts **inbox watching**, **scheduled jobs**, and other background work without a separate daemon.
+3. Hosts **background work** on the same process — inbox watching today, scheduled / proactive jobs later — without a second daemon.
 
-Those pieces all need I/O concurrency. The natural fit in Python is one **asyncio** event loop. The friction is how to combine **uvicorn** (FastAPI) with **python-telegram-bot (python-tg-bot)**.
+Those pieces all need I/O concurrency. The natural fit in Python is one **asyncio** event loop. The friction is how to combine **uvicorn** (FastAPI) with **python-telegram-bot (PTB)**.
 
-python-tg-bot’s convenience entrypoint `Application.run_polling()`:
+PTB’s convenience entrypoint `Application.run_polling()`:
 
 - Blocks the calling thread.
 - Owns (or expects to own) the asyncio lifecycle.
@@ -28,57 +29,59 @@ If we used `run_polling()` in one thread and uvicorn in another, we would get **
 
 ## Options considered
 
-
-| Option                                         | Summary                                                                                         | Why not (for v1)                                                              |
-| ---------------------------------------------- | ----------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------- |
-| **A. Two processes** (uvicorn + `run_polling`) | Separate API and bot                                                                            | Extra process management, shared state harder, worse Windows keep-alive story |
-| **B. Threads with separate loops**             | Bot thread + API thread                                                                         | Dual loops; locking across SQLAlchemy async sessions; harder lifespan         |
-| **C. Shared loop, manual python-tg-bot lifecycle**       | uvicorn `Server.serve()` + python-tg-bot `initialize` / `start` / `start_polling` inside FastAPI lifespan | Chosen                                                                        |
-| **D. Webhooks instead of polling**             | Telegram pushes to a public URL                                                                 | Needs a public endpoint; conflicts with loopback-only privacy defaults        |
-
-
-
+| Option | Summary | Why not (for v1) |
+|--------|---------|------------------|
+| **A. Two processes** (uvicorn + `run_polling`) | Separate API and bot | Extra process management, shared state harder, worse Windows keep-alive story |
+| **B. Threads with separate loops** | Bot thread + API thread | Dual loops; locking across SQLAlchemy async sessions; harder lifespan |
+| **C. Shared loop, manual PTB lifecycle** | uvicorn `Server.serve()` + PTB `initialize` / `start` / `start_polling` inside FastAPI lifespan | **Chosen** |
+| **D. Webhooks instead of polling** | Telegram pushes to a public URL | Needs a public endpoint; conflicts with loopback-only privacy defaults |
 
 ## Decision
 
-Run **one process, one asyncio event loop**, shared by FastAPI and the Telegram bot.
+Run **one process, one asyncio event loop**, shared by FastAPI, the Telegram bot, and all in-process background work.
 
-Concrete rules:
+Concrete rules (implemented in `apps/core/src/juno/runtime.py`):
 
-1. Entry is `asyncio.run(run_server())` (see `juno/runtime.py` / `juno serve`).
-2. Start the HTTP server with `uvicorn.Server.serve()` (awaitable), not a blocking `uvicorn.run()` that fights the outer loop.
-3. Build the python-tg-bot `Application` normally, but **never** call `Application.run_polling()`.
+1. **Entry** is `asyncio.run(run_server())` via `juno serve` (or bare `juno` with no subcommand).
+2. Start the HTTP server with **`uvicorn.Server.serve()`** (awaitable), not a blocking `uvicorn.run()` that fights the outer loop.
+3. Build the PTB `Application` normally, but **never** call `Application.run_polling()`.
 4. Inside FastAPI **lifespan**:
-  - startup: `await python-tg-bot.initialize()` → `await python-tg-bot.start()` → `await python-tg-bot.updater.start_polling(...)`
-  - shutdown (reverse): `updater.stop()` → `python-tg-bot.stop()` → `python-tg-bot.shutdown()`
-5. Future background work (inbox watcher, APScheduler jobs, Chroma maintenance) must be **asyncio tasks or async-compatible schedulers on this same loop**, not a second “main” loop in another thread.
+   - **Startup:** `await ptb.initialize()` → `await ptb.start()` → `await ptb.updater.start_polling(...)`
+   - **Shutdown (reverse):** `updater.stop()` → `ptb.stop()` → `ptb.shutdown()`, then stop the inbox watcher and dispose the DB.
+5. **All background work** on this process must be asyncio tasks, lifespan-managed objects, or async-compatible schedulers on **this same loop** — not a second “main” loop in another thread. That includes:
+   - The inbox watcher (`InboxWatcher`, landed in M1 / #16)
+   - Future APScheduler / proactive jobs (dependency declared; wiring deferred to M4 / epic #27)
+   - Chroma I/O via `VectorStore` async helpers ([ADR-04](004-chroma-collections.md))
+6. If `TELEGRAM_BOT_TOKEN` is empty, the API (and inbox watcher) still run and the bot is simply disabled — same process model either way.
+7. Before listen, `validate_serve_settings()` refuses a non-loopback bind and the example API token ([#21](https://github.com/Anna-Hax/JUNO/issues/21)).
 
-If `TELEGRAM_BOT_TOKEN` is empty, the API still runs and the bot is simply disabled — same process model either way.
+Blocking CPU work (PDF extract, embeddings, Chroma sync APIs) must use `asyncio.to_thread` (or the wrappers that already do) so HTTP and Telegram polling stay responsive.
 
 ## Consequences
-
-
 
 ### Positive
 
 - One mental model: “Juno is up” means one process answers `/health` and (when configured) polls Telegram.
-- Shared in-memory handles (`Database`, embedder, chat provider) without IPC.
+- Shared in-memory handles (`Database`, `VectorStore`, embedder, chat provider, `IngestPipeline`, `ReviewQueue`) without IPC.
 - Clean shutdown path through FastAPI lifespan.
 - Matches Windows Startup-folder shortcut: one `uv run juno serve` command.
-
-
+- Inbox drops and API ingest share the same pause flag and write queue as the bot.
 
 ### Negative / constraints
 
-- Everything long-running must play by asyncio rules; blocking CPU work needs `asyncio.to_thread` (or similar) so polling and HTTP stay responsive.
-- python-tg-bot and uvicorn upgrade notes must be checked together — lifecycle APIs are the integration surface.
-- You cannot casually call `run_polling()` in scripts or tests without recreating the dual-loop problem; tests should exercise the manual lifecycle or mock the bot.
+- Everything long-running must play by asyncio rules; accidental blocking work freezes the bot and the API together.
+- PTB and uvicorn upgrade notes must be checked together — lifecycle APIs are the integration surface.
+- You cannot casually call `run_polling()` in scripts or tests without recreating the dual-loop problem; tests should mock handlers or exercise the manual lifecycle.
+- On Windows, open Chroma clients hold file locks under `data/chroma/` — stop `juno serve` before `juno wipe` ([ADR-04](004-chroma-collections.md) / #23).
 
+### What landed (M1)
 
+- Inbox watcher started/stopped in the same lifespan as the bot ([#16](https://github.com/Anna-Hax/JUNO/issues/16)).
+- Telegram query / capture / pause / digest / status / HITL review all registered on that PTB application ([#18](https://github.com/Anna-Hax/JUNO/issues/18)–[#20](https://github.com/Anna-Hax/JUNO/issues/20)).
+- Chroma access goes through `VectorStore.upsert_async` / `query_async` ([ADR-04](004-chroma-collections.md)).
 
-### Follow-ups
+### Follow-ups (not M1)
 
-- Wire inbox watcher and APScheduler as tasks on this loop (M1).
-- Chroma access goes through `VectorStore` async helpers / `asyncio.to_thread` ([ADR-04](004-chroma-collections.md)).
-- Keep documenting “no `run_polling()`” next to any new entrypoint so the ADR is not rediscovered the hard way.
-
+- Wire **APScheduler** (already in `pyproject.toml`) as an asyncio-friendly scheduler on this loop for digests / resurfacing (M4 / epic [#27](https://github.com/Anna-Hax/JUNO/issues/27)).
+- Keep documenting “no `run_polling()`” next to any new entrypoint so this ADR is not rediscovered the hard way.
+- Live Spike S1 ([#4](https://github.com/Anna-Hax/JUNO/issues/4)): confirm `/health` + Telegram `/start` together on a real machine.

--- a/docs/adr/001-shared-event-loop.md
+++ b/docs/adr/001-shared-event-loop.md
@@ -80,8 +80,18 @@ Blocking CPU work (PDF extract, embeddings, Chroma sync APIs) must use `asyncio.
 - Telegram query / capture / pause / digest / status / HITL review all registered on that PTB application ([#18](https://github.com/Anna-Hax/JUNO/issues/18)–[#20](https://github.com/Anna-Hax/JUNO/issues/20)).
 - Chroma access goes through `VectorStore.upsert_async` / `query_async` ([ADR-04](004-chroma-collections.md)).
 
+### Live Spike S1 (#4, 2026-08-29)
+
+Confirmed on a real Windows machine with repo-root `.env`:
+
+- `juno serve` loads settings via parent `.env` discovery (`resolve_env_file` / `get_settings`) so `cd apps/core` matches the documented quick start.
+- `GET /health` → `{"status":"ok"}` without a token; `GET /status` → 401 without Bearer, 200 with `JUNO_API_TOKEN`.
+- Telegram bot token + allowlist load; PTB `start_polling` runs inside the FastAPI lifespan on the **same** asyncio loop (no second-loop crash). Outbound `sendMessage` to the allowlisted user succeeded; bot identity verified via `getMe`.
+- Optional: `POST /ingest` + `GET /search` round-trip committed a capture.
+
+Operator may still tap `/start`, a short query, and `/status` in Telegram for full UX confirm while `juno serve` is up.
+
 ### Follow-ups (not M1)
 
 - Wire **APScheduler** (already in `pyproject.toml`) as an asyncio-friendly scheduler on this loop for digests / resurfacing (M4 / epic [#27](https://github.com/Anna-Hax/JUNO/issues/27)).
 - Keep documenting “no `run_polling()`” next to any new entrypoint so this ADR is not rediscovered the hard way.
-- Live Spike S1 ([#4](https://github.com/Anna-Hax/JUNO/issues/4)): confirm `/health` + Telegram `/start` together on a real machine.

--- a/docs/adr/002-sqlite-write-queue.md
+++ b/docs/adr/002-sqlite-write-queue.md
@@ -1,23 +1,68 @@
 # ADR-02: SQLite write serialization
 
 ## Status
+
 Accepted (v1)
 
+## Date
+
+2026-08-20 (M0 scaffold)  
+**Last reviewed:** 2026-08-26 (after M1 / issue #12)
+
 ## Context
-Multiple producers write the graph: Telegram handlers, inbox watcher, FastAPI
-`/ingest`, and later scheduled jobs. Concurrent SQLite writers cause
-`database is locked` errors on Windows.
+
+Multiple producers write the knowledge graph in one process:
+
+- FastAPI `POST /ingest`
+- Inbox watcher (`InboxWatcher` → `IngestPipeline`)
+- Telegram capture handlers (forward / URL / document)
+- HITL review decisions (`ReviewQueue.decide`)
+- Runtime persistence (pause flag, embedder settings, module health)
+- Later: scheduled jobs (M4)
+
+SQLite allows only one writer at a time. On Windows especially, concurrent writers surface as `database is locked` / `OperationalError`, which is unacceptable for a personal agent that must keep ingesting while the user queries from Telegram.
+
+We already commit to **one asyncio event loop** ([ADR-01](001-shared-event-loop.md)). That means we can serialize writers with an in-process lock instead of inventing a multi-process write broker for v1.
+
+## Options considered
+
+| Option | Summary | Why not (for v1) |
+|--------|---------|------------------|
+| **A. Ignore it** | Let SQLAlchemy sessions write freely | Locks under concurrent inbox + bot + API |
+| **B. Separate write process / queue service** | Redis, dedicated writer worker | Overkill for local-first single-user v1 |
+| **C. WAL + `busy_timeout` only** | Rely on SQLite retries | Helps, but overlapping writers still contend and can fail under burst ingest |
+| **D. WAL + `busy_timeout` + asyncio write lock** | One `Database.write()` gate for all commits | **Chosen** |
 
 ## Decision
-- Use SQLite WAL mode and `busy_timeout=5000`.
-- Expose a single `Database.write()` method guarded by an `asyncio.Lock` so all
-  commits are serialized.
-- Reads may proceed without the write lock.
+
+Use **SQLite WAL mode**, a non-zero **busy timeout**, and a **single asyncio write lock** around every mutating transaction.
+
+Concrete rules (implemented in `apps/core/src/juno/graph/db.py`):
+
+1. On connect (and after migrate / `create_all`), set `PRAGMA journal_mode=WAL` and `PRAGMA busy_timeout=5000`.
+2. Expose **`Database.write(fn)`** — acquires `asyncio.Lock`, opens a session, begins a transaction, runs `fn(session)`, commits.
+3. Expose **`Database.read(fn)`** — opens a session **without** the write lock so reads can proceed while a write is held (subject to SQLite WAL semantics).
+4. **All** graph mutations go through `db.write(...)`. Callers must not open ad-hoc write sessions for commits. Known writers today: ingest pipeline, HITL queue, bot pause persistence, runtime health / embedder settings.
+5. `Database.journal_mode()` exists so tests can assert WAL is actually on after migrate.
+
+Acceptance for [#12](https://github.com/Anna-Hax/JUNO/issues/12): concurrent ingest must not lock. Covered by `apps/core/tests/test_write_queue.py` (many overlapping `IngestPipeline.ingest_text` calls via `asyncio.gather`, plus a read-during-write check).
 
 ## Consequences
-Write throughput is limited to one transaction at a time (fine for personal use).
-Callers must use `db.write` / `db.read` instead of opening ad-hoc sessions for writes.
 
-`PRAGMA journal_mode` is WAL after migrate; `Database.journal_mode()` exposes that for tests.
-Concurrent ingest (`asyncio.gather` of many `IngestPipeline.ingest_text` calls) must not raise
-`database is locked` — covered by `tests/test_write_queue.py` ([#12](https://github.com/Anna-Hax/JUNO/issues/12)).
+### Positive
+
+- Concurrent producers (bot + inbox + API) share one safe write path.
+- Personal-scale write throughput (one transaction at a time) is fine.
+- Reads stay available enough for `/search`, digests, and `/status` while a write is in flight.
+- Tests can prove the acceptance criterion without flaky “hope SQLite retries”.
+
+### Negative / constraints
+
+- Write throughput is intentionally limited; a pathological burst of huge ingest jobs will queue behind the lock.
+- Long-running work **inside** `db.write` holds the lock — keep write callbacks short (flush ORM rows; do PDF/HTML/Chroma work outside the lock, as the ingest pipeline already does).
+- Forgetting `db.write` and committing on a raw session reintroduces lock risk; code review should treat that as a bug.
+
+### Follow-ups
+
+- When M4 jobs land, they must use the same `Database.write` path — do not add a second writer.
+- If a future milestone needs true multi-process writers (e.g. a separate capture helper), revisit this ADR; WAL alone will not be enough across processes without a stronger coordination story.

--- a/docs/adr/003-alembic.md
+++ b/docs/adr/003-alembic.md
@@ -1,21 +1,67 @@
 # ADR-03: Alembic from day one
 
 ## Status
+
 Accepted (v1)
 
+## Date
+
+2026-08-20 (M0 scaffold)  
+**Last reviewed:** 2026-08-26 (after M1 / issue #11; schema still at revision `0001`)
+
 ## Context
-The graph schema will churn through M1–M2 (HITL fields, browser metadata, etc.).
-`create_all` alone cannot evolve existing user databases safely.
+
+The knowledge-graph schema lives in SQLAlchemy models under `apps/core/src/juno/models/`:
+
+- `captures`, `chunks`, `nodes`, `edges`
+- `review_items` (HITL)
+- `module_health`, `settings`
+
+That schema will keep evolving past v1.0 (browser metadata in M2, IDE fields in M3, prune / trust dials in M5, and so on). Shipping only `Base.metadata.create_all` at first boot works for empty databases, but it **cannot** safely alter an existing user’s `data/juno.db` when columns or tables change.
+
+Juno is local-first: users keep a long-lived SQLite file. Migrations are not optional polish — they are how we avoid “delete your DB to upgrade.”
+
+We also run under a **shared asyncio loop** ([ADR-01](001-shared-event-loop.md)). Nesting a sync Alembic engine inside an already-running async SQLAlchemy connection is a common source of “loop already running” / deadlocks. Migrations must stay off the serve loop.
+
+## Options considered
+
+| Option | Summary | Why not (for v1) |
+|--------|---------|------------------|
+| **A. `create_all` only** | Create missing tables at boot | No upgrades for existing files; silent drift from ORM |
+| **B. Hand-written SQL scripts** | Ad-hoc `.sql` files | Easy to forget; no revision identity; hard for CI |
+| **C. Alembic from day one** | Versioned revisions under `apps/core/alembic/` | **Chosen** |
+| **D. Defer Alembic until first breaking change** | Ship `create_all` now, migrate later | Leaves early adopters without a stamp/upgrade story |
 
 ## Decision
-- Ship Alembic migrations under `apps/core/alembic/`.
-- `juno db-init` and `juno serve` apply `alembic upgrade head` via sync SQLite
-  (`sqlite:///`) on a worker thread so the asyncio loop is never nested (ADR-01).
-- Databases created with the pre-migration `create_all` path are **stamped** at
-  head (tables already match revision `0001`).
-- `Base.metadata.create_all` remains for tests and that stamp detection only.
-- Schema changes require a new revision (`uv run alembic revision --autogenerate`).
+
+Use **Alembic** for all schema evolution, starting with the first revision.
+
+Concrete rules:
+
+1. Migrations live under `apps/core/alembic/` with `alembic.ini` in `apps/core/`. Current head: revision **`0001`** (`0001_initial_schema.py`) matching the ORM tables above.
+2. **`juno db-init`** and **`juno serve`** (via `Database.migrate()`) apply `alembic upgrade head`.
+3. The upgrade runs on a **sync** SQLite URL (`sqlite:///…`) inside **`asyncio.to_thread`**, so the asyncio loop is never nested (ADR-01). After upgrade, the async engine re-asserts `PRAGMA journal_mode=WAL` ([ADR-02](002-sqlite-write-queue.md)).
+4. Databases that were created with the pre-Alembic `create_all` path (tables already match `0001`) are **stamped** at head rather than re-created — see `juno.graph.migrations`.
+5. `Base.metadata.create_all` remains for **tests** and for that stamp-detection path only — not as the production upgrade mechanism.
+6. **Any** schema change requires a new revision (`uv run alembic revision --autogenerate` from `apps/core`, then review the script). Do not edit models without shipping a migration.
 
 ## Consequences
-CI runs `alembic upgrade head` against a temp SQLite file, and pytest asserts
-the upgraded schema matches ORM metadata. Do not edit models without a revision.
+
+### Positive
+
+- Existing `data/juno.db` files can move forward without a wipe when the schema changes.
+- CI runs `alembic upgrade head` against a temp directory before pytest (`.github/workflows/ci-python.yml`).
+- Pytest asserts the upgraded schema still matches ORM metadata (`test_migrations.py`).
+- `juno wipe` deletes the DB then re-runs migrate so a wiped install is still at head (#23).
+
+### Negative / constraints
+
+- Contributors must remember: model change ⇒ new Alembic revision in the same PR.
+- Autogenerate can miss renames / data migrations; always read the generated script.
+- Until a second revision exists, “stamp vs upgrade” only matters for people who still have pre-Alembic files — new installs just upgrade to `0001`.
+
+### Follow-ups
+
+- M2+ schema additions (browser / IDE capture fields) land as **new revisions**, not edits to `0001`.
+- If we ever need data backfills (not just DDL), put them in the revision’s `upgrade()` and keep them idempotent where possible.
+- Optional: expose `juno db-current` / `juno db-history` CLI helpers for debugging — not required for v1.0.

--- a/docs/adr/004-chroma-collections.md
+++ b/docs/adr/004-chroma-collections.md
@@ -6,27 +6,31 @@ Accepted (v1)
 
 ## Date
 
-2026-08-21 (M1 / issue #13)
+2026-08-21 (M1 / issue #13)  
+**Last reviewed:** 2026-08-26 (after M1 / v1.0 — ingest, RAG, export/wipe landed)
 
 ## Context
 
-Juno stores graph structure in SQLite (`chunks.chroma_id` links a row to a vector). Similarity search needs a **local vector index** that:
+Juno stores graph structure in SQLite. Chunks of captured text need a **local vector index** for similarity search so Telegram / `GET /search` can find “that thing I read” without scanning every row.
 
-- Survives `juno serve` restarts (acceptance for #13)
-- Lives under `data/` with the rest of the personal store (gitignored)
-- Works with the **stub hash embedder** in CI (no torch / no Chroma default ONNX download)
-- Works with MiniLM (or a later model) locally without mixing incompatible vector spaces
+Requirements for v1:
 
-Embedding models differ in **dimension and geometry**. Mixing `stub-hash-v1` (64-d) with `all-MiniLM-L6-v2` (384-d) in one collection fails or silently corrupts retrieval. `.env.example` already warns that changing `EMBEDDING_MODEL` requires a reindex.
+- Survive `juno serve` restarts (acceptance for [#13](https://github.com/Anna-Hax/JUNO/issues/13)).
+- Live under `data/` with the rest of the personal store (gitignored).
+- Work with the **stub hash embedder** in CI (no torch / no Chroma default ONNX download).
+- Work with MiniLM (or a later model) locally without mixing incompatible vector spaces.
+- Respect the shared asyncio loop ([ADR-01](001-shared-event-loop.md)) — Chroma’s client API is synchronous.
 
-Chroma I/O is **synchronous**. ADR-01 forbids blocking the shared asyncio loop for long work.
+Embedding models differ in **dimension and geometry**. Mixing `stub-hash-v1` (64-d) with `all-MiniLM-L6-v2` (384-d) in one collection fails or silently corrupts retrieval. `.env.example` warns that changing `EMBEDDING_MODEL` / backend requires a reindex.
+
+SQLite already holds the canonical text and `chunks.chroma_id` (the join key). Chroma holds the vectors for nearest-neighbor search only.
 
 ## Options considered
 
 | Option | Summary | Why not (for v1) |
 |--------|---------|------------------|
-| **A. One collection** | Single index for all embeddings | Dimension / metric mismatch when the model changes |
-| **B. Collection per embedding model** | Name derived from `embedder.model_id`; old collections left on disk | Chosen |
+| **A. One collection for all models** | Single index | Dimension / metric mismatch when the model changes |
+| **B. Collection per embedding model** | Name derived from `embedder.model_id`; old collections left on disk | **Chosen** |
 | **C. Vectors only in SQLite** | Store blobs next to chunks | No HNSW; retrieval would be a later rewrite |
 | **D. Hosted / server Chroma** | Separate process or cloud | Breaks local-first single-process v1 |
 | **E. Chroma’s default embedding function** | Let Chroma embed documents | Downloads ONNX in CI; duplicates Juno’s embedder |
@@ -35,17 +39,24 @@ Chroma I/O is **synchronous**. ADR-01 forbids blocking the shared asyncio loop f
 
 Use **Chroma `PersistentClient`** on `settings.chroma_path` (`data/chroma/` by default), with **one collection per embedding model**.
 
-Concrete rules (see `juno/graph/vectors.py`):
+Concrete rules (implemented in `apps/core/src/juno/graph/vectors.py` as `VectorStore`):
 
 1. **Persist on disk** — `chromadb.PersistentClient(path=…)` so a new process sees the same vectors.
-2. **Collection name** — `collection_name_for_model(embedder.model_id)` → `juno-{sanitized-id}` (Chroma 3–63 char rules). Example: `all-MiniLM-L6-v2` → `juno-all-MiniLM-L6-v2`.
-3. **Bring-your-own embeddings** — create collections with `embedding_function=None` and pass vectors from Juno’s `Embedder` on `upsert` / `query`. Do not use Chroma’s default embedder.
+2. **Collection name** — `collection_name_for_model(embedder.model_id)` → `juno-{sanitized-id}` (Chroma 3–63 character rules). Example: `all-MiniLM-L6-v2` → `juno-all-MiniLM-L6-v2`.
+3. **Bring-your-own embeddings** — create collections with `embedding_function=None` and pass vectors from Juno’s `Embedder` on `upsert` / `query`. Do **not** use Chroma’s default embedder.
 4. **Cosine space** — collection metadata sets `hnsw:space=cosine` (embedders L2-normalize).
 5. **No telemetry** — `anonymized_telemetry=False` (local-first / privacy).
-6. **Event loop** — from `juno serve`, call `upsert_async` / `query_async` (or `asyncio.to_thread` around sync methods). Do not block the loop with raw Chroma I/O.
-7. **Model change** — switching `EMBEDDING_MODEL` / backend opens a **new** collection. The old one remains until a later wipe/reindex tool (#23). Retrieval only uses the active model’s collection.
+6. **Event loop** — from `juno serve`, call `upsert_async` / `query_async` (wrappers around `asyncio.to_thread`). Do not block the loop with raw Chroma I/O.
+7. **Model change** — switching `EMBEDDING_MODEL` / backend opens a **new** collection. The old one remains on disk until wiped. Retrieval only uses the **active** model’s collection.
+8. **Chunk IDs** — ingest assigns `chunks.chroma_id` as `c{capture_id}-n{ordinal}` and upserts those IDs into Chroma so RAG can join hits back to SQLite captures.
 
-The wrapper is `VectorStore`. Runtime attaches it to `app.state.vectors`. `/status` reports `chroma_collection` and `chroma_count`. Ingest and RAG (#16, #17) write and query through this API; they do not construct a second Chroma client.
+Runtime attaches a single `VectorStore` to `app.state.vectors`. `/status` and Telegram `/status` report `chroma_collection` and `chroma_count`. Ingest, RAG, and export all use that handle; they do not construct a second Chroma client.
+
+### Export and wipe (#23)
+
+- **`juno export`** dumps all graph tables plus the **active** collection snapshot (ids, documents, metadatas, embeddings) via `VectorStore.export_snapshot()` / `juno.graph.ownership`.
+- **`juno wipe --confirm wipe-all-data`** deletes `data/juno.db` and the entire `data/chroma/` tree, then re-runs Alembic migrations on a fresh database ([ADR-03](003-alembic.md)).
+- **Stop `juno serve` before wipe on Windows** — an open `PersistentClient` can lock files under `data/chroma/` (`PermissionError`). `VectorStore.close()` exists for tests / CLI; the operator still must not wipe while serve is running.
 
 ## Consequences
 
@@ -54,18 +65,27 @@ The wrapper is `VectorStore`. Runtime attaches it to `app.state.vectors`. `/stat
 - Restart-safe vectors next to SQLite under `data/`.
 - Safe model switches without corrupting an existing index.
 - CI stays stub-only; no extra model download for Chroma.
-- One handle in-process (`app.state.vectors`), same pattern as `Database` / embedder.
+- One in-process handle (`app.state.vectors`), same pattern as `Database` / embedder.
+- Full local backup via `juno export`; full delete via `juno wipe` (data ownership / PRD §9).
 
 ### Negative / constraints
 
-- Changing models does **not** auto-reindex; search is empty until ingest runs again against the new collection.
-- Two collections can coexist on disk (disk use grows if models are swapped often).
-- Chroma is another SQLite-backed file tree under `data/chroma/`; backup should include that directory with `juno.db`.
+- Changing models does **not** auto-reindex; search is empty on the new collection until content is ingested again.
+- Two (or more) collections can coexist on disk — disk use grows if models are swapped often; wipe is the blunt cleanup.
+- Chroma is another SQLite-backed file tree under `data/chroma/`; any manual backup should include that directory with `juno.db` (or use `juno export`).
 - Callers that pass `query_texts=` without embeddings would fail (no collection embedding function by design).
+- Windows file locks make in-process wipe while a client is open unreliable — document and enforce “serve stopped”.
 
-### Follow-ups
+### What landed (M1)
 
-- Ingest pipeline (#16) assigns `chunks.chroma_id` as `c{capture_id}-n{ordinal}` and upserts through the attached `VectorStore`.
-- RAG retrieve (#17) queries `VectorStore` then joins hits to SQLite captures (`juno.rag.engine`).
-- Export/wipe ([#23](https://github.com/Anna-Hax/JUNO/issues/23)): `juno export` writes graph tables + active Chroma collection to JSON; `juno wipe --confirm wipe-all-data` deletes `data/juno.db` and `data/chroma/` then re-runs migrations. Stop `juno serve` before wipe on Windows (Chroma file locks).
-- Optional: record active collection name in SQLite `settings` so `/status` and HITL can explain a model mismatch.
+- Persistent client + per-model collections ([#13](https://github.com/Anna-Hax/JUNO/issues/13)).
+- Ingest upserts through the attached `VectorStore` with `c{capture_id}-n{ordinal}` IDs ([#16](https://github.com/Anna-Hax/JUNO/issues/16)).
+- RAG retrieve queries Chroma then joins to SQLite (`juno.rag.engine`, [#17](https://github.com/Anna-Hax/JUNO/issues/17)).
+- Embedder model / backend / dimensions persisted into SQLite `settings` on serve for later reindex awareness ([#14](https://github.com/Anna-Hax/JUNO/issues/14)).
+- Export / wipe CLI ([#23](https://github.com/Anna-Hax/JUNO/issues/23)).
+
+### Follow-ups (post–v1.0)
+
+- Optional **reindex** command: rebuild the active collection from SQLite `chunks` after an embedding model change (wipe deletes everything; reindex would migrate).
+- Optionally persist the **collection name** itself in SQLite `settings` (today we persist `embedding_model` / `embedding_backend` / `embedding_dimensions`, and `/status` reads the live `VectorStore.collection_name`).
+- M2+ capture modules must reuse the same `VectorStore` instance from runtime — do not open a second PersistentClient in the browser extension path (extension talks HTTP to the loopback API instead).

--- a/docs/next-work.md
+++ b/docs/next-work.md
@@ -1,61 +1,147 @@
-# Next work (after M0 bootstrap)
+# Next work
 
-**Last updated:** 2026-08-26  
-**Track issues on:** https://github.com/Anna-Hax/JUNO/issues
+**Last updated:** 2026-08-29  
+**Track issues on:** [https://github.com/Anna-Hax/JUNO/issues](https://github.com/Anna-Hax/JUNO/issues)  
+**Package:** `1.0.0` (M1 foundation complete — [`docs/v1.0-release-gate.md`](v1.0-release-gate.md))
+
+Prefer one open issue ≈ one PR (`Closes #N`). This file is kept as-is across branch merges (`merge=ours`).
 
 ---
 
-## M1 v1.0 foundation — **complete**
+## Before M2 (finish / unblock)
 
-Gate: [`docs/v1.0-release-gate.md`](v1.0-release-gate.md) (issue **#24**, [PR #40](https://github.com/Anna-Hax/JUNO/pull/40)).
+Do these **before or while starting** M2 coding. They are not blocked on the browser extension, but leaving them open means M2 work has no live smoke proof and a weaker board.  
+Before this make sure that docs/adr are up to date.
 
-| Issue | Work | PR |
-|-------|------|-----|
-| #11 | Alembic schema | (early M1) |
-| #13 | Chroma client | [#29](https://github.com/Anna-Hax/JUNO/pull/29) |
-| #16 | Ingest + inbox | [#31](https://github.com/Anna-Hax/JUNO/pull/31) |
+
+| Order | Item                                                                                                                                                               | Issue                                                                         | Why                                                                                    |
+| ----- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ----------------------------------------------------------------------------- | -------------------------------------------------------------------------------------- |
+| 1     | **Live Spike S1** — ✅ done 2026-08-29 ([session 16](sessions/16-session-spike-s1-live.md)); optional interactive Telegram `/start` from the client while serve is up | [#4](https://github.com/Anna-Hax/JUNO/issues/4)                               | Proves ADR-01 on a real machine; M2 extension depends on the same loopback API + token |
+| 2     | **Projects v2 board** + optional auto-add secrets                                                                                                                  | [#9](https://github.com/Anna-Hax/JUNO/issues/9)                               | M2 will create many tickets; board keeps Ready / In Progress / Done honest             |
+| 3     | **Branch protection** on `main` (require CI Python + PR Checks)                                                                                                    | (repo Settings)                                                               | Stops accidental direct pushes during the extension wave                               |
+| 4     | **Close / note M1 milestone** on GitHub if still open with 0 open issues                                                                                           | Milestone [M1: v1.0 Foundation](https://github.com/Anna-Hax/JUNO/milestone/7) | Hygiene only                                                                           |
+
+
+
+
+### Spike S1 checklist (#4)
+
+```powershell
+cd apps/core
+uv sync --extra dev
+# Optional MiniLM: uv sync --extra dev --extra embeddings
+copy ..\..\.env.example ..\..\.env   # then edit secrets — not change-me
+uv run juno db-init
+uv run juno serve
+```
+
+Confirm together:
+
+- [x] `GET http://127.0.0.1:8787/health` → `{"status":"ok"}` (no token)
+- [x] `GET /status` with `Authorization: Bearer …` → 200; without → 401
+- [x] Telegram bot online on shared loop (`getMe` + outbound to allowlist); operator: `/start`, a text query, `/status` from the client
+- [x] Optional: `POST /ingest` + `/search` (Spike S1 smoke capture)
+
+
+
+### Projects board (#9)
+
+```powershell
+gh auth refresh -h github.com -s project,read:project
+.\scripts\bootstrap-project.ps1
+```
+
+Then set Status columns in the UI; optionally add `PROJECT_PAT` + `PROJECT_NUMBER` secrets for `.github/workflows/project-automation.yml`.
+
+---
+
+
+
+## Unlock M2 (planning, first coding day)
+
+Epic only today: [#25](https://github.com/Anna-Hax/JUNO/issues/25) — *Epic: M2 Browser capture (v1.1)*.  
+Milestone: [M2: v1.1 Browser Capture](https://github.com/Anna-Hax/JUNO/milestone/8).
+
+**First coding task:** expand #25 into concrete child issues (wave policy — do **not** invent the whole M3–M5 backlog yet). Suggested titles below; create with milestone **M2**, labels `area: extension` / `area: api` / `area: bot` as appropriate, and `priority: P0` or `P1`.
+
+Stub today: `apps/extension/` (MV3 manifest + log-only `background.js`, host permission for `127.0.0.1`). Extension must talk **HTTP to the loopback API** — no second Chroma/SQLite client ([ADR-04](adr/004-chroma-collections.md)).
+
+---
+
+
+
+## M2 implementation order (proposed small PRs)
+
+PRD Phase 2 + epic #25: Spike S2, MV3, URL/title, metrics, highlights, excludes, digests.  
+Prefer one issue ≈ one PR. Order is dependency-aware.
+
+
+| Order | Proposed work                                                                                                                                | Notes / acceptance sketch                                                                                  |
+| ----- | -------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------- |
+| 1     | **Spike S2** — custom MV3 extension vs lighter history/bookmark APIs; prove one capture reaches `POST /ingest` with Bearer token             | Decision recorded in a session doc or short ADR note; smoke on Chrome (or Edge) against local `juno serve` |
+| 2     | **MV3 scaffold** — real permissions, options/popup for `JUNO_API_TOKEN` + API base URL, service worker structure, bump CI extension checks   | Load unpacked extension; token stored locally; CI still validates manifest                                 |
+| 3     | **Capture URL + title + timestamp** (`source_type=browser`) via `/ingest`                                                                    | Row in `captures`; shows up in `/search` / bot query                                                       |
+| 4     | **Engagement metrics** — active time on page, scroll depth (and any other cheap signals)                                                     | Stored on capture (`raw_json` and/or new columns via **new Alembic revision**, not edit of `0001`)         |
+| 5     | **Highlights / selections**                                                                                                                  | Highlight text attached to the page capture; retrievable                                                   |
+| 6     | **Domain / URL excludes** + respect global `/pause`                                                                                          | Banking etc. never ingested; pause returns 423 from API and extension backs off                            |
+| 7     | **Module health** — extension last-success / last-error in `module_health`; Telegram `/status` and `GET /status` show browser sync freshness | Silent breakage is visible within a day of testing                                                         |
+| 8     | **Cross-reference** browser captures vs upload/inbox content in retrieve / digest text                                                       | “You also uploaded notes on X” style citations or digest lines                                             |
+| 9     | **Digest enrichment** — `/digest today|week` includes browser reading (on-demand already exists; deepen for M2)                              | Scheduled *push* digests stay M4 unless explicitly pulled forward                                          |
+| 10    | **Extension tests + docs** — unit/integration where feasible; README load steps; session log; M2 gate checklist                              | CI green on `apps/extension/`**                                                                            |
+
+
+
+
+### M2 design constraints (do not violate)
+
+1. One process, one loop ([ADR-01](adr/001-shared-event-loop.md)) — extension is a **client**, not a second daemon.
+2. All DB writes through `Database.write()` ([ADR-02](adr/002-sqlite-write-queue.md)).
+3. Schema changes = new Alembic revision ([ADR-03](adr/003-alembic.md)).
+4. Vectors only via the serve-process `VectorStore` after ingest ([ADR-04](adr/004-chroma-collections.md)).
+5. Loopback + token auth only ([#21](https://github.com/Anna-Hax/JUNO/issues/21)) — never bind `0.0.0.0` for the extension.
+6. HITL: high-confidence URL visits may auto-commit; sensitive batches stay reviewable ([#20](https://github.com/Anna-Hax/JUNO/issues/20) patterns).
+
+
+
+### Explicitly **not** M2 (keep in later epics)
+
+
+| Epic                                              | Milestone             | Scope                                     |
+| ------------------------------------------------- | --------------------- | ----------------------------------------- |
+| [#26](https://github.com/Anna-Hax/JUNO/issues/26) | M3 IDE / Cursor       | Chat + terminal error capture             |
+| [#27](https://github.com/Anna-Hax/JUNO/issues/27) | M4 Proactive + mobile | APScheduler push digests, voice, temporal |
+| [#28](https://github.com/Anna-Hax/JUNO/issues/28) | M5 v2 polish          | Flashcards, drafts, trust dial, Slack     |
+
+
+---
+
+
+
+## M1 complete (reference)
+
+
+| Issue     | Work                | PR                                              |
+| --------- | ------------------- | ----------------------------------------------- |
+| #11       | Alembic schema      | (early M1)                                      |
+| #13       | Chroma client       | [#29](https://github.com/Anna-Hax/JUNO/pull/29) |
+| #16       | Ingest + inbox      | [#31](https://github.com/Anna-Hax/JUNO/pull/31) |
 | #14 / #15 | MiniLM + LLM health | [#32](https://github.com/Anna-Hax/JUNO/pull/32) |
-| #17 | RAG + citations | [#33](https://github.com/Anna-Hax/JUNO/pull/33) |
-| #18 / #19 | Telegram bot | [#34](https://github.com/Anna-Hax/JUNO/pull/34) |
-| #20 | HITL `/review` | [#35](https://github.com/Anna-Hax/JUNO/pull/35) |
-| #21 | API harden | [#36](https://github.com/Anna-Hax/JUNO/pull/36) |
-| #12 | Write queue | [#37](https://github.com/Anna-Hax/JUNO/pull/37) |
-| #22 | Integration tests | [#38](https://github.com/Anna-Hax/JUNO/pull/38) |
-| #23 | Export / wipe | [#39](https://github.com/Anna-Hax/JUNO/pull/39) |
-| #24 | Release gate | [#40](https://github.com/Anna-Hax/JUNO/pull/40) |
+| #17       | RAG + citations     | [#33](https://github.com/Anna-Hax/JUNO/pull/33) |
+| #18 / #19 | Telegram bot        | [#34](https://github.com/Anna-Hax/JUNO/pull/34) |
+| #20       | HITL `/review`      | [#35](https://github.com/Anna-Hax/JUNO/pull/35) |
+| #21       | API harden          | [#36](https://github.com/Anna-Hax/JUNO/pull/36) |
+| #12       | Write queue         | [#37](https://github.com/Anna-Hax/JUNO/pull/37) |
+| #22       | Integration tests   | [#38](https://github.com/Anna-Hax/JUNO/pull/38) |
+| #23       | Export / wipe       | [#39](https://github.com/Anna-Hax/JUNO/pull/39) |
+| #24       | Release gate        | [#40](https://github.com/Anna-Hax/JUNO/pull/40) |
 
-**Next coding wave:** M2 browser capture — expand epic **#25** into split tickets.
-
----
-
-## Do first (finish M0 ops)
-
-1. **Projects board** (issue #9)
-   ```powershell
-   gh auth refresh -h github.com -s project,read:project
-   .\scripts\bootstrap-project.ps1
-   ```
-
-2. **Live Spike S1** (issue #4) — fill `.env`, run `juno serve`, confirm Telegram `/start` + `GET /health` together.
-
-3. **Branch protection** on `main` — require CI Python + PR Checks.
 
 ---
 
-## After v1.0
 
-- Expand epic **#25** (M2 browser) into split tickets.
-- Then #26 IDE, #27 proactive, #28 v2 polish — same wave pattern.
-
----
 
 ## When you finish a coding session
 
-Add a new file: `docs/sessions/0N-session-<short-name>.md` describing:
-
-- What changed (files / commits / issues closed)
-- What broke or was deferred
-- How to verify
-
-Keep this `docs/next-work.md` updated so the board and docs stay aligned.
-Do not recreate `docs/sessions/03-next-work.md`. This file is kept as-is across branch merges.
+Add `docs/sessions/0N-session-<short-name>.md` with what changed, what deferred, how to verify.  
+Update **this** file so the board and docs stay aligned.  
+Do not recreate `docs/sessions/03-next-work.md`.

--- a/docs/sessions/16-session-spike-s1-live.md
+++ b/docs/sessions/16-session-spike-s1-live.md
@@ -1,0 +1,57 @@
+# Session 16 — Live Spike S1 (#4)
+
+**Date:** 2026-08-29  
+**Issue:** [#4](https://github.com/Anna-Hax/JUNO/issues/4) — Spike S1: PTB + uvicorn shared event-loop hello-world  
+**Branch:** `chore/spike-s1-live-4`
+
+## What changed
+
+- **`resolve_env_file` / `get_settings`** in `apps/core/src/juno/config.py` — walk cwd then parents for `.env` so the documented `cd apps/core` + repo-root `.env` quick start actually loads secrets (previously `juno serve` fell back to `change-me` and refused to start).
+- Unit test for parent `.env` discovery.
+- ADR-01 live-smoke section; README note; this session log; `docs/next-work.md` checklist update.
+
+## Live smoke (this machine)
+
+| Check | Result |
+|-------|--------|
+| `uv run juno db-init` | OK (alembic → 0001) |
+| `uv run juno serve` | OK on `127.0.0.1:8787` (shared loop; PTB polling started) |
+| `GET /health` (no token) | `{"status":"ok"}` |
+| `GET /status` without Bearer | 401 |
+| `GET /status` with Bearer | 200 (`capture_paused`, embedder, llm fields) |
+| Telegram `getMe` | OK (`@JUNO_2006_bot`) |
+| Outbound `sendMessage` to allowlisted user | OK |
+| `POST /ingest` + `GET /search?q=Spike%20S1` | Capture committed; search returned it |
+
+Notes:
+
+- Ollama was down → `llm_healthy: false` (retrieve-only); expected.
+- Embeddings used **stub** (no `--extra embeddings` in this smoke); MiniLM optional.
+- Interactive Telegram `/start` + query + `/status` from the phone/desktop client: operator confirm while serve is up (bot already messaged the allowlist chat).
+
+## Deferred
+
+- Projects board (#9), branch protection, M1 milestone close — next Before-M2 items.
+- MiniLM install / Ollama up — not required to close #4.
+
+## How to verify
+
+```powershell
+cd apps/core
+uv sync --extra dev
+# ensure repo-root .env has real JUNO_API_TOKEN + Telegram token/allowlist
+uv run juno db-init
+uv run juno serve
+# other shell:
+Invoke-RestMethod http://127.0.0.1:8787/health
+# GET /status with Authorization: Bearer <token>
+# Telegram: /start, a short query, /status
+```
+
+## Links
+
+| Doc | Role |
+|-----|------|
+| [001-shared-event-loop.md](../adr/001-shared-event-loop.md) | ADR-01 + live smoke |
+| [next-work.md](../next-work.md) | Global board |
+| [15-session-v1-release-gate.md](15-session-v1-release-gate.md) | Prior M1 gate |

--- a/docs/sessions/README.md
+++ b/docs/sessions/README.md
@@ -21,6 +21,7 @@ Living notes for what was implemented, how GitHub is set up, and what to do next
 | [13-session-integration-tests.md](13-session-integration-tests.md) | **M1 #22** — ingest → retrieve → review integration tests |
 | [14-session-export-wipe.md](14-session-export-wipe.md) | **M1 #23** — `juno export` + `juno wipe` |
 | [15-session-v1-release-gate.md](15-session-v1-release-gate.md) | **M1 #24** — v1.0 release gate |
+| [16-session-spike-s1-live.md](16-session-spike-s1-live.md) | **#4** — Live Spike S1 (shared-loop smoke) |
 | [v1.0-release-gate.md](../v1.0-release-gate.md) | M1 checklist (all P0 closed) |
 
 Architecture decisions live in [`../adr/`](../adr/). Product requirements: [`../../personal-knowledge-graph-prd.md](../../personal-knowledge-graph-prd.md).


### PR DESCRIPTION
## Summary
- Walk cwd/parents for `.env` so `juno serve` from `apps/core` loads the repo-root secrets documented in the quick start (unblocks live Spike S1).
- Record live smoke on ADR-01 + session 16: `/health`, `/status` auth, Telegram bot on the shared loop, optional ingest/search.
- Closes #4.

## Test plan
- [x] `uv run pytest` (112 passed)
- [x] `uv run ruff check` + format
- [x] Live: `juno serve` → `/health` 200, `/status` 401/200, Telegram `getMe` + outbound, ingest/search
- [ ] CI green on this PR
