### PR TITLE
chore(project): idempotent JUNO Roadmap board bootstrap

### DIFF
--- a/docs/next-work.md
+++ b/docs/next-work.md
@@ -17,7 +17,7 @@ Before this make sure that docs/adr are up to date.
 | Order | Item                                                                                                                                                               | Issue                                                                         | Why                                                                                    |
 | ----- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ----------------------------------------------------------------------------- | -------------------------------------------------------------------------------------- |
 | 1     | **Live Spike S1** — ✅ done 2026-08-29 ([session 16](sessions/16-session-spike-s1-live.md)); optional interactive Telegram `/start` from the client while serve is up | [#4](https://github.com/Anna-Hax/JUNO/issues/4)                               | Proves ADR-01 on a real machine; M2 extension depends on the same loopback API + token |
-| 2     | **Projects v2 board** + optional auto-add secrets                                                                                                                  | [#9](https://github.com/Anna-Hax/JUNO/issues/9)                               | M2 will create many tickets; board keeps Ready / In Progress / Done honest             |
+| 2     | **Projects v2 board** — ✅ done 2026-08-29 ([session 17](sessions/17-session-projects-board.md)); board [#1](https://github.com/users/Anna-Hax/projects/1) + auto-add secrets | [#9](https://github.com/Anna-Hax/JUNO/issues/9)                               | M2 will create many tickets; board keeps Ready / In Progress / Done honest             |
 | 3     | **Branch protection** on `main` (require CI Python + PR Checks)                                                                                                    | (repo Settings)                                                               | Stops accidental direct pushes during the extension wave                               |
 | 4     | **Close / note M1 milestone** on GitHub if still open with 0 open issues                                                                                           | Milestone [M1: v1.0 Foundation](https://github.com/Anna-Hax/JUNO/milestone/7) | Hygiene only                                                                           |
 
@@ -48,10 +48,10 @@ Confirm together:
 
 ```powershell
 gh auth refresh -h github.com -s project,read:project
-.\scripts\bootstrap-project.ps1
+.\scripts\bootstrap-project.ps1   # idempotent — reuses JUNO Roadmap #1
 ```
 
-Then set Status columns in the UI; optionally add `PROJECT_PAT` + `PROJECT_NUMBER` secrets for `.github/workflows/project-automation.yml`.
+Board: [JUNO Roadmap](https://github.com/users/Anna-Hax/projects/1). Secrets `PROJECT_PAT` + `PROJECT_NUMBER=1` set for `.github/workflows/project-automation.yml`.
 
 ---
 

--- a/docs/sessions/01-github-setup.md
+++ b/docs/sessions/01-github-setup.md
@@ -53,16 +53,16 @@ Epics: #25 M2 · #26 M3 · #27 M4 · #28 M5
 
 ## Progress board (Projects v2)
 
-**Status:** not created yet (token missing `project` / `read:project`).
+**Status:** **live** — [JUNO Roadmap](https://github.com/users/Anna-Hax/projects/1) (project **#1**).
 
 ```powershell
 gh auth refresh -h github.com -s project,read:project
-.\scripts\bootstrap-project.ps1
+.\scripts\bootstrap-project.ps1   # idempotent — reuses project #1
 ```
 
-Intended board columns: Backlog → Ready → In Progress → In Review → Blocked → Done.
+Status columns today: **Todo → In Progress → Done** (customize in the UI for Ready / Blocked / In Review if desired).
 
-Optional CI secrets for auto-add: `PROJECT_PAT`, `PROJECT_NUMBER` (see `.github/workflows/project-automation.yml`).
+CI secrets for auto-add: `PROJECT_PAT`, `PROJECT_NUMBER=1` (see `.github/workflows/project-automation.yml`).
 
 ---
 
@@ -73,7 +73,7 @@ Optional CI secrets for auto-add: `PROJECT_PAT`, `PROJECT_NUMBER` (see `.github/
 | CI Python | push/PR to `main` | **Green** on first scaffold push |
 | CI Extension | path `apps/extension/**` | JSON + file presence |
 | PR Checks | PR open/edit | title format + Closes/Refs |
-| Project Automation | issue/PR open | no-ops until secrets set |
+| Project Automation | issue/PR open | uses `PROJECT_PAT` + `PROJECT_NUMBER=1` |
 
 PR template: `.github/PULL_REQUEST_TEMPLATE.md`
 

--- a/docs/sessions/17-session-projects-board.md
+++ b/docs/sessions/17-session-projects-board.md
@@ -1,0 +1,44 @@
+# Session 17 — Projects v2 board (#9)
+
+**Date:** 2026-08-29  
+**Issue:** [#9](https://github.com/Anna-Hax/JUNO/issues/9) — Projects v2 board + auto-add workflow  
+**Branch:** `chore/projects-board-9`
+
+## What changed
+
+- Confirmed **[JUNO Roadmap](https://github.com/users/Anna-Hax/projects/1)** (project **#1**) already held open/closed M0–M5 issues with Status **Todo / In Progress / Done**.
+- Made `scripts/bootstrap-project.ps1` **idempotent** (parse `gh project list` JSON `.projects`, reuse open “JUNO Roadmap”, do not create duplicates). Closed/deleted an accidental project #2 created during the first buggy run.
+- Set repo secrets **`PROJECT_NUMBER=1`** and **`PROJECT_PAT`** (token with `project` scope) so `.github/workflows/project-automation.yml` can auto-add new issues/PRs.
+- Updated `docs/sessions/01-github-setup.md` + `docs/next-work.md`.
+
+## Acceptance
+
+| Check | Result |
+|-------|--------|
+| Open issues on board | Yes (#9, #25–#28 + historical M1 items) |
+| Bootstrap script safe to re-run | Yes — reuses #1 |
+| Auto-add secrets | `PROJECT_PAT` + `PROJECT_NUMBER` set |
+
+Optional UI polish (not blocking): rename/expand Status options to Backlog / Ready / In Review / Blocked in the project UI.
+
+## Note on `PROJECT_PAT`
+
+Bootstrap used the current `gh auth` token. If Actions add-to-project starts failing after re-auth, replace the secret with a classic PAT that has **project** (and repo) scope.
+
+## How to verify
+
+```powershell
+gh project list --owner Anna-Hax
+.\scripts\bootstrap-project.ps1   # should print Reusing project #1
+gh secret list --repo Anna-Hax/JUNO   # PROJECT_PAT, PROJECT_NUMBER present
+```
+
+Open a throwaway issue or PR and confirm the Project Automation workflow adds it to project #1.
+
+## Links
+
+| Doc | Role |
+|-----|------|
+| [01-github-setup.md](01-github-setup.md) | Board + secrets |
+| [next-work.md](../next-work.md) | Global board |
+| [16-session-spike-s1-live.md](16-session-spike-s1-live.md) | Prior Before-M2 item |

--- a/docs/sessions/README.md
+++ b/docs/sessions/README.md
@@ -22,6 +22,7 @@ Living notes for what was implemented, how GitHub is set up, and what to do next
 | [14-session-export-wipe.md](14-session-export-wipe.md) | **M1 #23** — `juno export` + `juno wipe` |
 | [15-session-v1-release-gate.md](15-session-v1-release-gate.md) | **M1 #24** — v1.0 release gate |
 | [16-session-spike-s1-live.md](16-session-spike-s1-live.md) | **#4** — Live Spike S1 (shared-loop smoke) |
+| [17-session-projects-board.md](17-session-projects-board.md) | **#9** — Projects v2 board + auto-add |
 | [v1.0-release-gate.md](../v1.0-release-gate.md) | M1 checklist (all P0 closed) |
 
 Architecture decisions live in [`../adr/`](../adr/). Product requirements: [`../../personal-knowledge-graph-prd.md](../../personal-knowledge-graph-prd.md).

--- a/scripts/bootstrap-project.ps1
+++ b/scripts/bootstrap-project.ps1
@@ -1,21 +1,44 @@
 # After: gh auth refresh -h github.com -s project,read:project
-# Creates JUNO Roadmap project and links open issues.
+# Ensures JUNO Roadmap project exists, links open issues, prints board URL.
+# Idempotent: reuses an existing open "JUNO Roadmap" project instead of creating a duplicate.
 
 $ErrorActionPreference = "Stop"
 $owner = "Anna-Hax"
 $repo = "Anna-Hax/JUNO"
+$title = "JUNO Roadmap"
 
-$created = gh project create --owner $owner --title "JUNO Roadmap" --format json | ConvertFrom-Json
-$number = $created.number
-Write-Host "Created project #$number"
+$list = gh project list --owner $owner --limit 100 --format json | ConvertFrom-Json
+$projects = @($list.projects)
+$existing = $projects |
+  Where-Object { $_.title -eq $title -and -not $_.closed } |
+  Sort-Object number |
+  Select-Object -First 1
 
-# Add open issues
-$issues = gh issue list --repo $repo --state open --limit 100 --json url | ConvertFrom-Json
+if ($null -eq $existing) {
+  $created = gh project create --owner $owner --title $title --format json | ConvertFrom-Json
+  $number = $created.number
+  Write-Host "Created project #$number"
+} else {
+  $number = $existing.number
+  Write-Host "Reusing project #$number ($($existing.url))"
+}
+
+# Add open issues (ignore failures — often means already on the board)
+$issues = gh issue list --repo $repo --state open --limit 100 --json url,number | ConvertFrom-Json
 foreach ($i in $issues) {
-  gh project item-add $number --owner $owner --url $i.url | Out-Null
-  Write-Host "added $($i.url)"
+  $prev = $ErrorActionPreference
+  $ErrorActionPreference = "Continue"
+  gh project item-add $number --owner $owner --url $i.url 2>&1 | Out-Null
+  $code = $LASTEXITCODE
+  $ErrorActionPreference = $prev
+  if ($code -eq 0) {
+    Write-Host "added #$($i.number)"
+  } else {
+    Write-Host "skip #$($i.number) (already on board or add failed)"
+  }
 }
 
 Write-Host "Open: https://github.com/users/$owner/projects/$number"
-Write-Host "Then: configure Status field (Backlog/Ready/In Progress/In Review/Blocked/Done) in the UI."
-Write-Host "Optional: set repo secrets PROJECT_PAT + PROJECT_NUMBER for .github/workflows/project-automation.yml"
+Write-Host "Status field: Todo / In Progress / Done (customize in the project UI if you want Ready/Blocked/etc)."
+Write-Host "CI auto-add: repo secrets PROJECT_PAT (token with project scope) + PROJECT_NUMBER=$number"
+Write-Host "  Workflow: .github/workflows/project-automation.yml"


### PR DESCRIPTION
## Summary
- Make `scripts/bootstrap-project.ps1` idempotent (reuse open JUNO Roadmap #1).
- Document live board + `PROJECT_PAT` / `PROJECT_NUMBER=1` for auto-add.
- Closes #9.

## Test plan
- [x] `.\scripts\bootstrap-project.ps1` prints Reusing project #1
- [x] Secrets listed on repo
- [ ] CI / PR Checks green
