### PR TITLE
docs(ops): record main branch protection and close M1 milestone

### DIFF
--- a/docs/next-work.md
+++ b/docs/next-work.md
@@ -18,8 +18,8 @@ Before this make sure that docs/adr are up to date.
 | ----- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ----------------------------------------------------------------------------- | -------------------------------------------------------------------------------------- |
 | 1     | **Live Spike S1** — ✅ done 2026-08-29 ([session 16](sessions/16-session-spike-s1-live.md)); optional interactive Telegram `/start` from the client while serve is up | [#4](https://github.com/Anna-Hax/JUNO/issues/4)                               | Proves ADR-01 on a real machine; M2 extension depends on the same loopback API + token |
 | 2     | **Projects v2 board** — ✅ done 2026-08-29 ([session 17](sessions/17-session-projects-board.md)); board [#1](https://github.com/users/Anna-Hax/projects/1) + auto-add secrets | [#9](https://github.com/Anna-Hax/JUNO/issues/9)                               | M2 will create many tickets; board keeps Ready / In Progress / Done honest             |
-| 3     | **Branch protection** on `main` (require CI Python + PR Checks)                                                                                                    | (repo Settings)                                                               | Stops accidental direct pushes during the extension wave                               |
-| 4     | **Close / note M1 milestone** on GitHub if still open with 0 open issues                                                                                           | Milestone [M1: v1.0 Foundation](https://github.com/Anna-Hax/JUNO/milestone/7) | Hygiene only                                                                           |
+| 3     | **Branch protection** on `main` — ✅ done 2026-08-29 ([session 18](sessions/18-session-before-m2-ops.md)) | (repo Settings)                                                               | Stops accidental direct pushes during the extension wave                               |
+| 4     | **Close / note M1 milestone** — ✅ closed 2026-08-29 ([M1 milestone](https://github.com/Anna-Hax/JUNO/milestone/7)) | Milestone [M1: v1.0 Foundation](https://github.com/Anna-Hax/JUNO/milestone/7) | Hygiene only                                                                           |
 
 
 
@@ -52,6 +52,12 @@ gh auth refresh -h github.com -s project,read:project
 ```
 
 Board: [JUNO Roadmap](https://github.com/users/Anna-Hax/projects/1). Secrets `PROJECT_PAT` + `PROJECT_NUMBER=1` set for `.github/workflows/project-automation.yml`.
+
+---
+
+## Before M2 — **complete** (2026-08-29)
+
+All four prep items done. Next: expand epic [#25](https://github.com/Anna-Hax/JUNO/issues/25) and start M2 coding (Spike S2 first).
 
 ---
 

--- a/docs/sessions/01-github-setup.md
+++ b/docs/sessions/01-github-setup.md
@@ -81,4 +81,10 @@ PR template: `.github/PULL_REQUEST_TEMPLATE.md`
 
 ## Branch protection
 
-Not enabled yet. Recommended after board exists: require PR + `CI Python` + `PR Checks` before merge to `main`.
+**Enabled** on `main` (2026-08-29): require PR + `lint-test (ubuntu-latest)`, `lint-test (windows-latest)`, `pr-hygiene`.
+
+Re-apply from repo root:
+
+```powershell
+gh api repos/Anna-Hax/JUNO/branches/main/protection -X PUT --input scripts/branch-protection-main.json
+```

--- a/docs/sessions/18-session-before-m2-ops.md
+++ b/docs/sessions/18-session-before-m2-ops.md
@@ -1,0 +1,33 @@
+# Session 18 — Before M2 ops (branch protection + M1 close)
+
+**Date:** 2026-08-29  
+**Branch:** `chore/before-m2-ops`
+
+## What changed
+
+- Applied **`main` branch protection** via GitHub API (documented in `scripts/branch-protection-main.json`):
+  - Required checks: `lint-test (ubuntu-latest)`, `lint-test (windows-latest)`, `pr-hygiene`
+  - PR required (0 approving reviews — solo maintainer)
+  - No force-push / delete on `main`
+- Closed milestone **[M1: v1.0 Foundation](https://github.com/Anna-Hax/JUNO/milestone/7)** (0 open issues, 14 closed).
+- Updated `docs/next-work.md`, `docs/sessions/01-github-setup.md`, `docs/v1.0-release-gate.md`.
+
+## How to re-apply branch protection
+
+```powershell
+gh api repos/Anna-Hax/JUNO/branches/main/protection -X PUT --input scripts/branch-protection-main.json
+gh api repos/Anna-Hax/JUNO/branches/main/protection
+```
+
+## Verify
+
+- Settings → Branches → `main` shows required status checks.
+- Direct push to `main` should be rejected (use PRs).
+- M1 milestone shows **Closed**.
+
+## Links
+
+| Doc | Role |
+|-----|------|
+| [next-work.md](../next-work.md) | Before-M2 queue |
+| [01-github-setup.md](01-github-setup.md) | Board + protection |

--- a/docs/sessions/README.md
+++ b/docs/sessions/README.md
@@ -23,6 +23,7 @@ Living notes for what was implemented, how GitHub is set up, and what to do next
 | [15-session-v1-release-gate.md](15-session-v1-release-gate.md) | **M1 #24** — v1.0 release gate |
 | [16-session-spike-s1-live.md](16-session-spike-s1-live.md) | **#4** — Live Spike S1 (shared-loop smoke) |
 | [17-session-projects-board.md](17-session-projects-board.md) | **#9** — Projects v2 board + auto-add |
+| [18-session-before-m2-ops.md](18-session-before-m2-ops.md) | Before M2 — branch protection + M1 close |
 | [v1.0-release-gate.md](../v1.0-release-gate.md) | M1 checklist (all P0 closed) |
 
 Architecture decisions live in [`../adr/`](../adr/). Product requirements: [`../../personal-knowledge-graph-prd.md](../../personal-knowledge-graph-prd.md).

--- a/docs/v1.0-release-gate.md
+++ b/docs/v1.0-release-gate.md
@@ -49,10 +49,12 @@ This checklist closes issue **#24**. Acceptance: **all M1 P0 issues closed**.
 
 ## Manual smoke (operator)
 
-Still tracked under M0 (not blocking the v1.0 tag):
+Completed:
 
-1. [#4](https://github.com/Anna-Hax/JUNO/issues/4) — fill `.env`, `juno serve`, Telegram `/start` + `GET /health`
-2. [#9](https://github.com/Anna-Hax/JUNO/issues/9) — Projects v2 board bootstrap
+1. [#4](https://github.com/Anna-Hax/JUNO/issues/4) — fill `.env`, `juno serve`, Telegram + `GET /health` ([session 16](sessions/16-session-spike-s1-live.md))
+2. [#9](https://github.com/Anna-Hax/JUNO/issues/9) — Projects v2 board ([session 17](sessions/17-session-projects-board.md))
+
+M1 milestone **closed** 2026-08-29; `main` branch protection enabled ([session 18](sessions/18-session-before-m2-ops.md)).
 
 ---
 

--- a/scripts/branch-protection-main.json
+++ b/scripts/branch-protection-main.json
@@ -1,0 +1,19 @@
+{
+  "required_status_checks": {
+    "strict": true,
+    "contexts": [
+      "lint-test (ubuntu-latest)",
+      "lint-test (windows-latest)",
+      "pr-hygiene"
+    ]
+  },
+  "enforce_admins": false,
+  "required_pull_request_reviews": {
+    "required_approving_review_count": 0,
+    "dismiss_stale_reviews": false
+  },
+  "restrictions": null,
+  "required_linear_history": false,
+  "allow_force_pushes": false,
+  "allow_deletions": false
+}


### PR DESCRIPTION
## Summary
- Add `scripts/branch-protection-main.json` and session 18 documenting `main` protection (lint-test ubuntu/windows + pr-hygiene).
- Mark M1 milestone closed and Before-M2 prep complete in docs.
- Refs #25 (unblocks M2 browser capture wave).

## Test plan
- [x] Branch protection applied on GitHub
- [x] M1 milestone closed (0 open)
- [x] CI green
