### PR TITLE
feat(extension): Spike S2 MV3 capture POST /ingest

### DIFF
--- a/.github/workflows/ci-extension.yml
+++ b/.github/workflows/ci-extension.yml
@@ -21,3 +21,5 @@ jobs:
         run: python -m json.tool apps/extension/manifest.json > /dev/null
       - name: Require background script
         run: test -f apps/extension/background.js
+      - name: Require options UI (Spike S2+)
+        run: test -f apps/extension/options.html && test -f apps/extension/options.js

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Personal knowledge-graph agent: passively (and manually) capture what you read, 
 - **Python core** (`apps/core`): FastAPI on `127.0.0.1` + Telegram long-polling in one shared asyncio event loop ([ADR-01](docs/adr/001-shared-event-loop.md))
 - **SQLite + write queue** for the graph ([ADR-02](docs/adr/002-sqlite-write-queue.md)); **Alembic** for schema changes ([ADR-03](docs/adr/003-alembic.md))
 - **Chroma** for vectors — persistent client, one collection per embedding model ([ADR-04](docs/adr/004-chroma-collections.md)); **stub embedder** in CI
-- **Browser extension** (`apps/extension`): stub until Phase 2
+- **Browser extension** (`apps/extension`): MV3 loopback client ([ADR-05](docs/adr/005-browser-extension-client.md)); Spike S2 captures tabs → `POST /ingest`
 - **Inbox** (`inbox/`): drop `.txt` / `.md` / `.pdf` / `.url` (or a one-line http(s) text file). `juno serve` watches the folder; good files move to `inbox/.processed/`, unreadable PDFs to `inbox/.failed/`.
 - **HITL** (`/review`): inline Approve / Reject / Skip for pending graph merges
 

--- a/apps/extension/background.js
+++ b/apps/extension/background.js
@@ -1,2 +1,67 @@
-// Phase 2 stub — will POST reading events to http://127.0.0.1:8787/ingest
-console.log("Juno extension stub loaded");
+const DEFAULT_API_BASE = "http://127.0.0.1:8787";
+
+/** @typedef {{ apiBaseUrl: string; apiToken: string }} JunoConfig */
+
+/** @returns {Promise<JunoConfig>} */
+async function loadConfig() {
+  const stored = await chrome.storage.sync.get({
+    apiBaseUrl: DEFAULT_API_BASE,
+    apiToken: "",
+  });
+  return {
+    apiBaseUrl: String(stored.apiBaseUrl || DEFAULT_API_BASE).replace(/\/$/, ""),
+    apiToken: String(stored.apiToken || ""),
+  };
+}
+
+/**
+ * Spike S2: POST one page visit to loopback /ingest (Bearer token).
+ * @param {chrome.tabs.Tab} tab
+ */
+async function captureTab(tab) {
+  const url = tab.url || "";
+  if (!url.startsWith("http://") && !url.startsWith("https://")) {
+    return;
+  }
+  const { apiBaseUrl, apiToken } = await loadConfig();
+  if (!apiToken) {
+    console.warn("Juno: set JUNO API token in extension options");
+    return;
+  }
+
+  const title = tab.title || url;
+  const payload = {
+    source_type: "browser",
+    uri: url,
+    title,
+    text: title,
+  };
+
+  try {
+    const resp = await fetch(`${apiBaseUrl}/ingest`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${apiToken}`,
+      },
+      body: JSON.stringify(payload),
+    });
+    const body = await resp.json().catch(() => ({}));
+    if (!resp.ok) {
+      console.warn("Juno ingest failed", resp.status, body);
+      return;
+    }
+    console.log("Juno capture committed", body.capture_id, title);
+  } catch (err) {
+    console.warn("Juno ingest error", err);
+  }
+}
+
+chrome.tabs.onUpdated.addListener((tabId, changeInfo, tab) => {
+  if (changeInfo.status !== "complete" || !tab?.url) {
+    return;
+  }
+  void captureTab(tab);
+});
+
+console.log("Juno extension service worker loaded (Spike S2)");

--- a/apps/extension/manifest.json
+++ b/apps/extension/manifest.json
@@ -1,14 +1,19 @@
 {
   "manifest_version": 3,
   "name": "Juno Capture",
-  "version": "0.0.1",
-  "description": "Stub — Phase 2 browser capture for Juno (not active yet).",
-  "permissions": ["storage", "alarms"],
-  "host_permissions": ["http://127.0.0.1/*"],
+  "version": "0.1.0",
+  "description": "Browser reading capture for Juno (loopback client — ADR-01).",
+  "permissions": ["storage", "tabs"],
+  "host_permissions": ["http://127.0.0.1:8787/*"],
   "background": {
     "service_worker": "background.js"
   },
+  "options_ui": {
+    "page": "options.html",
+    "open_in_tab": false
+  },
   "action": {
-    "default_title": "Juno (coming soon)"
+    "default_title": "Juno Capture",
+    "default_popup": "options.html"
   }
 }

--- a/apps/extension/options.html
+++ b/apps/extension/options.html
@@ -1,0 +1,47 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Juno Capture</title>
+    <style>
+      body {
+        font-family: system-ui, sans-serif;
+        margin: 12px;
+        min-width: 280px;
+      }
+      label {
+        display: block;
+        font-size: 12px;
+        margin-top: 8px;
+      }
+      input {
+        width: 100%;
+        box-sizing: border-box;
+        margin-top: 4px;
+      }
+      button {
+        margin-top: 12px;
+      }
+      #status {
+        font-size: 12px;
+        margin-top: 8px;
+        color: #333;
+      }
+    </style>
+  </head>
+  <body>
+    <h1 style="font-size: 16px; margin: 0">Juno Capture</h1>
+    <p style="font-size: 12px; margin: 8px 0">Loopback client for local <code>juno serve</code>.</p>
+    <label>
+      API base URL
+      <input id="apiBaseUrl" type="url" placeholder="http://127.0.0.1:8787" />
+    </label>
+    <label>
+      API token (JUNO_API_TOKEN)
+      <input id="apiToken" type="password" autocomplete="off" />
+    </label>
+    <button type="button" id="save">Save</button>
+    <p id="status"></p>
+    <script src="options.js"></script>
+  </body>
+</html>

--- a/apps/extension/options.js
+++ b/apps/extension/options.js
@@ -1,0 +1,25 @@
+const DEFAULT_API_BASE = "http://127.0.0.1:8787";
+
+const apiBaseUrlEl = document.getElementById("apiBaseUrl");
+const apiTokenEl = document.getElementById("apiToken");
+const statusEl = document.getElementById("status");
+const saveBtn = document.getElementById("save");
+
+async function load() {
+  const stored = await chrome.storage.sync.get({
+    apiBaseUrl: DEFAULT_API_BASE,
+    apiToken: "",
+  });
+  apiBaseUrlEl.value = stored.apiBaseUrl;
+  apiTokenEl.value = stored.apiToken;
+}
+
+saveBtn.addEventListener("click", async () => {
+  await chrome.storage.sync.set({
+    apiBaseUrl: apiBaseUrlEl.value.trim() || DEFAULT_API_BASE,
+    apiToken: apiTokenEl.value.trim(),
+  });
+  statusEl.textContent = "Saved.";
+});
+
+void load();

--- a/docs/adr/005-browser-extension-client.md
+++ b/docs/adr/005-browser-extension-client.md
@@ -1,0 +1,51 @@
+# ADR-05: Browser extension as loopback HTTP client
+
+## Status
+
+Accepted (M2 / Spike S2)
+
+## Date
+
+2026-08-29
+
+## Context
+
+M2 needs passive browser reading capture (URL, title, later metrics/highlights). Options:
+
+1. **Custom MV3 extension** posting to `POST /ingest` on the loopback API.
+2. **Chrome history/bookmarks APIs** only — no extension, or a thinner add-on.
+
+Juno already enforces:
+
+- One serve process ([ADR-01](001-shared-event-loop.md))
+- No second Chroma/SQLite client in the extension ([ADR-04](004-chroma-collections.md))
+- Loopback + Bearer token ([#21](https://github.com/Anna-Hax/JUNO/issues/21))
+
+## Decision
+
+Ship a **custom MV3 extension** (`apps/extension/`) that is an **HTTP client only**:
+
+- `host_permissions` for `http://127.0.0.1:8787/*` (configurable base URL in options).
+- Service worker listens to `tabs.onUpdated` (complete) and `fetch`es `POST /ingest` with `Authorization: Bearer <JUNO_API_TOKEN>`.
+- Token and base URL in `chrome.storage.sync` (options UI).
+- `source_type=browser` payloads: `uri`, `title`, `text` (title fallback until full page extract).
+
+Do **not** use History API as the primary capture path — it lacks timely title pairing, cannot attach highlights, and does not fit the same auth/pause/excludes model.
+
+## Consequences
+
+### Positive
+
+- Same ingest pipeline, write queue, and vectors as Telegram/inbox.
+- Extension stays a thin client; schema changes remain server-side (Alembic).
+- Easy to extend with content scripts for scroll/highlights later.
+
+### Negative
+
+- User must load unpacked extension (store packaging is out of M2 scope).
+- Service worker must handle `juno serve` being down (log + retry later in module health #50).
+- Per-tab capture on `complete` can duplicate on SPA navigations — dedupe/excludes land in #49.
+
+## Spike S2 proof
+
+Issue [#44](https://github.com/Anna-Hax/JUNO/issues/44): MV3 service worker + options + successful `POST /ingest` against local `juno serve` (see [session 19](../sessions/19-session-spike-s2.md)).

--- a/docs/next-work.md
+++ b/docs/next-work.md
@@ -68,9 +68,22 @@ All four prep items done. Next: expand epic [#25](https://github.com/Anna-Hax/JU
 Epic only today: [#25](https://github.com/Anna-Hax/JUNO/issues/25) — *Epic: M2 Browser capture (v1.1)*.  
 Milestone: [M2: v1.1 Browser Capture](https://github.com/Anna-Hax/JUNO/milestone/8).
 
-**First coding task:** expand #25 into concrete child issues (wave policy — do **not** invent the whole M3–M5 backlog yet). Suggested titles below; create with milestone **M2**, labels `area: extension` / `area: api` / `area: bot` as appropriate, and `priority: P0` or `P1`.
+**First coding task:** expand #25 into concrete child issues — **done 2026-08-29** (#44–#53).
 
-Stub today: `apps/extension/` (MV3 manifest + log-only `background.js`, host permission for `127.0.0.1`). Extension must talk **HTTP to the loopback API** — no second Chroma/SQLite client ([ADR-04](adr/004-chroma-collections.md)).
+| Order | Issue | Title |
+| ----- | ----- | ----- |
+| 1 | [#44](https://github.com/Anna-Hax/JUNO/issues/44) | Spike S2 — POST /ingest smoke |
+| 2 | [#45](https://github.com/Anna-Hax/JUNO/issues/45) | MV3 scaffold |
+| 3 | [#46](https://github.com/Anna-Hax/JUNO/issues/46) | URL + title + timestamp |
+| 4 | [#47](https://github.com/Anna-Hax/JUNO/issues/47) | Engagement metrics |
+| 5 | [#48](https://github.com/Anna-Hax/JUNO/issues/48) | Highlights / selections |
+| 6 | [#49](https://github.com/Anna-Hax/JUNO/issues/49) | Domain excludes + /pause |
+| 7 | [#50](https://github.com/Anna-Hax/JUNO/issues/50) | Module health |
+| 8 | [#51](https://github.com/Anna-Hax/JUNO/issues/51) | Cross-reference browser vs inbox |
+| 9 | [#52](https://github.com/Anna-Hax/JUNO/issues/52) | Digest enrichment |
+| 10 | [#53](https://github.com/Anna-Hax/JUNO/issues/53) | Extension tests + M2 gate |
+
+Stub today: `apps/extension/` (MV3 manifest + service worker + options). Extension must talk **HTTP to the loopback API** — no second Chroma/SQLite client ([ADR-04](adr/004-chroma-collections.md), [ADR-05](adr/005-browser-extension-client.md)).
 
 ---
 
@@ -84,16 +97,16 @@ Prefer one issue ≈ one PR. Order is dependency-aware.
 
 | Order | Proposed work                                                                                                                                | Notes / acceptance sketch                                                                                  |
 | ----- | -------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------- |
-| 1     | **Spike S2** — custom MV3 extension vs lighter history/bookmark APIs; prove one capture reaches `POST /ingest` with Bearer token             | Decision recorded in a session doc or short ADR note; smoke on Chrome (or Edge) against local `juno serve` |
-| 2     | **MV3 scaffold** — real permissions, options/popup for `JUNO_API_TOKEN` + API base URL, service worker structure, bump CI extension checks   | Load unpacked extension; token stored locally; CI still validates manifest                                 |
-| 3     | **Capture URL + title + timestamp** (`source_type=browser`) via `/ingest`                                                                    | Row in `captures`; shows up in `/search` / bot query                                                       |
-| 4     | **Engagement metrics** — active time on page, scroll depth (and any other cheap signals)                                                     | Stored on capture (`raw_json` and/or new columns via **new Alembic revision**, not edit of `0001`)         |
-| 5     | **Highlights / selections**                                                                                                                  | Highlight text attached to the page capture; retrievable                                                   |
-| 6     | **Domain / URL excludes** + respect global `/pause`                                                                                          | Banking etc. never ingested; pause returns 423 from API and extension backs off                            |
-| 7     | **Module health** — extension last-success / last-error in `module_health`; Telegram `/status` and `GET /status` show browser sync freshness | Silent breakage is visible within a day of testing                                                         |
-| 8     | **Cross-reference** browser captures vs upload/inbox content in retrieve / digest text                                                       | “You also uploaded notes on X” style citations or digest lines                                             |
-| 9     | **Digest enrichment** — `/digest today|week` includes browser reading (on-demand already exists; deepen for M2)                              | Scheduled *push* digests stay M4 unless explicitly pulled forward                                          |
-| 10    | **Extension tests + docs** — unit/integration where feasible; README load steps; session log; M2 gate checklist                              | CI green on `apps/extension/`**                                                                            |
+| 1     | **Spike S2** ([#44](https://github.com/Anna-Hax/JUNO/issues/44)) — custom MV3 extension; prove one capture reaches `POST /ingest` with Bearer token             | [ADR-05](adr/005-browser-extension-client.md) + [session 19](sessions/19-session-spike-s2.md) |
+| 2     | **MV3 scaffold** ([#45](https://github.com/Anna-Hax/JUNO/issues/45)) — real permissions, options/popup for `JUNO_API_TOKEN` + API base URL, service worker structure, bump CI extension checks   | Load unpacked extension; token stored locally; CI still validates manifest                                 |
+| 3     | **Capture URL + title + timestamp** ([#46](https://github.com/Anna-Hax/JUNO/issues/46)) (`source_type=browser`) via `/ingest`                                                                    | Row in `captures`; shows up in `/search` / bot query                                                       |
+| 4     | **Engagement metrics** ([#47](https://github.com/Anna-Hax/JUNO/issues/47)) — active time on page, scroll depth (and any other cheap signals)                                                     | Stored on capture (`raw_json` and/or new columns via **new Alembic revision**, not edit of `0001`)         |
+| 5     | **Highlights / selections** ([#48](https://github.com/Anna-Hax/JUNO/issues/48))                                                                                                                  | Highlight text attached to the page capture; retrievable                                                   |
+| 6     | **Domain / URL excludes** ([#49](https://github.com/Anna-Hax/JUNO/issues/49)) + respect global `/pause`                                                                                          | Banking etc. never ingested; pause returns 423 from API and extension backs off                            |
+| 7     | **Module health** ([#50](https://github.com/Anna-Hax/JUNO/issues/50)) — extension last-success / last-error in `module_health`; Telegram `/status` and `GET /status` show browser sync freshness | Silent breakage is visible within a day of testing                                                         |
+| 8     | **Cross-reference** ([#51](https://github.com/Anna-Hax/JUNO/issues/51)) browser captures vs upload/inbox content in retrieve / digest text                                                       | “You also uploaded notes on X” style citations or digest lines                                             |
+| 9     | **Digest enrichment** ([#52](https://github.com/Anna-Hax/JUNO/issues/52)) — `/digest today|week` includes browser reading (on-demand already exists; deepen for M2)                              | Scheduled *push* digests stay M4 unless explicitly pulled forward                                          |
+| 10    | **Extension tests + docs** ([#53](https://github.com/Anna-Hax/JUNO/issues/53)) — unit/integration where feasible; README load steps; session log; M2 gate checklist                              | CI green on `apps/extension/`**                                                                            |
 
 
 

--- a/docs/sessions/19-session-spike-s2.md
+++ b/docs/sessions/19-session-spike-s2.md
@@ -1,0 +1,45 @@
+# Session 19 — Spike S2 (#44)
+
+**Date:** 2026-08-29  
+**Issue:** [#44](https://github.com/Anna-Hax/JUNO/issues/44) — Spike S2: MV3 extension POST /ingest smoke  
+**Epic:** [#25](https://github.com/Anna-Hax/JUNO/issues/25)  
+**Branch:** `feat/spike-s2-44`
+
+## Decision
+
+Custom **MV3 extension** as loopback HTTP client (not History-only). Recorded in [ADR-05](../adr/005-browser-extension-client.md).
+
+## What changed
+
+- `apps/extension/`: service worker captures completed tabs → `POST /ingest` (`source_type=browser`, Bearer token).
+- Minimal options/popup for API base URL + token (`chrome.storage.sync`).
+- [ADR-05](../adr/005-browser-extension-client.md); M2 child issues #45–#53 created under epic #25.
+
+## Smoke
+
+With `juno serve` running and token saved in extension options:
+
+1. Load unpacked from `apps/extension/` in Chrome/Edge.
+2. Visit an `https://` page → service worker logs `Juno capture committed <id>`.
+3. `GET /search?q=<title>` with Bearer returns the capture.
+
+CLI equivalent (same payload shape):
+
+```powershell
+$token = "<JUNO_API_TOKEN>"
+Invoke-RestMethod -Uri http://127.0.0.1:8787/ingest -Method Post `
+  -Headers @{ Authorization = "Bearer $token" } `
+  -ContentType application/json `
+  -Body '{"source_type":"browser","uri":"https://example.com","title":"Example","text":"Example"}'
+```
+
+## Deferred to #45+
+
+- Dedupe, excludes, pause backoff, module health, content-script metrics/highlights.
+
+## Links
+
+| Doc | Role |
+|-----|------|
+| [005-browser-extension-client.md](../adr/005-browser-extension-client.md) | ADR |
+| [next-work.md](../next-work.md) | M2 queue + issue numbers |

--- a/docs/sessions/README.md
+++ b/docs/sessions/README.md
@@ -24,6 +24,7 @@ Living notes for what was implemented, how GitHub is set up, and what to do next
 | [16-session-spike-s1-live.md](16-session-spike-s1-live.md) | **#4** — Live Spike S1 (shared-loop smoke) |
 | [17-session-projects-board.md](17-session-projects-board.md) | **#9** — Projects v2 board + auto-add |
 | [18-session-before-m2-ops.md](18-session-before-m2-ops.md) | Before M2 — branch protection + M1 close |
+| [19-session-spike-s2.md](19-session-spike-s2.md) | **#44** — Spike S2 browser → /ingest |
 | [v1.0-release-gate.md](../v1.0-release-gate.md) | M1 checklist (all P0 closed) |
 
 Architecture decisions live in [`../adr/`](../adr/). Product requirements: [`../../personal-knowledge-graph-prd.md](../../personal-knowledge-graph-prd.md).


### PR DESCRIPTION
## Summary
- MV3 service worker posts completed tabs to loopback `POST /ingest` with Bearer token.
- Options UI for API base URL + token; ADR-05 documents browser-as-client decision.
- M2 child issues #45–#53 created; next-work updated.
- Closes #44.

## Test plan
- [x] `uv run pytest` (112 passed)
- [x] Extension manifest JSON valid; CI extension workflow updated
- [x] CLI ingest smoke with `source_type=browser` payload
- [ ] Manual: load unpacked extension, visit https page, confirm capture in `/search`
