### PR TITLE
feat(extension): MV3 scaffold with lib, popup, and README

### DIFF
--- a/.github/workflows/ci-extension.yml
+++ b/.github/workflows/ci-extension.yml
@@ -23,3 +23,11 @@ jobs:
         run: test -f apps/extension/background.js
       - name: Require options UI (Spike S2+)
         run: test -f apps/extension/options.html && test -f apps/extension/options.js
+      - name: Require popup and shared lib
+        run: |
+          test -f apps/extension/popup.html
+          test -f apps/extension/popup.js
+          test -f apps/extension/lib/config.js
+          test -f apps/extension/lib/api.js
+      - name: Require extension README
+        run: test -f apps/extension/README.md

--- a/apps/extension/README.md
+++ b/apps/extension/README.md
@@ -1,0 +1,29 @@
+# Juno Capture (browser extension)
+
+MV3 **loopback client** for [Juno](../../README.md). Sends page visits to local `juno serve` via `POST /ingest` — no direct SQLite/Chroma access ([ADR-05](../../docs/adr/005-browser-extension-client.md)).
+
+## Load unpacked (Chrome / Edge)
+
+1. Start the core: `cd apps/core && uv run juno serve`
+2. Open `chrome://extensions` → **Developer mode** → **Load unpacked**
+3. Select this folder: `apps/extension/`
+4. Click the Juno toolbar icon → **Options…** (or right-click → Options)
+5. Set **API base URL** (`http://127.0.0.1:8787`) and **API token** (same as `JUNO_API_TOKEN` in repo-root `.env`)
+6. Browse an `https://` page — check service worker console for `Juno capture committed`
+
+## Layout
+
+| Path | Role |
+|------|------|
+| `manifest.json` | MV3 permissions (`storage`, `tabs`, loopback host) |
+| `background.js` | Service worker — tab capture orchestration |
+| `lib/config.js` | `chrome.storage.sync` settings |
+| `lib/api.js` | Bearer-authenticated fetch to `/status` and `/ingest` |
+| `options.html` | Full settings page |
+| `popup.html` | Quick connection status |
+
+## Privacy
+
+- Only talks to `127.0.0.1` (configurable base URL).
+- Token stays in extension storage on your machine.
+- Respects global capture pause when API returns 423 (see core `/pause`).

--- a/apps/extension/background.js
+++ b/apps/extension/background.js
@@ -1,21 +1,7 @@
-const DEFAULT_API_BASE = "http://127.0.0.1:8787";
-
-/** @typedef {{ apiBaseUrl: string; apiToken: string }} JunoConfig */
-
-/** @returns {Promise<JunoConfig>} */
-async function loadConfig() {
-  const stored = await chrome.storage.sync.get({
-    apiBaseUrl: DEFAULT_API_BASE,
-    apiToken: "",
-  });
-  return {
-    apiBaseUrl: String(stored.apiBaseUrl || DEFAULT_API_BASE).replace(/\/$/, ""),
-    apiToken: String(stored.apiToken || ""),
-  };
-}
+importScripts("lib/config.js", "lib/api.js");
 
 /**
- * Spike S2: POST one page visit to loopback /ingest (Bearer token).
+ * Spike S2+: POST page visit to loopback /ingest (Bearer token).
  * @param {chrome.tabs.Tab} tab
  */
 async function captureTab(tab) {
@@ -23,7 +9,7 @@ async function captureTab(tab) {
   if (!url.startsWith("http://") && !url.startsWith("https://")) {
     return;
   }
-  const { apiBaseUrl, apiToken } = await loadConfig();
+  const { apiBaseUrl, apiToken } = await JunoConfig.load();
   if (!apiToken) {
     console.warn("Juno: set JUNO API token in extension options");
     return;
@@ -37,24 +23,12 @@ async function captureTab(tab) {
     text: title,
   };
 
-  try {
-    const resp = await fetch(`${apiBaseUrl}/ingest`, {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-        Authorization: `Bearer ${apiToken}`,
-      },
-      body: JSON.stringify(payload),
-    });
-    const body = await resp.json().catch(() => ({}));
-    if (!resp.ok) {
-      console.warn("Juno ingest failed", resp.status, body);
-      return;
-    }
-    console.log("Juno capture committed", body.capture_id, title);
-  } catch (err) {
-    console.warn("Juno ingest error", err);
+  const { ok, status, body } = await JunoApi.postIngest(apiBaseUrl, apiToken, payload);
+  if (!ok) {
+    console.warn("Juno ingest failed", status, body);
+    return;
   }
+  console.log("Juno capture committed", body.capture_id, title);
 }
 
 chrome.tabs.onUpdated.addListener((tabId, changeInfo, tab) => {
@@ -64,4 +38,4 @@ chrome.tabs.onUpdated.addListener((tabId, changeInfo, tab) => {
   void captureTab(tab);
 });
 
-console.log("Juno extension service worker loaded (Spike S2)");
+console.log("Juno extension service worker loaded");

--- a/apps/extension/lib/api.js
+++ b/apps/extension/lib/api.js
@@ -1,0 +1,39 @@
+/** Loopback HTTP helpers for Juno serve (ADR-05). Depends on JunoConfig. */
+const JunoApi = {
+  /** @param {string} token */
+  authHeaders(token) {
+    return {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${token}`,
+    };
+  },
+
+  /**
+   * @param {string} apiBaseUrl
+   * @param {string} token
+   * @returns {Promise<{ ok: boolean; status: number; body: object }>}
+   */
+  async getStatus(apiBaseUrl, token) {
+    const resp = await fetch(`${apiBaseUrl}/status`, {
+      headers: JunoApi.authHeaders(token),
+    });
+    const body = await resp.json().catch(() => ({}));
+    return { ok: resp.ok, status: resp.status, body };
+  },
+
+  /**
+   * @param {string} apiBaseUrl
+   * @param {string} token
+   * @param {object} payload
+   * @returns {Promise<{ ok: boolean; status: number; body: object }>}
+   */
+  async postIngest(apiBaseUrl, token, payload) {
+    const resp = await fetch(`${apiBaseUrl}/ingest`, {
+      method: "POST",
+      headers: JunoApi.authHeaders(token),
+      body: JSON.stringify(payload),
+    });
+    const body = await resp.json().catch(() => ({}));
+    return { ok: resp.ok, status: resp.status, body };
+  },
+};

--- a/apps/extension/lib/config.js
+++ b/apps/extension/lib/config.js
@@ -1,0 +1,28 @@
+/** Shared Juno extension settings (chrome.storage.sync). */
+const JunoConfig = {
+  DEFAULT_API_BASE: "http://127.0.0.1:8787",
+
+  /** @returns {Promise<{ apiBaseUrl: string; apiToken: string }>} */
+  async load() {
+    const stored = await chrome.storage.sync.get({
+      apiBaseUrl: JunoConfig.DEFAULT_API_BASE,
+      apiToken: "",
+    });
+    return {
+      apiBaseUrl: String(stored.apiBaseUrl || JunoConfig.DEFAULT_API_BASE).replace(/\/$/, ""),
+      apiToken: String(stored.apiToken || ""),
+    };
+  },
+
+  /** @param {{ apiBaseUrl?: string; apiToken?: string }} values */
+  async save(values) {
+    const patch = {};
+    if (values.apiBaseUrl !== undefined) {
+      patch.apiBaseUrl = values.apiBaseUrl.trim() || JunoConfig.DEFAULT_API_BASE;
+    }
+    if (values.apiToken !== undefined) {
+      patch.apiToken = values.apiToken.trim();
+    }
+    await chrome.storage.sync.set(patch);
+  },
+};

--- a/apps/extension/manifest.json
+++ b/apps/extension/manifest.json
@@ -14,6 +14,6 @@
   },
   "action": {
     "default_title": "Juno Capture",
-    "default_popup": "options.html"
+    "default_popup": "popup.html"
   }
 }

--- a/apps/extension/options.html
+++ b/apps/extension/options.html
@@ -42,6 +42,7 @@
     </label>
     <button type="button" id="save">Save</button>
     <p id="status"></p>
+    <script src="lib/config.js"></script>
     <script src="options.js"></script>
   </body>
 </html>

--- a/apps/extension/options.js
+++ b/apps/extension/options.js
@@ -1,23 +1,18 @@
-const DEFAULT_API_BASE = "http://127.0.0.1:8787";
-
 const apiBaseUrlEl = document.getElementById("apiBaseUrl");
 const apiTokenEl = document.getElementById("apiToken");
 const statusEl = document.getElementById("status");
 const saveBtn = document.getElementById("save");
 
 async function load() {
-  const stored = await chrome.storage.sync.get({
-    apiBaseUrl: DEFAULT_API_BASE,
-    apiToken: "",
-  });
-  apiBaseUrlEl.value = stored.apiBaseUrl;
-  apiTokenEl.value = stored.apiToken;
+  const cfg = await JunoConfig.load();
+  apiBaseUrlEl.value = cfg.apiBaseUrl;
+  apiTokenEl.value = cfg.apiToken;
 }
 
 saveBtn.addEventListener("click", async () => {
-  await chrome.storage.sync.set({
-    apiBaseUrl: apiBaseUrlEl.value.trim() || DEFAULT_API_BASE,
-    apiToken: apiTokenEl.value.trim(),
+  await JunoConfig.save({
+    apiBaseUrl: apiBaseUrlEl.value,
+    apiToken: apiTokenEl.value,
   });
   statusEl.textContent = "Saved.";
 });

--- a/apps/extension/popup.html
+++ b/apps/extension/popup.html
@@ -1,0 +1,29 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Juno Capture</title>
+    <style>
+      body {
+        font-family: system-ui, sans-serif;
+        margin: 12px;
+        min-width: 240px;
+      }
+      #status {
+        font-size: 13px;
+        margin: 8px 0;
+      }
+      button {
+        margin-top: 8px;
+      }
+    </style>
+  </head>
+  <body>
+    <strong>Juno Capture</strong>
+    <p id="status">Loading…</p>
+    <button type="button" id="openOptions">Options…</button>
+    <script src="lib/config.js"></script>
+    <script src="lib/api.js"></script>
+    <script src="popup.js"></script>
+  </body>
+</html>

--- a/apps/extension/popup.js
+++ b/apps/extension/popup.js
@@ -1,0 +1,28 @@
+const statusEl = document.getElementById("status");
+const openOptions = document.getElementById("openOptions");
+
+async function refresh() {
+  statusEl.textContent = "Checking…";
+  const { apiBaseUrl, apiToken } = await JunoConfig.load();
+  if (!apiToken) {
+    statusEl.textContent = "Set API token in Options.";
+    return;
+  }
+  try {
+    const { ok, status, body } = await JunoApi.getStatus(apiBaseUrl, apiToken);
+    if (!ok) {
+      statusEl.textContent = `API error ${status}. Is juno serve running?`;
+      return;
+    }
+    const paused = body.capture_paused ? "paused" : "running";
+    statusEl.textContent = `Connected — capture ${paused}.`;
+  } catch {
+    statusEl.textContent = "Cannot reach Juno API. Start juno serve.";
+  }
+}
+
+openOptions.addEventListener("click", () => {
+  chrome.runtime.openOptionsPage();
+});
+
+void refresh();

--- a/docs/next-work.md
+++ b/docs/next-work.md
@@ -73,7 +73,7 @@ Milestone: [M2: v1.1 Browser Capture](https://github.com/Anna-Hax/JUNO/milestone
 | Order | Issue | Title |
 | ----- | ----- | ----- |
 | 1 | [#44](https://github.com/Anna-Hax/JUNO/issues/44) | Spike S2 — POST /ingest smoke |
-| 2 | [#45](https://github.com/Anna-Hax/JUNO/issues/45) | MV3 scaffold |
+| 2 | [#45](https://github.com/Anna-Hax/JUNO/issues/45) | MV3 scaffold — ✅ [session 20](sessions/20-session-mv3-scaffold.md) |
 | 3 | [#46](https://github.com/Anna-Hax/JUNO/issues/46) | URL + title + timestamp |
 | 4 | [#47](https://github.com/Anna-Hax/JUNO/issues/47) | Engagement metrics |
 | 5 | [#48](https://github.com/Anna-Hax/JUNO/issues/48) | Highlights / selections |
@@ -98,7 +98,7 @@ Prefer one issue ≈ one PR. Order is dependency-aware.
 | Order | Proposed work                                                                                                                                | Notes / acceptance sketch                                                                                  |
 | ----- | -------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------- |
 | 1     | **Spike S2** ([#44](https://github.com/Anna-Hax/JUNO/issues/44)) — custom MV3 extension; prove one capture reaches `POST /ingest` with Bearer token             | [ADR-05](adr/005-browser-extension-client.md) + [session 19](sessions/19-session-spike-s2.md) |
-| 2     | **MV3 scaffold** ([#45](https://github.com/Anna-Hax/JUNO/issues/45)) — real permissions, options/popup for `JUNO_API_TOKEN` + API base URL, service worker structure, bump CI extension checks   | Load unpacked extension; token stored locally; CI still validates manifest                                 |
+| 2     | **MV3 scaffold** ([#45](https://github.com/Anna-Hax/JUNO/issues/45)) — ✅ [session 20](sessions/20-session-mv3-scaffold.md)   | Load unpacked extension; token stored locally; CI validates manifest + lib |
 | 3     | **Capture URL + title + timestamp** ([#46](https://github.com/Anna-Hax/JUNO/issues/46)) (`source_type=browser`) via `/ingest`                                                                    | Row in `captures`; shows up in `/search` / bot query                                                       |
 | 4     | **Engagement metrics** ([#47](https://github.com/Anna-Hax/JUNO/issues/47)) — active time on page, scroll depth (and any other cheap signals)                                                     | Stored on capture (`raw_json` and/or new columns via **new Alembic revision**, not edit of `0001`)         |
 | 5     | **Highlights / selections** ([#48](https://github.com/Anna-Hax/JUNO/issues/48))                                                                                                                  | Highlight text attached to the page capture; retrievable                                                   |

--- a/docs/sessions/20-session-mv3-scaffold.md
+++ b/docs/sessions/20-session-mv3-scaffold.md
@@ -1,0 +1,20 @@
+# Session 20 — MV3 scaffold (#45)
+
+**Date:** 2026-08-29  
+**Issue:** [#45](https://github.com/Anna-Hax/JUNO/issues/45)  
+**Branch:** `feat/mv3-scaffold-45`
+
+## What changed
+
+- Refactored extension into `lib/config.js` + `lib/api.js`; thin `background.js` service worker.
+- Separate **popup** (connection status) vs **options** (token + base URL).
+- `apps/extension/README.md` with load-unpacked steps.
+- CI extension job validates lib/, popup, and README.
+
+## Verify
+
+```powershell
+# CI locally
+python -m json.tool apps/extension/manifest.json
+# Load unpacked per apps/extension/README.md; popup shows Connected when serve is up.
+```

--- a/docs/sessions/README.md
+++ b/docs/sessions/README.md
@@ -25,6 +25,7 @@ Living notes for what was implemented, how GitHub is set up, and what to do next
 | [17-session-projects-board.md](17-session-projects-board.md) | **#9** — Projects v2 board + auto-add |
 | [18-session-before-m2-ops.md](18-session-before-m2-ops.md) | Before M2 — branch protection + M1 close |
 | [19-session-spike-s2.md](19-session-spike-s2.md) | **#44** — Spike S2 browser → /ingest |
+| [20-session-mv3-scaffold.md](20-session-mv3-scaffold.md) | **#45** — MV3 scaffold |
 | [v1.0-release-gate.md](../v1.0-release-gate.md) | M1 checklist (all P0 closed) |
 
 Architecture decisions live in [`../adr/`](../adr/). Product requirements: [`../../personal-knowledge-graph-prd.md](../../personal-knowledge-graph-prd.md).


### PR DESCRIPTION
## Summary
- Refactor extension into `lib/config.js` + `lib/api.js`; popup for status, options for settings.
- Add `apps/extension/README.md` with load-unpacked steps.
- Closes #45.

## Test plan
- [x] Extension CI validate job (manifest, lib, popup, README)
- [x] Core pytest unchanged
- [ ] Manual: load unpacked, popup shows Connected when serve is up
