### PR TITLE
feat(extension): browser capture with visited_at timestamp

### DIFF
--- a/.github/workflows/ci-extension.yml
+++ b/.github/workflows/ci-extension.yml
@@ -29,5 +29,6 @@ jobs:
           test -f apps/extension/popup.js
           test -f apps/extension/lib/config.js
           test -f apps/extension/lib/api.js
+          test -f apps/extension/lib/capture.js
       - name: Require extension README
         run: test -f apps/extension/README.md

--- a/apps/core/src/juno/ingest/pipeline.py
+++ b/apps/core/src/juno/ingest/pipeline.py
@@ -132,9 +132,7 @@ class IngestPipeline:
             source_type=source_type,
             raw=raw or {"extractor": "inline"},
         )
-        return await self._commit(
-            extracted, source_type=source_type, captured_at=captured_at
-        )
+        return await self._commit(extracted, source_type=source_type, captured_at=captured_at)
 
     async def ingest_payload(self, payload: dict[str, Any]) -> IngestResult:
         source_type = str(payload.get("source_type") or "api")

--- a/apps/core/src/juno/ingest/pipeline.py
+++ b/apps/core/src/juno/ingest/pipeline.py
@@ -19,6 +19,24 @@ from juno.models import Capture, Chunk, ModuleHealth
 logger = logging.getLogger("juno.ingest.pipeline")
 
 
+def _parse_visited_at(value: Any) -> datetime | None:
+    """Parse extension/client ISO timestamp for captured_at."""
+    if value is None:
+        return None
+    text = str(value).strip()
+    if not text:
+        return None
+    if text.endswith("Z"):
+        text = text[:-1] + "+00:00"
+    try:
+        parsed = datetime.fromisoformat(text)
+    except ValueError:
+        return None
+    if parsed.tzinfo is None:
+        return parsed.replace(tzinfo=UTC)
+    return parsed.astimezone(UTC)
+
+
 class VectorSink(Protocol):
     """Subset of VectorStore used by ingest (ADR-04). Optional until #13 lands."""
 
@@ -105,6 +123,7 @@ class IngestPipeline:
         uri: str | None = None,
         title: str | None = None,
         raw: dict[str, Any] | None = None,
+        captured_at: datetime | None = None,
     ) -> IngestResult:
         extracted = Extracted(
             text=text or "",
@@ -113,7 +132,9 @@ class IngestPipeline:
             source_type=source_type,
             raw=raw or {"extractor": "inline"},
         )
-        return await self._commit(extracted, source_type=source_type)
+        return await self._commit(
+            extracted, source_type=source_type, captured_at=captured_at
+        )
 
     async def ingest_payload(self, payload: dict[str, Any]) -> IngestResult:
         source_type = str(payload.get("source_type") or "api")
@@ -121,20 +142,42 @@ class IngestPipeline:
         uri = payload.get("uri")
         text = payload.get("text")
         title = payload.get("title")
+        raw = payload.get("raw_json")
+        if not isinstance(raw, dict):
+            raw = None
+        visited_at = _parse_visited_at(payload.get("visited_at"))
+        if visited_at is None and raw is not None:
+            visited_at = _parse_visited_at(raw.get("visited_at"))
 
         if path_val:
             return await self.ingest_path(Path(str(path_val)), source_type=source_type)
         if isinstance(uri, str) and uri.startswith(("http://", "https://")) and not text:
             kind = source_type if source_type not in {"api", ""} else "url"
             return await self.ingest_url(uri, source_type=kind)
+        browser_raw = raw or {}
+        if source_type == "browser":
+            browser_raw = {
+                **browser_raw,
+                "visited_at": (visited_at or datetime.now(UTC)).isoformat(),
+                "uri": uri,
+                "title": title,
+            }
         return await self.ingest_text(
             text=str(text) if text is not None else "",
             source_type=source_type,
             uri=str(uri) if uri else None,
             title=str(title) if title else None,
+            raw=browser_raw if source_type == "browser" else raw,
+            captured_at=visited_at,
         )
 
-    async def _commit(self, extracted: Extracted, *, source_type: str) -> IngestResult:
+    async def _commit(
+        self,
+        extracted: Extracted,
+        *,
+        source_type: str,
+        captured_at: datetime | None = None,
+    ) -> IngestResult:
         pieces = chunk_text(extracted.text or "")
 
         async def write(session: AsyncSession) -> tuple[int, list[tuple[str, str]]]:
@@ -146,6 +189,8 @@ class IngestPipeline:
                 raw_json=extracted.raw or None,
                 status="committed",
             )
+            if captured_at is not None:
+                capture.captured_at = captured_at
             session.add(capture)
             await session.flush()
             stored: list[tuple[str, str]] = []

--- a/apps/core/tests/test_ingest.py
+++ b/apps/core/tests/test_ingest.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from datetime import UTC, datetime
 from pathlib import Path
 
 import httpx
@@ -256,3 +257,32 @@ async def test_ingest_api_persists_text(settings, db, pipeline):
     assert body["status"] == "committed"
     assert body["chunk_count"] == 1
     assert blocked.status_code == 423
+
+
+@pytest.mark.asyncio
+async def test_browser_payload_stores_visited_at_and_raw_json(db, pipeline):
+    when = datetime(2026, 8, 29, 12, 0, tzinfo=UTC)
+    result = await pipeline.ingest_payload(
+        {
+            "source_type": "browser",
+            "uri": "https://example.com/page",
+            "title": "Example page",
+            "text": "Example page",
+            "visited_at": when.isoformat(),
+        }
+    )
+    assert result.status == "committed"
+    assert result.capture_id is not None
+
+    async def read(session):
+        row = await session.get(Capture, result.capture_id)
+        assert row is not None
+        assert row.source_type == "browser"
+        assert row.uri == "https://example.com/page"
+        assert row.title == "Example page"
+        assert row.captured_at.replace(tzinfo=UTC) == when
+        assert row.raw_json is not None
+        assert row.raw_json.get("visited_at") == when.isoformat()
+        return row
+
+    await db.read(read)

--- a/apps/extension/background.js
+++ b/apps/extension/background.js
@@ -1,7 +1,7 @@
-importScripts("lib/config.js", "lib/api.js");
+importScripts("lib/config.js", "lib/api.js", "lib/capture.js");
 
 /**
- * Spike S2+: POST page visit to loopback /ingest (Bearer token).
+ * POST page visit to loopback /ingest (Bearer token).
  * @param {chrome.tabs.Tab} tab
  */
 async function captureTab(tab) {
@@ -15,20 +15,13 @@ async function captureTab(tab) {
     return;
   }
 
-  const title = tab.title || url;
-  const payload = {
-    source_type: "browser",
-    uri: url,
-    title,
-    text: title,
-  };
-
+  const payload = JunoCapture.buildPayload(tab);
   const { ok, status, body } = await JunoApi.postIngest(apiBaseUrl, apiToken, payload);
   if (!ok) {
     console.warn("Juno ingest failed", status, body);
     return;
   }
-  console.log("Juno capture committed", body.capture_id, title);
+  console.log("Juno capture committed", body.capture_id, payload.title);
 }
 
 chrome.tabs.onUpdated.addListener((tabId, changeInfo, tab) => {

--- a/apps/extension/lib/capture.js
+++ b/apps/extension/lib/capture.js
@@ -1,0 +1,25 @@
+/** Build browser capture payloads for POST /ingest. */
+const JunoCapture = {
+  /**
+   * @param {chrome.tabs.Tab} tab
+   * @returns {object}
+   */
+  buildPayload(tab) {
+    const url = tab.url || "";
+    const title = tab.title || url;
+    const visitedAt = new Date().toISOString();
+    return {
+      source_type: "browser",
+      uri: url,
+      title,
+      text: title,
+      visited_at: visitedAt,
+      raw_json: {
+        visited_at: visitedAt,
+        uri: url,
+        title,
+        tab_id: tab.id,
+      },
+    };
+  },
+};

--- a/docs/next-work.md
+++ b/docs/next-work.md
@@ -74,7 +74,7 @@ Milestone: [M2: v1.1 Browser Capture](https://github.com/Anna-Hax/JUNO/milestone
 | ----- | ----- | ----- |
 | 1 | [#44](https://github.com/Anna-Hax/JUNO/issues/44) | Spike S2 — POST /ingest smoke |
 | 2 | [#45](https://github.com/Anna-Hax/JUNO/issues/45) | MV3 scaffold — ✅ [session 20](sessions/20-session-mv3-scaffold.md) |
-| 3 | [#46](https://github.com/Anna-Hax/JUNO/issues/46) | URL + title + timestamp |
+| 3 | [#46](https://github.com/Anna-Hax/JUNO/issues/46) | URL + title + timestamp — ✅ [session 21](sessions/21-session-browser-timestamp.md) |
 | 4 | [#47](https://github.com/Anna-Hax/JUNO/issues/47) | Engagement metrics |
 | 5 | [#48](https://github.com/Anna-Hax/JUNO/issues/48) | Highlights / selections |
 | 6 | [#49](https://github.com/Anna-Hax/JUNO/issues/49) | Domain excludes + /pause |
@@ -99,7 +99,7 @@ Prefer one issue ≈ one PR. Order is dependency-aware.
 | ----- | -------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------- |
 | 1     | **Spike S2** ([#44](https://github.com/Anna-Hax/JUNO/issues/44)) — custom MV3 extension; prove one capture reaches `POST /ingest` with Bearer token             | [ADR-05](adr/005-browser-extension-client.md) + [session 19](sessions/19-session-spike-s2.md) |
 | 2     | **MV3 scaffold** ([#45](https://github.com/Anna-Hax/JUNO/issues/45)) — ✅ [session 20](sessions/20-session-mv3-scaffold.md)   | Load unpacked extension; token stored locally; CI validates manifest + lib |
-| 3     | **Capture URL + title + timestamp** ([#46](https://github.com/Anna-Hax/JUNO/issues/46)) (`source_type=browser`) via `/ingest`                                                                    | Row in `captures`; shows up in `/search` / bot query                                                       |
+| 3     | **Capture URL + title + timestamp** ([#46](https://github.com/Anna-Hax/JUNO/issues/46)) — ✅ [session 21](sessions/21-session-browser-timestamp.md)                                                                    | Row in `captures`; shows up in `/search` / bot query                                                       |
 | 4     | **Engagement metrics** ([#47](https://github.com/Anna-Hax/JUNO/issues/47)) — active time on page, scroll depth (and any other cheap signals)                                                     | Stored on capture (`raw_json` and/or new columns via **new Alembic revision**, not edit of `0001`)         |
 | 5     | **Highlights / selections** ([#48](https://github.com/Anna-Hax/JUNO/issues/48))                                                                                                                  | Highlight text attached to the page capture; retrievable                                                   |
 | 6     | **Domain / URL excludes** ([#49](https://github.com/Anna-Hax/JUNO/issues/49)) + respect global `/pause`                                                                                          | Banking etc. never ingested; pause returns 423 from API and extension backs off                            |

--- a/docs/sessions/21-session-browser-timestamp.md
+++ b/docs/sessions/21-session-browser-timestamp.md
@@ -1,0 +1,19 @@
+# Session 21 — Browser URL + title + timestamp (#46)
+
+**Date:** 2026-08-29  
+**Issue:** [#46](https://github.com/Anna-Hax/JUNO/issues/46)  
+**Branch:** `feat/browser-capture-timestamp-46`
+
+## What changed
+
+- Extension `lib/capture.js` sends `visited_at` + `raw_json` on browser ingests.
+- `ingest_payload` persists client timestamp as `captures.captured_at` and stores browser metadata in `raw_json`.
+- Test: `test_browser_payload_stores_visited_at_and_raw_json`.
+
+## Verify
+
+```powershell
+cd apps/core
+$env:EMBEDDING_BACKEND='stub'
+uv run pytest tests/test_ingest.py::test_browser_payload_stores_visited_at_and_raw_json -q
+```

--- a/docs/sessions/README.md
+++ b/docs/sessions/README.md
@@ -26,6 +26,7 @@ Living notes for what was implemented, how GitHub is set up, and what to do next
 | [18-session-before-m2-ops.md](18-session-before-m2-ops.md) | Before M2 — branch protection + M1 close |
 | [19-session-spike-s2.md](19-session-spike-s2.md) | **#44** — Spike S2 browser → /ingest |
 | [20-session-mv3-scaffold.md](20-session-mv3-scaffold.md) | **#45** — MV3 scaffold |
+| [21-session-browser-timestamp.md](21-session-browser-timestamp.md) | **#46** — URL + title + timestamp |
 | [v1.0-release-gate.md](../v1.0-release-gate.md) | M1 checklist (all P0 closed) |
 
 Architecture decisions live in [`../adr/`](../adr/). Product requirements: [`../../personal-knowledge-graph-prd.md](../../personal-knowledge-graph-prd.md).


### PR DESCRIPTION
## Summary
- Extension builds browser payloads with `visited_at` and `raw_json`.
- Ingest pipeline stores client timestamp on `captures.captured_at`.
- Closes #46.

## Test plan
- [x] `test_browser_payload_stores_visited_at_and_raw_json`
- [x] Extension CI validate
- [ ] Full pytest on PR
