### PR TITLE
feat(extension): engagement metrics on browser capture

### DIFF
--- a/.github/workflows/ci-extension.yml
+++ b/.github/workflows/ci-extension.yml
@@ -30,5 +30,7 @@ jobs:
           test -f apps/extension/lib/config.js
           test -f apps/extension/lib/api.js
           test -f apps/extension/lib/capture.js
+          test -f apps/extension/lib/tabs.js
+          test -f apps/extension/content.js
       - name: Require extension README
         run: test -f apps/extension/README.md

--- a/apps/core/src/juno/ingest/pipeline.py
+++ b/apps/core/src/juno/ingest/pipeline.py
@@ -160,6 +160,8 @@ class IngestPipeline:
                 "uri": uri,
                 "title": title,
             }
+            if raw and isinstance(raw.get("metrics"), dict):
+                browser_raw["metrics"] = raw["metrics"]
         return await self.ingest_text(
             text=str(text) if text is not None else "",
             source_type=source_type,

--- a/apps/core/tests/test_ingest.py
+++ b/apps/core/tests/test_ingest.py
@@ -286,3 +286,28 @@ async def test_browser_payload_stores_visited_at_and_raw_json(db, pipeline):
         return row
 
     await db.read(read)
+
+
+@pytest.mark.asyncio
+async def test_browser_payload_stores_engagement_metrics(db, pipeline):
+    when = datetime(2026, 8, 29, 14, 0, tzinfo=UTC)
+    metrics = {"active_time_ms": 42000, "scroll_depth": 0.75}
+    result = await pipeline.ingest_payload(
+        {
+            "source_type": "browser",
+            "uri": "https://example.com/article",
+            "title": "Article",
+            "text": "Article",
+            "visited_at": when.isoformat(),
+            "raw_json": {"metrics": metrics},
+        }
+    )
+    assert result.status == "committed"
+
+    async def read(session):
+        row = await session.get(Capture, result.capture_id)
+        assert row.raw_json is not None
+        assert row.raw_json.get("metrics") == metrics
+        return row
+
+    await db.read(read)

--- a/apps/extension/background.js
+++ b/apps/extension/background.js
@@ -1,10 +1,11 @@
-importScripts("lib/config.js", "lib/api.js", "lib/capture.js");
+importScripts("lib/config.js", "lib/api.js", "lib/capture.js", "lib/tabs.js");
 
 /**
- * POST page visit to loopback /ingest (Bearer token).
+ * POST page visit with optional engagement metrics.
  * @param {chrome.tabs.Tab} tab
+ * @param {object | null} metrics
  */
-async function captureTab(tab) {
+async function captureTab(tab, metrics) {
   const url = tab.url || "";
   if (!url.startsWith("http://") && !url.startsWith("https://")) {
     return;
@@ -15,20 +16,57 @@ async function captureTab(tab) {
     return;
   }
 
-  const payload = JunoCapture.buildPayload(tab);
+  const payload = JunoCapture.buildPayload(tab, metrics);
   const { ok, status, body } = await JunoApi.postIngest(apiBaseUrl, apiToken, payload);
   if (!ok) {
     console.warn("Juno ingest failed", status, body);
     return;
   }
-  console.log("Juno capture committed", body.capture_id, payload.title);
+  console.log("Juno capture committed", body.capture_id, payload.title, metrics || {});
+}
+
+/** @param {number} tabId */
+async function finalizeTab(tabId) {
+  const row = JunoTabs.take(tabId);
+  if (!row) {
+    return;
+  }
+  await captureTab(row.tab, row.metrics);
 }
 
 chrome.tabs.onUpdated.addListener((tabId, changeInfo, tab) => {
-  if (changeInfo.status !== "complete" || !tab?.url) {
+  if (changeInfo.status === "complete" && tab?.url) {
+    JunoTabs.track(tab);
+  }
+});
+
+chrome.tabs.onActivated.addListener(async (activeInfo) => {
+  for (const tabId of JunoTabs.sessions.keys()) {
+    if (tabId !== activeInfo.tabId) {
+      await finalizeTab(tabId);
+    }
+  }
+});
+
+chrome.tabs.onRemoved.addListener((tabId) => {
+  void finalizeTab(tabId);
+});
+
+chrome.runtime.onMessage.addListener((message, sender) => {
+  const tabId = sender.tab?.id;
+  if (tabId == null) {
     return;
   }
-  void captureTab(tab);
+  if (message.type === "juno-metrics" && message.metrics) {
+    JunoTabs.setMetrics(tabId, message.metrics);
+    return;
+  }
+  if (message.type === "juno-page-done") {
+    if (message.metrics) {
+      JunoTabs.setMetrics(tabId, message.metrics);
+    }
+    void finalizeTab(tabId);
+  }
 });
 
 console.log("Juno extension service worker loaded");

--- a/apps/extension/content.js
+++ b/apps/extension/content.js
@@ -1,0 +1,58 @@
+/** Page engagement signals for Juno browser capture (#47). */
+(() => {
+  let activeMs = 0;
+  let lastTick = Date.now();
+  let visible = !document.hidden;
+  let maxScroll = 0;
+
+  function tick() {
+    const now = Date.now();
+    if (visible) {
+      activeMs += now - lastTick;
+    }
+    lastTick = now;
+  }
+
+  function scrollDepth() {
+    const root = document.documentElement;
+    const scrollTop = window.scrollY || root.scrollTop || 0;
+    const viewport = window.innerHeight || root.clientHeight || 1;
+    const total = Math.max(root.scrollHeight - viewport, 1);
+    return Math.min(1, scrollTop / total);
+  }
+
+  function snapshot() {
+    tick();
+    return {
+      active_time_ms: Math.round(activeMs),
+      scroll_depth: Math.round(maxScroll * 1000) / 1000,
+    };
+  }
+
+  function report(finalize) {
+    const metrics = snapshot();
+    chrome.runtime
+      .sendMessage({ type: finalize ? "juno-page-done" : "juno-metrics", metrics })
+      .catch(() => {});
+  }
+
+  document.addEventListener("visibilitychange", () => {
+    tick();
+    visible = !document.hidden;
+    if (!visible) {
+      report(true);
+    }
+  });
+
+  window.addEventListener(
+    "scroll",
+    () => {
+      maxScroll = Math.max(maxScroll, scrollDepth());
+    },
+    { passive: true }
+  );
+
+  window.addEventListener("pagehide", () => report(true));
+
+  setInterval(() => report(false), 5000);
+})();

--- a/apps/extension/lib/capture.js
+++ b/apps/extension/lib/capture.js
@@ -2,24 +2,29 @@
 const JunoCapture = {
   /**
    * @param {chrome.tabs.Tab} tab
+   * @param {object | null} metrics
    * @returns {object}
    */
-  buildPayload(tab) {
+  buildPayload(tab, metrics) {
     const url = tab.url || "";
     const title = tab.title || url;
     const visitedAt = new Date().toISOString();
+    const raw = {
+      visited_at: visitedAt,
+      uri: url,
+      title,
+      tab_id: tab.id,
+    };
+    if (metrics) {
+      raw.metrics = metrics;
+    }
     return {
       source_type: "browser",
       uri: url,
       title,
       text: title,
       visited_at: visitedAt,
-      raw_json: {
-        visited_at: visitedAt,
-        uri: url,
-        title,
-        tab_id: tab.id,
-      },
+      raw_json: raw,
     };
   },
 };

--- a/apps/extension/lib/tabs.js
+++ b/apps/extension/lib/tabs.js
@@ -1,0 +1,28 @@
+/** Tab session state for deferred browser capture with metrics. */
+const JunoTabs = {
+  /** @type {Map<number, { tab: chrome.tabs.Tab; metrics: object | null }>} */
+  sessions: new Map(),
+
+  /** @param {chrome.tabs.Tab} tab */
+  track(tab) {
+    if (!tab.id || !tab.url?.startsWith("http")) {
+      return;
+    }
+    this.sessions.set(tab.id, { tab, metrics: null });
+  },
+
+  /** @param {number} tabId @param {object} metrics */
+  setMetrics(tabId, metrics) {
+    const row = this.sessions.get(tabId);
+    if (row) {
+      row.metrics = metrics;
+    }
+  },
+
+  /** @param {number} tabId */
+  take(tabId) {
+    const row = this.sessions.get(tabId);
+    this.sessions.delete(tabId);
+    return row;
+  },
+};

--- a/apps/extension/manifest.json
+++ b/apps/extension/manifest.json
@@ -4,7 +4,14 @@
   "version": "0.1.0",
   "description": "Browser reading capture for Juno (loopback client — ADR-01).",
   "permissions": ["storage", "tabs"],
-  "host_permissions": ["http://127.0.0.1:8787/*"],
+  "host_permissions": ["http://127.0.0.1:8787/*", "http://*/*", "https://*/*"],
+  "content_scripts": [
+    {
+      "matches": ["http://*/*", "https://*/*"],
+      "js": ["content.js"],
+      "run_at": "document_idle"
+    }
+  ],
   "background": {
     "service_worker": "background.js"
   },

--- a/docs/next-work.md
+++ b/docs/next-work.md
@@ -75,7 +75,7 @@ Milestone: [M2: v1.1 Browser Capture](https://github.com/Anna-Hax/JUNO/milestone
 | 1 | [#44](https://github.com/Anna-Hax/JUNO/issues/44) | Spike S2 — POST /ingest smoke |
 | 2 | [#45](https://github.com/Anna-Hax/JUNO/issues/45) | MV3 scaffold — ✅ [session 20](sessions/20-session-mv3-scaffold.md) |
 | 3 | [#46](https://github.com/Anna-Hax/JUNO/issues/46) | URL + title + timestamp — ✅ [session 21](sessions/21-session-browser-timestamp.md) |
-| 4 | [#47](https://github.com/Anna-Hax/JUNO/issues/47) | Engagement metrics |
+| 4 | [#47](https://github.com/Anna-Hax/JUNO/issues/47) | Engagement metrics — ✅ [session 22](sessions/22-session-engagement-metrics.md) |
 | 5 | [#48](https://github.com/Anna-Hax/JUNO/issues/48) | Highlights / selections |
 | 6 | [#49](https://github.com/Anna-Hax/JUNO/issues/49) | Domain excludes + /pause |
 | 7 | [#50](https://github.com/Anna-Hax/JUNO/issues/50) | Module health |
@@ -100,7 +100,7 @@ Prefer one issue ≈ one PR. Order is dependency-aware.
 | 1     | **Spike S2** ([#44](https://github.com/Anna-Hax/JUNO/issues/44)) — custom MV3 extension; prove one capture reaches `POST /ingest` with Bearer token             | [ADR-05](adr/005-browser-extension-client.md) + [session 19](sessions/19-session-spike-s2.md) |
 | 2     | **MV3 scaffold** ([#45](https://github.com/Anna-Hax/JUNO/issues/45)) — ✅ [session 20](sessions/20-session-mv3-scaffold.md)   | Load unpacked extension; token stored locally; CI validates manifest + lib |
 | 3     | **Capture URL + title + timestamp** ([#46](https://github.com/Anna-Hax/JUNO/issues/46)) — ✅ [session 21](sessions/21-session-browser-timestamp.md)                                                                    | Row in `captures`; shows up in `/search` / bot query                                                       |
-| 4     | **Engagement metrics** ([#47](https://github.com/Anna-Hax/JUNO/issues/47)) — active time on page, scroll depth (and any other cheap signals)                                                     | Stored on capture (`raw_json` and/or new columns via **new Alembic revision**, not edit of `0001`)         |
+| 4     | **Engagement metrics** ([#47](https://github.com/Anna-Hax/JUNO/issues/47)) — ✅ [session 22](sessions/22-session-engagement-metrics.md)                                                     | `raw_json.metrics`: active_time_ms, scroll_depth                                                         |
 | 5     | **Highlights / selections** ([#48](https://github.com/Anna-Hax/JUNO/issues/48))                                                                                                                  | Highlight text attached to the page capture; retrievable                                                   |
 | 6     | **Domain / URL excludes** ([#49](https://github.com/Anna-Hax/JUNO/issues/49)) + respect global `/pause`                                                                                          | Banking etc. never ingested; pause returns 423 from API and extension backs off                            |
 | 7     | **Module health** ([#50](https://github.com/Anna-Hax/JUNO/issues/50)) — extension last-success / last-error in `module_health`; Telegram `/status` and `GET /status` show browser sync freshness | Silent breakage is visible within a day of testing                                                         |

--- a/docs/sessions/22-session-engagement-metrics.md
+++ b/docs/sessions/22-session-engagement-metrics.md
@@ -1,0 +1,21 @@
+# Session 22 — Engagement metrics (#47)
+
+**Date:** 2026-08-29  
+**Issue:** [#47](https://github.com/Anna-Hax/JUNO/issues/47)  
+**Branch:** `feat/engagement-metrics-47`
+
+## What changed
+
+- `content.js` tracks **active time** and **scroll depth**; reports on interval and page hide.
+- Background defers ingest until tab switch/close/page-done so metrics are included.
+- Metrics stored in `captures.raw_json.metrics` (`active_time_ms`, `scroll_depth`).
+
+## Verify
+
+```powershell
+cd apps/core
+$env:EMBEDDING_BACKEND='stub'
+uv run pytest tests/test_ingest.py::test_browser_payload_stores_engagement_metrics -q
+```
+
+Load extension, visit a page, scroll, switch tabs — ingest logs should include metrics.

--- a/docs/sessions/README.md
+++ b/docs/sessions/README.md
@@ -27,6 +27,7 @@ Living notes for what was implemented, how GitHub is set up, and what to do next
 | [19-session-spike-s2.md](19-session-spike-s2.md) | **#44** — Spike S2 browser → /ingest |
 | [20-session-mv3-scaffold.md](20-session-mv3-scaffold.md) | **#45** — MV3 scaffold |
 | [21-session-browser-timestamp.md](21-session-browser-timestamp.md) | **#46** — URL + title + timestamp |
+| [22-session-engagement-metrics.md](22-session-engagement-metrics.md) | **#47** — Engagement metrics |
 | [v1.0-release-gate.md](../v1.0-release-gate.md) | M1 checklist (all P0 closed) |
 
 Architecture decisions live in [`../adr/`](../adr/). Product requirements: [`../../personal-knowledge-graph-prd.md](../../personal-knowledge-graph-prd.md).


### PR DESCRIPTION
## Summary
- Content script tracks active time + scroll depth.
- Deferred ingest on tab switch/close/pagehide includes metrics in `raw_json`.
- Closes #47.

## Test plan
- [x] `test_browser_payload_stores_engagement_metrics`
- [x] Extension CI validate
