### PR TITLE
feat(extension): capture text highlights on browser pages

### DIFF
--- a/apps/core/src/juno/ingest/pipeline.py
+++ b/apps/core/src/juno/ingest/pipeline.py
@@ -162,6 +162,8 @@ class IngestPipeline:
             }
             if raw and isinstance(raw.get("metrics"), dict):
                 browser_raw["metrics"] = raw["metrics"]
+            if raw and isinstance(raw.get("highlights"), list):
+                browser_raw["highlights"] = raw["highlights"]
         return await self.ingest_text(
             text=str(text) if text is not None else "",
             source_type=source_type,

--- a/apps/core/tests/test_ingest.py
+++ b/apps/core/tests/test_ingest.py
@@ -311,3 +311,27 @@ async def test_browser_payload_stores_engagement_metrics(db, pipeline):
         return row
 
     await db.read(read)
+
+
+@pytest.mark.asyncio
+async def test_browser_payload_stores_highlights(db, pipeline):
+    highlights = [{"text": "Important quote", "at": "2026-08-29T14:00:00+00:00"}]
+    result = await pipeline.ingest_payload(
+        {
+            "source_type": "browser",
+            "uri": "https://example.com/article",
+            "title": "Article",
+            "text": "Article\n\nImportant quote",
+            "raw_json": {"highlights": highlights},
+        }
+    )
+    assert result.status == "committed"
+
+    async def read(session):
+        row = await session.get(Capture, result.capture_id)
+        assert row.raw_json is not None
+        assert row.raw_json.get("highlights") == highlights
+        assert "Important quote" in (row.text or "")
+        return row
+
+    await db.read(read)

--- a/apps/extension/background.js
+++ b/apps/extension/background.js
@@ -5,7 +5,7 @@ importScripts("lib/config.js", "lib/api.js", "lib/capture.js", "lib/tabs.js");
  * @param {chrome.tabs.Tab} tab
  * @param {object | null} metrics
  */
-async function captureTab(tab, metrics) {
+async function captureTab(tab, metrics, highlights) {
   const url = tab.url || "";
   if (!url.startsWith("http://") && !url.startsWith("https://")) {
     return;
@@ -16,7 +16,7 @@ async function captureTab(tab, metrics) {
     return;
   }
 
-  const payload = JunoCapture.buildPayload(tab, metrics);
+  const payload = JunoCapture.buildPayload(tab, metrics, highlights);
   const { ok, status, body } = await JunoApi.postIngest(apiBaseUrl, apiToken, payload);
   if (!ok) {
     console.warn("Juno ingest failed", status, body);
@@ -31,7 +31,7 @@ async function finalizeTab(tabId) {
   if (!row) {
     return;
   }
-  await captureTab(row.tab, row.metrics);
+  await captureTab(row.tab, row.metrics, row.highlights);
 }
 
 chrome.tabs.onUpdated.addListener((tabId, changeInfo, tab) => {
@@ -59,6 +59,10 @@ chrome.runtime.onMessage.addListener((message, sender) => {
   }
   if (message.type === "juno-metrics" && message.metrics) {
     JunoTabs.setMetrics(tabId, message.metrics);
+    return;
+  }
+  if (message.type === "juno-highlight" && message.highlight) {
+    JunoTabs.addHighlight(tabId, message.highlight);
     return;
   }
   if (message.type === "juno-page-done") {

--- a/apps/extension/content.js
+++ b/apps/extension/content.js
@@ -55,4 +55,21 @@
   window.addEventListener("pagehide", () => report(true));
 
   setInterval(() => report(false), 5000);
+
+  document.addEventListener("mouseup", () => {
+    const selection = window.getSelection();
+    const text = selection?.toString().trim();
+    if (!text || text.length < 3) {
+      return;
+    }
+    chrome.runtime
+      .sendMessage({
+        type: "juno-highlight",
+        highlight: {
+          text: text.slice(0, 2000),
+          at: new Date().toISOString(),
+        },
+      })
+      .catch(() => {});
+  });
 })();

--- a/apps/extension/lib/capture.js
+++ b/apps/extension/lib/capture.js
@@ -3,12 +3,14 @@ const JunoCapture = {
   /**
    * @param {chrome.tabs.Tab} tab
    * @param {object | null} metrics
+   * @param {object[] | null} highlights
    * @returns {object}
    */
-  buildPayload(tab, metrics) {
+  buildPayload(tab, metrics, highlights) {
     const url = tab.url || "";
     const title = tab.title || url;
     const visitedAt = new Date().toISOString();
+    const list = Array.isArray(highlights) ? highlights : [];
     const raw = {
       visited_at: visitedAt,
       uri: url,
@@ -18,11 +20,17 @@ const JunoCapture = {
     if (metrics) {
       raw.metrics = metrics;
     }
+    if (list.length) {
+      raw.highlights = list;
+    }
+    const highlightText = list.map((item) => item.text).filter(Boolean);
+    const text =
+      highlightText.length > 0 ? [title, ...highlightText].join("\n\n") : title;
     return {
       source_type: "browser",
       uri: url,
       title,
-      text: title,
+      text,
       visited_at: visitedAt,
       raw_json: raw,
     };

--- a/apps/extension/lib/tabs.js
+++ b/apps/extension/lib/tabs.js
@@ -1,6 +1,6 @@
 /** Tab session state for deferred browser capture with metrics. */
 const JunoTabs = {
-  /** @type {Map<number, { tab: chrome.tabs.Tab; metrics: object | null }>} */
+  /** @type {Map<number, { tab: chrome.tabs.Tab; metrics: object | null; highlights: object[] }>} */
   sessions: new Map(),
 
   /** @param {chrome.tabs.Tab} tab */
@@ -8,7 +8,7 @@ const JunoTabs = {
     if (!tab.id || !tab.url?.startsWith("http")) {
       return;
     }
-    this.sessions.set(tab.id, { tab, metrics: null });
+    this.sessions.set(tab.id, { tab, metrics: null, highlights: [] });
   },
 
   /** @param {number} tabId @param {object} metrics */
@@ -16,6 +16,14 @@ const JunoTabs = {
     const row = this.sessions.get(tabId);
     if (row) {
       row.metrics = metrics;
+    }
+  },
+
+  /** @param {number} tabId @param {object} highlight */
+  addHighlight(tabId, highlight) {
+    const row = this.sessions.get(tabId);
+    if (row && highlight?.text) {
+      row.highlights.push(highlight);
     }
   },
 

--- a/docs/next-work.md
+++ b/docs/next-work.md
@@ -76,7 +76,7 @@ Milestone: [M2: v1.1 Browser Capture](https://github.com/Anna-Hax/JUNO/milestone
 | 2 | [#45](https://github.com/Anna-Hax/JUNO/issues/45) | MV3 scaffold — ✅ [session 20](sessions/20-session-mv3-scaffold.md) |
 | 3 | [#46](https://github.com/Anna-Hax/JUNO/issues/46) | URL + title + timestamp — ✅ [session 21](sessions/21-session-browser-timestamp.md) |
 | 4 | [#47](https://github.com/Anna-Hax/JUNO/issues/47) | Engagement metrics — ✅ [session 22](sessions/22-session-engagement-metrics.md) |
-| 5 | [#48](https://github.com/Anna-Hax/JUNO/issues/48) | Highlights / selections |
+| 5 | [#48](https://github.com/Anna-Hax/JUNO/issues/48) | Highlights — ✅ [session 23](sessions/23-session-highlights.md) |
 | 6 | [#49](https://github.com/Anna-Hax/JUNO/issues/49) | Domain excludes + /pause |
 | 7 | [#50](https://github.com/Anna-Hax/JUNO/issues/50) | Module health |
 | 8 | [#51](https://github.com/Anna-Hax/JUNO/issues/51) | Cross-reference browser vs inbox |
@@ -101,7 +101,7 @@ Prefer one issue ≈ one PR. Order is dependency-aware.
 | 2     | **MV3 scaffold** ([#45](https://github.com/Anna-Hax/JUNO/issues/45)) — ✅ [session 20](sessions/20-session-mv3-scaffold.md)   | Load unpacked extension; token stored locally; CI validates manifest + lib |
 | 3     | **Capture URL + title + timestamp** ([#46](https://github.com/Anna-Hax/JUNO/issues/46)) — ✅ [session 21](sessions/21-session-browser-timestamp.md)                                                                    | Row in `captures`; shows up in `/search` / bot query                                                       |
 | 4     | **Engagement metrics** ([#47](https://github.com/Anna-Hax/JUNO/issues/47)) — ✅ [session 22](sessions/22-session-engagement-metrics.md)                                                     | `raw_json.metrics`: active_time_ms, scroll_depth                                                         |
-| 5     | **Highlights / selections** ([#48](https://github.com/Anna-Hax/JUNO/issues/48))                                                                                                                  | Highlight text attached to the page capture; retrievable                                                   |
+| 5     | **Highlights / selections** ([#48](https://github.com/Anna-Hax/JUNO/issues/48)) — ✅ [session 23](sessions/23-session-highlights.md)                                                                                                                  | Highlight text in `raw_json.highlights` + ingest text for search                                                   |
 | 6     | **Domain / URL excludes** ([#49](https://github.com/Anna-Hax/JUNO/issues/49)) + respect global `/pause`                                                                                          | Banking etc. never ingested; pause returns 423 from API and extension backs off                            |
 | 7     | **Module health** ([#50](https://github.com/Anna-Hax/JUNO/issues/50)) — extension last-success / last-error in `module_health`; Telegram `/status` and `GET /status` show browser sync freshness | Silent breakage is visible within a day of testing                                                         |
 | 8     | **Cross-reference** ([#51](https://github.com/Anna-Hax/JUNO/issues/51)) browser captures vs upload/inbox content in retrieve / digest text                                                       | “You also uploaded notes on X” style citations or digest lines                                             |

--- a/docs/sessions/23-session-highlights.md
+++ b/docs/sessions/23-session-highlights.md
@@ -1,0 +1,11 @@
+# Session 23 — Highlights (#48)
+
+**Date:** 2026-08-29  
+**Issue:** [#48](https://github.com/Anna-Hax/JUNO/issues/48)  
+**Branch:** `feat/highlights-48`
+
+## What changed
+
+- Content script captures text selections (mouseup) → `raw_json.highlights`.
+- Highlight text appended to ingest `text` for search/RAG retrieval.
+- Test: `test_browser_payload_stores_highlights`.

--- a/docs/sessions/README.md
+++ b/docs/sessions/README.md
@@ -28,6 +28,7 @@ Living notes for what was implemented, how GitHub is set up, and what to do next
 | [20-session-mv3-scaffold.md](20-session-mv3-scaffold.md) | **#45** — MV3 scaffold |
 | [21-session-browser-timestamp.md](21-session-browser-timestamp.md) | **#46** — URL + title + timestamp |
 | [22-session-engagement-metrics.md](22-session-engagement-metrics.md) | **#47** — Engagement metrics |
+| [23-session-highlights.md](23-session-highlights.md) | **#48** — Highlights / selections |
 | [v1.0-release-gate.md](../v1.0-release-gate.md) | M1 checklist (all P0 closed) |
 
 Architecture decisions live in [`../adr/`](../adr/). Product requirements: [`../../personal-knowledge-graph-prd.md](../../personal-knowledge-graph-prd.md).


### PR DESCRIPTION
## Summary
- Content script sends selected text to background; included in browser ingest.
- Highlight text merged into capture body for retrieval.
- Closes #48.

## Test plan
- [x] `test_browser_payload_stores_highlights`
