### PR TITLE
feat(bot): cross-reference browser hits with uploads

### DIFF
--- a/apps/core/src/juno/bot/services.py
+++ b/apps/core/src/juno/bot/services.py
@@ -6,8 +6,9 @@ import re
 from dataclasses import dataclass
 from datetime import UTC, datetime, timedelta
 from typing import Any
+from urllib.parse import urlparse
 
-from sqlalchemy import select
+from sqlalchemy import or_, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from juno.config import Settings
@@ -136,7 +137,22 @@ async def answer_user_query(svc: BotServices, text: str) -> str:
         n_results=5,
         mode="auto",
     )
-    return format_search_outcome(outcome)
+    reply = format_search_outcome(outcome)
+    if svc.db is None:
+        return reply
+    browser_hits = [
+        hit for hit in outcome.results if getattr(hit, "source_type", None) == "browser"
+    ]
+    if not browser_hits:
+        return reply
+    related = await related_upload_captures(svc.db, browser_hits=browser_hits)
+    if not related:
+        return reply
+    extra = ["", "You also uploaded notes on:"]
+    for row in related:
+        label = row.title or row.uri or f"capture #{row.id}"
+        extra.append(f"• #{row.id} {label}")
+    return clip(reply + "\n".join(extra))
 
 
 def format_capture_ack(result: IngestResult) -> str:
@@ -243,6 +259,49 @@ async def recent_captures(db: Database, *, since: datetime, limit: int = 20) -> 
         result = await session.execute(
             select(Capture)
             .where(Capture.captured_at >= since)
+            .order_by(Capture.captured_at.desc())
+            .limit(limit)
+        )
+        return list(result.scalars())
+
+    return await db.read(fn)
+
+
+async def related_upload_captures(
+    db: Database,
+    *,
+    browser_hits: list[Any],
+    limit: int = 3,
+) -> list[Capture]:
+    """Cross-reference browser hits with upload/inbox captures (#51)."""
+    titles: set[str] = set()
+    hosts: set[str] = set()
+    for hit in browser_hits:
+        title = (getattr(hit, "title", None) or "").strip()
+        if title:
+            titles.add(title[:80])
+        uri = getattr(hit, "uri", None) or ""
+        if uri:
+            host = urlparse(uri).netloc.lower()
+            if host:
+                hosts.add(host)
+    if not titles and not hosts:
+        return []
+
+    async def fn(session: AsyncSession) -> list[Capture]:
+        clauses = []
+        for title in list(titles)[:3]:
+            for word in re.findall(r"[A-Za-z]{4,}", title):
+                clauses.append(Capture.title.ilike(f"%{word}%"))
+        for host in list(hosts)[:3]:
+            clauses.append(Capture.uri.ilike(f"%{host}%"))
+        if not clauses:
+            return []
+        result = await session.execute(
+            select(Capture)
+            .where(Capture.source_type != "browser")
+            .where(Capture.status == "committed")
+            .where(or_(*clauses))
             .order_by(Capture.captured_at.desc())
             .limit(limit)
         )

--- a/apps/core/tests/test_bot.py
+++ b/apps/core/tests/test_bot.py
@@ -393,3 +393,32 @@ async def test_text_query_uses_rag_engine_when_llm_healthy(allowed_settings, db)
     assert "Rust notes" in body
     assert "Confidence:" in body
     assert chat.complete_calls == 1
+
+
+@pytest.mark.asyncio
+async def test_related_upload_captures_finds_upload_for_browser_hit(db):
+    from juno.bot.services import related_upload_captures
+    from juno.ingest.pipeline import IngestPipeline
+    from juno.rag.engine import SourcedHit
+
+    pipeline = IngestPipeline(db)
+    await pipeline.ingest_text(
+        "Saved Rust ownership notes from inbox.",
+        source_type="upload",
+        title="Rust ownership notes",
+    )
+    hits = [
+        SourcedHit(
+            chroma_id="c2-n0",
+            text="Rust book",
+            score=0.9,
+            capture_id=2,
+            title="Rust ownership guide",
+            uri="https://example.com/rust",
+            source_type="browser",
+        )
+    ]
+    related = await related_upload_captures(db, browser_hits=hits)
+    assert len(related) == 1
+    assert related[0].source_type == "upload"
+    assert "Rust" in (related[0].title or "")

--- a/docs/next-work.md
+++ b/docs/next-work.md
@@ -79,7 +79,7 @@ Milestone: [M2: v1.1 Browser Capture](https://github.com/Anna-Hax/JUNO/milestone
 | 5 | [#48](https://github.com/Anna-Hax/JUNO/issues/48) | Highlights — ✅ [session 23](sessions/23-session-highlights.md) |
 | 6 | [#49](https://github.com/Anna-Hax/JUNO/issues/49) | Domain excludes + pause — ✅ [session 24](sessions/24-session-domain-excludes.md) |
 | 7 | [#50](https://github.com/Anna-Hax/JUNO/issues/50) | Module health — ✅ [session 25](sessions/25-session-module-health.md) |
-| 8 | [#51](https://github.com/Anna-Hax/JUNO/issues/51) | Cross-reference browser vs inbox |
+| 8 | [#51](https://github.com/Anna-Hax/JUNO/issues/51) | Cross-reference — ✅ [session 26](sessions/26-session-cross-reference.md) |
 | 9 | [#52](https://github.com/Anna-Hax/JUNO/issues/52) | Digest enrichment |
 | 10 | [#53](https://github.com/Anna-Hax/JUNO/issues/53) | Extension tests + M2 gate |
 

--- a/docs/sessions/26-session-cross-reference.md
+++ b/docs/sessions/26-session-cross-reference.md
@@ -1,0 +1,18 @@
+# Session 26 — Cross-reference browser vs inbox (#51)
+
+**Date:** 2026-08-29  
+**Issue:** [#51](https://github.com/Anna-Hax/JUNO/issues/51)  
+**Branch:** `feat/cross-reference-51`
+
+## What changed
+
+- `related_upload_captures()` finds upload/inbox rows matching browser hit titles/domains.
+- Query replies append **You also uploaded notes on:** when browser hits have related uploads.
+
+## Verify
+
+```powershell
+cd apps/core
+$env:EMBEDDING_BACKEND='stub'
+uv run pytest tests/test_bot.py::test_related_upload_captures_finds_upload_for_browser_hit -q
+```

--- a/docs/sessions/README.md
+++ b/docs/sessions/README.md
@@ -31,6 +31,7 @@ Living notes for what was implemented, how GitHub is set up, and what to do next
 | [23-session-highlights.md](23-session-highlights.md) | **#48** — Highlights / selections |
 | [24-session-domain-excludes.md](24-session-domain-excludes.md) | **#49** — Domain excludes + pause |
 | [25-session-module-health.md](25-session-module-health.md) | **#50** — Extension module health |
+| [26-session-cross-reference.md](26-session-cross-reference.md) | **#51** — Cross-reference browser vs inbox |
 | [v1.0-release-gate.md](../v1.0-release-gate.md) | M1 checklist (all P0 closed) |
 
 Architecture decisions live in [`../adr/`](../adr/). Product requirements: [`../../personal-knowledge-graph-prd.md](../../personal-knowledge-graph-prd.md).


### PR DESCRIPTION
﻿## Summary
- `related_upload_captures()` links browser hits to upload/inbox rows.
- Appends related-upload note in query replies when matches exist.
- Closes #51.

## Test plan
- [x] `test_related_upload_captures_finds_upload_for_browser_hit`
