### PR TITLE
feat(bot): group digest by browser vs uploads (#52)

### DIFF
--- a/apps/core/src/juno/bot/services.py
+++ b/apps/core/src/juno/bot/services.py
@@ -171,15 +171,29 @@ def format_digest(captures: list[Capture], window: str) -> str:
     label = "today" if window == "today" else "this week"
     if not captures:
         return f"No captures {label}."
+    browser = [row for row in captures if row.source_type == "browser"]
+    other = [row for row in captures if row.source_type != "browser"]
     lines = [f"Digest {label} ({len(captures)}):"]
-    for row in captures:
+    if browser:
+        lines.append(f"Browser reading ({len(browser)}):")
+        lines.extend(_digest_lines(browser))
+    if other:
+        if browser:
+            lines.append(f"Uploads / other ({len(other)}):")
+        lines.extend(_digest_lines(other))
+    return clip("\n".join(lines))
+
+
+def _digest_lines(rows: list[Capture]) -> list[str]:
+    lines: list[str] = []
+    for row in rows:
         when = _fmt_dt(row.captured_at)
         title = row.title or row.uri or (row.text or "")[:60] or "(no text)"
         title = " ".join(str(title).split())
         if len(title) > 80:
             title = title[:79].rstrip() + "…"
         lines.append(f"• #{row.id} [{row.source_type}/{row.status}] {when} — {title}")
-    return clip("\n".join(lines))
+    return lines
 
 
 def format_status(

--- a/apps/core/tests/test_bot.py
+++ b/apps/core/tests/test_bot.py
@@ -21,6 +21,7 @@ from juno.bot.handlers import (
 from juno.bot.services import (
     BOT_DATA_KEY,
     BotServices,
+    format_digest,
     format_retrieve_reply,
     load_capture_paused,
     persist_capture_paused,
@@ -31,7 +32,7 @@ from juno.config import Settings
 from juno.graph.db import Database
 from juno.graph.vectors import VectorHit
 from juno.ingest.pipeline import IngestPipeline, IngestResult
-from juno.models import AppSetting
+from juno.models import AppSetting, Capture
 from juno.runtime import build_telegram_application
 
 ALLOWED_ID = 42
@@ -162,6 +163,30 @@ def test_single_http_url():
 def test_format_retrieve_reply_empty():
     text = format_retrieve_reply("rust", [])
     assert "Nothing in the graph" in text
+
+
+def test_format_digest_groups_browser_reading():
+    from datetime import UTC, datetime
+
+    now = datetime.now(UTC)
+    browser = Capture(
+        id=1,
+        source_type="browser",
+        title="Rust book",
+        status="committed",
+        captured_at=now,
+    )
+    upload = Capture(
+        id=2,
+        source_type="upload",
+        title="Notes",
+        status="committed",
+        captured_at=now,
+    )
+    text = format_digest([upload, browser], "today")
+    assert "Browser reading (1):" in text
+    assert "Uploads / other (1):" in text
+    assert "Rust book" in text
 
 
 def test_format_retrieve_reply_hits():

--- a/docs/next-work.md
+++ b/docs/next-work.md
@@ -80,7 +80,7 @@ Milestone: [M2: v1.1 Browser Capture](https://github.com/Anna-Hax/JUNO/milestone
 | 6 | [#49](https://github.com/Anna-Hax/JUNO/issues/49) | Domain excludes + pause — ✅ [session 24](sessions/24-session-domain-excludes.md) |
 | 7 | [#50](https://github.com/Anna-Hax/JUNO/issues/50) | Module health — ✅ [session 25](sessions/25-session-module-health.md) |
 | 8 | [#51](https://github.com/Anna-Hax/JUNO/issues/51) | Cross-reference — ✅ [session 26](sessions/26-session-cross-reference.md) |
-| 9 | [#52](https://github.com/Anna-Hax/JUNO/issues/52) | Digest enrichment |
+| 9 | [#52](https://github.com/Anna-Hax/JUNO/issues/52) | Digest enrichment — ✅ [session 27](sessions/27-session-digest-enrichment.md) |
 | 10 | [#53](https://github.com/Anna-Hax/JUNO/issues/53) | Extension tests + M2 gate |
 
 Stub today: `apps/extension/` (MV3 manifest + service worker + options). Extension must talk **HTTP to the loopback API** — no second Chroma/SQLite client ([ADR-04](adr/004-chroma-collections.md), [ADR-05](adr/005-browser-extension-client.md)).
@@ -104,8 +104,8 @@ Prefer one issue ≈ one PR. Order is dependency-aware.
 | 5     | **Highlights / selections** ([#48](https://github.com/Anna-Hax/JUNO/issues/48)) — ✅ [session 23](sessions/23-session-highlights.md)                                                                                                                  | Highlight text in `raw_json.highlights` + ingest text for search                                                   |
 | 6     | **Domain / URL excludes** ([#49](https://github.com/Anna-Hax/JUNO/issues/49)) — ✅ [session 24](sessions/24-session-domain-excludes.md)                                                                                          | Options excludes; API 423 backs extension off; respects `/pause`                            |
 | 7     | **Module health** ([#50](https://github.com/Anna-Hax/JUNO/issues/50)) — ✅ [session 25](sessions/25-session-module-health.md) | `extension` row in `module_health`; `GET /status.modules` + Telegram `/status`                         |
-| 8     | **Cross-reference** ([#51](https://github.com/Anna-Hax/JUNO/issues/51)) browser captures vs upload/inbox content in retrieve / digest text                                                       | “You also uploaded notes on X” style citations or digest lines                                             |
-| 9     | **Digest enrichment** ([#52](https://github.com/Anna-Hax/JUNO/issues/52)) — `/digest today|week` includes browser reading (on-demand already exists; deepen for M2)                              | Scheduled *push* digests stay M4 unless explicitly pulled forward                                          |
+| 8     | **Cross-reference** ([#51](https://github.com/Anna-Hax/JUNO/issues/51)) — ✅ [session 26](sessions/26-session-cross-reference.md) browser captures vs upload/inbox content in retrieve / digest text                                                       | “You also uploaded notes on X” style citations or digest lines                                             |
+| 9     | **Digest enrichment** ([#52](https://github.com/Anna-Hax/JUNO/issues/52)) — ✅ [session 27](sessions/27-session-digest-enrichment.md) — `/digest today|week` groups browser reading vs uploads/other                              | Scheduled *push* digests stay M4 unless explicitly pulled forward                                          |
 | 10    | **Extension tests + docs** ([#53](https://github.com/Anna-Hax/JUNO/issues/53)) — unit/integration where feasible; README load steps; session log; M2 gate checklist                              | CI green on `apps/extension/`**                                                                            |
 
 

--- a/docs/sessions/27-session-digest-enrichment.md
+++ b/docs/sessions/27-session-digest-enrichment.md
@@ -1,0 +1,16 @@
+# Session 27 — Digest enrichment (#52)
+
+**Date:** 2026-08-29  
+**Issue:** [#52](https://github.com/Anna-Hax/JUNO/issues/52)  
+**Branch:** `feat/digest-enrichment-52`
+
+## What changed
+
+- `/digest today|week` groups **Browser reading** vs **Uploads / other** sections.
+
+## Verify
+
+```powershell
+cd apps/core
+uv run pytest tests/test_bot.py::test_format_digest_groups_browser_reading -q
+```

--- a/docs/sessions/README.md
+++ b/docs/sessions/README.md
@@ -32,6 +32,7 @@ Living notes for what was implemented, how GitHub is set up, and what to do next
 | [24-session-domain-excludes.md](24-session-domain-excludes.md) | **#49** — Domain excludes + pause |
 | [25-session-module-health.md](25-session-module-health.md) | **#50** — Extension module health |
 | [26-session-cross-reference.md](26-session-cross-reference.md) | **#51** — Cross-reference browser vs inbox |
+| [27-session-digest-enrichment.md](27-session-digest-enrichment.md) | **#52** — Digest enrichment (browser vs uploads) |
 | [v1.0-release-gate.md](../v1.0-release-gate.md) | M1 checklist (all P0 closed) |
 
 Architecture decisions live in [`../adr/`](../adr/). Product requirements: [`../../personal-knowledge-graph-prd.md](../../personal-knowledge-graph-prd.md).


### PR DESCRIPTION
## Summary

- `/digest today|week` groups captures into **Browser reading** vs **Uploads / other** sections.
- Unit test for grouped digest formatting.

## Test plan

- [x] `uv run pytest tests/test_bot.py::test_format_digest_groups_browser_reading -q`

Closes #52
