### PR TITLE
feat(extension): M2 gate — validator and v1.1 release (#53)

### DIFF
--- a/.github/workflows/ci-extension.yml
+++ b/.github/workflows/ci-extension.yml
@@ -5,11 +5,13 @@ on:
     branches: [main]
     paths:
       - "apps/extension/**"
+      - "scripts/validate-extension.py"
       - ".github/workflows/ci-extension.yml"
   pull_request:
     branches: [main]
     paths:
       - "apps/extension/**"
+      - "scripts/validate-extension.py"
       - ".github/workflows/ci-extension.yml"
 
 jobs:
@@ -17,20 +19,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Validate manifest JSON
-        run: python -m json.tool apps/extension/manifest.json > /dev/null
-      - name: Require background script
-        run: test -f apps/extension/background.js
-      - name: Require options UI (Spike S2+)
-        run: test -f apps/extension/options.html && test -f apps/extension/options.js
-      - name: Require popup and shared lib
-        run: |
-          test -f apps/extension/popup.html
-          test -f apps/extension/popup.js
-          test -f apps/extension/lib/config.js
-          test -f apps/extension/lib/api.js
-          test -f apps/extension/lib/capture.js
-          test -f apps/extension/lib/tabs.js
-          test -f apps/extension/lib/excludes.js
-      - name: Require extension README
-        run: test -f apps/extension/README.md
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+      - name: Validate extension (manifest, files, JS syntax)
+        run: python scripts/validate-extension.py

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Personal knowledge-graph agent: passively (and manually) capture what you read, code, and discuss — query it from **Telegram**. Local-first on your PC.
 
-**Status:** **v1.0 foundation** (M1 complete) — local ingest, RAG query, Telegram capture/HITL, export/wipe. Not a daily driver until M2+ capture modules land.
+**Status:** **v1.1 browser capture** (M2 complete) — v1.0 foundation plus MV3 extension → loopback ingest, metrics, highlights, grouped digests. IDE capture (M3) is next.
 
 ## Architecture (v1)
 

--- a/apps/core/pyproject.toml
+++ b/apps/core/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "juno"
-version = "1.0.0"
+version = "1.1.0"
 description = "Personal knowledge graph agent — local-first second brain via Telegram"
 requires-python = ">=3.12"
 dependencies = [

--- a/apps/core/src/juno/__init__.py
+++ b/apps/core/src/juno/__init__.py
@@ -1,3 +1,3 @@
 """Juno — personal knowledge graph agent."""
 
-__version__ = "1.0.0"
+__version__ = "1.1.0"

--- a/apps/core/tests/test_extension_validate.py
+++ b/apps/core/tests/test_extension_validate.py
@@ -1,0 +1,21 @@
+"""Run scripts/validate-extension.py from the repo root."""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+SCRIPT = REPO_ROOT / "scripts" / "validate-extension.py"
+
+
+def test_validate_extension_script():
+    proc = subprocess.run(
+        [sys.executable, str(SCRIPT)],
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert proc.returncode == 0, proc.stderr or proc.stdout

--- a/apps/extension/README.md
+++ b/apps/extension/README.md
@@ -27,3 +27,10 @@ MV3 **loopback client** for [Juno](../../README.md). Sends page visits to local 
 - Only talks to `127.0.0.1` (configurable base URL).
 - Token stays in extension storage on your machine.
 - Respects global capture pause when API returns 423 (see core `/pause`).
+
+## Verify (CI / local)
+
+```powershell
+# from repo root
+python scripts/validate-extension.py
+```

--- a/apps/extension/manifest.json
+++ b/apps/extension/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Juno Capture",
-  "version": "0.1.0",
+  "version": "1.1.0",
   "description": "Browser reading capture for Juno (loopback client — ADR-01).",
   "permissions": ["storage", "tabs"],
   "host_permissions": ["http://127.0.0.1:8787/*", "http://*/*", "https://*/*"],

--- a/docs/next-work.md
+++ b/docs/next-work.md
@@ -2,7 +2,7 @@
 
 **Last updated:** 2026-08-29  
 **Track issues on:** [https://github.com/Anna-Hax/JUNO/issues](https://github.com/Anna-Hax/JUNO/issues)  
-**Package:** `1.0.0` (M1 foundation complete — [`docs/v1.0-release-gate.md`](v1.0-release-gate.md))
+**Package:** `1.1.0` (M2 browser capture complete — [`docs/v1.1-release-gate.md`](v1.1-release-gate.md))
 
 Prefer one open issue ≈ one PR (`Closes #N`). This file is kept as-is across branch merges (`merge=ours`).
 
@@ -81,9 +81,17 @@ Milestone: [M2: v1.1 Browser Capture](https://github.com/Anna-Hax/JUNO/milestone
 | 7 | [#50](https://github.com/Anna-Hax/JUNO/issues/50) | Module health — ✅ [session 25](sessions/25-session-module-health.md) |
 | 8 | [#51](https://github.com/Anna-Hax/JUNO/issues/51) | Cross-reference — ✅ [session 26](sessions/26-session-cross-reference.md) |
 | 9 | [#52](https://github.com/Anna-Hax/JUNO/issues/52) | Digest enrichment — ✅ [session 27](sessions/27-session-digest-enrichment.md) |
-| 10 | [#53](https://github.com/Anna-Hax/JUNO/issues/53) | Extension tests + M2 gate |
+| 10 | [#53](https://github.com/Anna-Hax/JUNO/issues/53) | Extension tests + M2 gate — ✅ [session 28](sessions/28-session-m2-gate.md) |
 
 Stub today: `apps/extension/` (MV3 manifest + service worker + options). Extension must talk **HTTP to the loopback API** — no second Chroma/SQLite client ([ADR-04](adr/004-chroma-collections.md), [ADR-05](adr/005-browser-extension-client.md)).
+
+---
+
+## M2 — **complete** (2026-08-29)
+
+Epic [#25](https://github.com/Anna-Hax/JUNO/issues/25) closed; milestone [M2: v1.1 Browser Capture](https://github.com/Anna-Hax/JUNO/milestone/8) complete. Gate: [`docs/v1.1-release-gate.md`](v1.1-release-gate.md).
+
+**Next:** epic [#26](https://github.com/Anna-Hax/JUNO/issues/26) — M3 IDE / Cursor capture.
 
 ---
 
@@ -106,7 +114,7 @@ Prefer one issue ≈ one PR. Order is dependency-aware.
 | 7     | **Module health** ([#50](https://github.com/Anna-Hax/JUNO/issues/50)) — ✅ [session 25](sessions/25-session-module-health.md) | `extension` row in `module_health`; `GET /status.modules` + Telegram `/status`                         |
 | 8     | **Cross-reference** ([#51](https://github.com/Anna-Hax/JUNO/issues/51)) — ✅ [session 26](sessions/26-session-cross-reference.md) browser captures vs upload/inbox content in retrieve / digest text                                                       | “You also uploaded notes on X” style citations or digest lines                                             |
 | 9     | **Digest enrichment** ([#52](https://github.com/Anna-Hax/JUNO/issues/52)) — ✅ [session 27](sessions/27-session-digest-enrichment.md) — `/digest today|week` groups browser reading vs uploads/other                              | Scheduled *push* digests stay M4 unless explicitly pulled forward                                          |
-| 10    | **Extension tests + docs** ([#53](https://github.com/Anna-Hax/JUNO/issues/53)) — unit/integration where feasible; README load steps; session log; M2 gate checklist                              | CI green on `apps/extension/`**                                                                            |
+| 10    | **Extension tests + docs** ([#53](https://github.com/Anna-Hax/JUNO/issues/53)) — ✅ [session 28](sessions/28-session-m2-gate.md) — `validate-extension.py`; v1.1 gate                              | CI green on `apps/extension/`                                                                            |
 
 
 

--- a/docs/sessions/28-session-m2-gate.md
+++ b/docs/sessions/28-session-m2-gate.md
@@ -1,0 +1,23 @@
+# Session 28 — M2 gate: extension tests + v1.1 (#53)
+
+**Date:** 2026-08-29  
+**Issue:** [#53](https://github.com/Anna-Hax/JUNO/issues/53)  
+**Branch:** `feat/m2-gate-53`
+
+## What changed
+
+- `scripts/validate-extension.py` — manifest, file graph, optional Node JS syntax check.
+- Core pytest invokes the validator; CI Extension workflow runs it.
+- [`docs/v1.1-release-gate.md`](../v1.1-release-gate.md) — M2 checklist; package **1.1.0**.
+
+## Verify
+
+```powershell
+python scripts/validate-extension.py
+cd apps/core
+$env:EMBEDDING_BACKEND='stub'
+uv run pytest tests/test_extension_validate.py -q
+uv run juno version   # expect 1.1.0
+```
+
+Load unpacked extension per [`apps/extension/README.md`](../../apps/extension/README.md).

--- a/docs/sessions/README.md
+++ b/docs/sessions/README.md
@@ -33,6 +33,8 @@ Living notes for what was implemented, how GitHub is set up, and what to do next
 | [25-session-module-health.md](25-session-module-health.md) | **#50** — Extension module health |
 | [26-session-cross-reference.md](26-session-cross-reference.md) | **#51** — Cross-reference browser vs inbox |
 | [27-session-digest-enrichment.md](27-session-digest-enrichment.md) | **#52** — Digest enrichment (browser vs uploads) |
+| [28-session-m2-gate.md](28-session-m2-gate.md) | **#53** — M2 gate + extension validation |
 | [v1.0-release-gate.md](../v1.0-release-gate.md) | M1 checklist (all P0 closed) |
+| [v1.1-release-gate.md](../v1.1-release-gate.md) | M2 checklist (browser capture) |
 
 Architecture decisions live in [`../adr/`](../adr/). Product requirements: [`../../personal-knowledge-graph-prd.md](../../personal-knowledge-graph-prd.md).

--- a/docs/v1.1-release-gate.md
+++ b/docs/v1.1-release-gate.md
@@ -1,0 +1,65 @@
+# v1.1 release gate (M2: Browser Capture)
+
+**Date:** 2026-08-29  
+**Milestone:** [M2: v1.1 Browser Capture](https://github.com/Anna-Hax/JUNO/milestone/8)  
+**Package version:** `1.1.0` (`apps/core`)  
+**Epic:** [#25](https://github.com/Anna-Hax/JUNO/issues/25)
+
+This checklist closes issue **#53**. Acceptance: **all M2 child issues closed** and extension CI green.
+
+---
+
+## M2 issues (#44–#53)
+
+| Issue | Capability | Status | PR |
+|-------|------------|--------|-----|
+| [#44](https://github.com/Anna-Hax/JUNO/issues/44) | Spike S2 — POST /ingest | ✅ Closed | [#54](https://github.com/Anna-Hax/JUNO/pull/54) |
+| [#45](https://github.com/Anna-Hax/JUNO/issues/45) | MV3 scaffold | ✅ Closed | [#55](https://github.com/Anna-Hax/JUNO/pull/55) |
+| [#46](https://github.com/Anna-Hax/JUNO/issues/46) | URL + title + timestamp | ✅ Closed | [#56](https://github.com/Anna-Hax/JUNO/pull/56) |
+| [#47](https://github.com/Anna-Hax/JUNO/issues/47) | Engagement metrics | ✅ Closed | [#57](https://github.com/Anna-Hax/JUNO/pull/57) |
+| [#48](https://github.com/Anna-Hax/JUNO/issues/48) | Highlights / selections | ✅ Closed | [#58](https://github.com/Anna-Hax/JUNO/pull/58) |
+| [#49](https://github.com/Anna-Hax/JUNO/issues/49) | Domain excludes + pause | ✅ Closed | [#59](https://github.com/Anna-Hax/JUNO/pull/59) |
+| [#50](https://github.com/Anna-Hax/JUNO/issues/50) | Module health (`extension`) | ✅ Closed | [#60](https://github.com/Anna-Hax/JUNO/pull/60) |
+| [#51](https://github.com/Anna-Hax/JUNO/issues/51) | Cross-reference browser vs inbox | ✅ Closed | [#61](https://github.com/Anna-Hax/JUNO/pull/61) |
+| [#52](https://github.com/Anna-Hax/JUNO/issues/52) | Digest enrichment | ✅ Closed | [#62](https://github.com/Anna-Hax/JUNO/pull/62) |
+| [#53](https://github.com/Anna-Hax/JUNO/issues/53) | Extension tests + this gate | ✅ Closed | (this doc + PR) |
+
+**M2:** 10 / 10 closed.
+
+---
+
+## CI / quality gate
+
+- [x] `uv run pytest` — core tests include browser ingest + `validate-extension.py`
+- [x] `uv run ruff check` + format check
+- [x] `CI Extension` — manifest, required files, `scripts/validate-extension.py`
+- [x] PR hygiene (`Closes #N`, conventional title)
+
+---
+
+## Manual smoke (operator)
+
+1. `uv run juno serve` with repo-root `.env`
+2. Load unpacked `apps/extension/` — set token in Options
+3. Browse an `https://` page; switch tab — capture committed in logs
+4. Telegram: `/status` shows `extension` module; `/digest today` groups browser reading
+
+---
+
+## What v1.1 means
+
+Phase 2 browser capture from the PRD:
+
+- MV3 extension as loopback client ([ADR-05](adr/005-browser-extension-client.md))
+- URL, title, timestamp, engagement metrics, highlights → `POST /ingest`
+- Domain excludes; respects global `/pause` (423)
+- Extension module health on `/status`
+- Cross-reference + grouped digests in Telegram
+
+**Not in v1.1:** IDE capture (M3), proactive push digests (M4), polish (M5).
+
+---
+
+## Next milestone
+
+Epic [#26](https://github.com/Anna-Hax/JUNO/issues/26) — M3 IDE / Cursor capture.

--- a/scripts/validate-extension.py
+++ b/scripts/validate-extension.py
@@ -1,0 +1,118 @@
+#!/usr/bin/env python3
+"""Validate apps/extension layout, manifest, and JS syntax (Node when available)."""
+
+from __future__ import annotations
+
+import json
+import re
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+EXT = ROOT / "apps" / "extension"
+
+REQUIRED_FILES = (
+    "manifest.json",
+    "background.js",
+    "content.js",
+    "options.html",
+    "options.js",
+    "popup.html",
+    "popup.js",
+    "README.md",
+    "lib/config.js",
+    "lib/api.js",
+    "lib/capture.js",
+    "lib/tabs.js",
+    "lib/excludes.js",
+)
+
+IMPORT_SCRIPTS = re.compile(r"""importScripts\s*\(\s*(['"].+?['"](?:\s*,\s*['"].+?['"])*)\s*\)""")
+SCRIPT_SRC = re.compile(r"""<script[^>]+src=["']([^"']+)["']""", re.I)
+
+
+def _fail(msg: str) -> None:
+    print(f"validate-extension: {msg}", file=sys.stderr)
+    sys.exit(1)
+
+
+def _quoted_paths(import_args: str) -> list[str]:
+    return re.findall(r"""['"]([^'"]+)['"]""", import_args)
+
+
+def _check_files_exist(relative_paths: set[str]) -> None:
+    for rel in sorted(relative_paths):
+        if not (EXT / rel).is_file():
+            _fail(f"missing referenced file: {rel}")
+
+
+def _load_manifest() -> dict:
+    manifest_path = EXT / "manifest.json"
+    try:
+        data = json.loads(manifest_path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        _fail(f"invalid manifest.json: {exc}")
+    if data.get("manifest_version") != 3:
+        _fail("manifest_version must be 3")
+    sw = (data.get("background") or {}).get("service_worker")
+    if sw != "background.js":
+        _fail("background.service_worker must be background.js")
+    hosts = data.get("host_permissions") or []
+    if not any("127.0.0.1:8787" in h for h in hosts):
+        _fail("host_permissions must include loopback 127.0.0.1:8787")
+    for entry in data.get("content_scripts") or []:
+        for js in entry.get("js") or []:
+            _check_files_exist({js})
+    return data
+
+
+def _collect_js_references() -> set[str]:
+    refs: set[str] = {"background.js"}
+    bg = (EXT / "background.js").read_text(encoding="utf-8")
+    match = IMPORT_SCRIPTS.search(bg)
+    if not match:
+        _fail("background.js must call importScripts(...)")
+    refs.update(_quoted_paths(match.group(1)))
+    for html_name in ("options.html", "popup.html"):
+        html = (EXT / html_name).read_text(encoding="utf-8")
+        refs.update(SCRIPT_SRC.findall(html))
+        refs.add(html_name.replace(".html", ".js"))
+    refs.add("content.js")
+    return refs
+
+
+def _check_js_syntax(js_files: list[Path]) -> None:
+    node = shutil.which("node")
+    if not node:
+        print("validate-extension: node not found — skipping JS syntax check")
+        return
+    for path in js_files:
+        proc = subprocess.run(
+            [node, "--check", str(path)],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        if proc.returncode != 0:
+            detail = (proc.stderr or proc.stdout or "").strip()
+            _fail(f"JS syntax error in {path.relative_to(ROOT)}: {detail}")
+
+
+def main() -> None:
+    if not EXT.is_dir():
+        _fail(f"extension dir not found: {EXT}")
+    for rel in REQUIRED_FILES:
+        if not (EXT / rel).is_file():
+            _fail(f"missing required file: {rel}")
+    _load_manifest()
+    refs = _collect_js_references()
+    _check_files_exist(refs)
+    js_files = sorted(EXT.rglob("*.js"))
+    _check_js_syntax(js_files)
+    print(f"validate-extension: OK ({len(REQUIRED_FILES)} required files, {len(js_files)} JS)")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

- Add `scripts/validate-extension.py` (manifest, file graph, Node JS syntax).
- Wire validator into CI Extension + core pytest.
- Add [`docs/v1.1-release-gate.md`](docs/v1.1-release-gate.md); bump package and extension to **1.1.0**.
- Mark M2 complete in docs; README status updated.

## Test plan

- [x] `python scripts/validate-extension.py`
- [x] `uv run pytest tests/test_extension_validate.py -q`
- [x] `uv run pytest -q` (119 tests)

Closes #53
Refs #25
