### PR TITLE
feat(ide): adapter scaffold with config, poll, and CI

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -26,3 +26,10 @@ EMBEDDING_MODEL=all-MiniLM-L6-v2
 # Use stub embedder in CI / tests: stub | sentence_transformers
 # Local MiniLM: uv sync --extra embeddings  (falls back to stub if missing)
 EMBEDDING_BACKEND=sentence_transformers
+
+# IDE adapter (apps/ide) — HTTP client only; empty path = platform Cursor default
+# JUNO_CURSOR_VSCDB=
+# JUNO_CURSOR_WORKSPACE_STORAGE=
+# JUNO_CURSOR_WORKSPACE=
+# JUNO_IDE_POLL_SECONDS=60
+# JUNO_IDE_STATE=

--- a/.github/workflows/ci-ide.yml
+++ b/.github/workflows/ci-ide.yml
@@ -1,0 +1,26 @@
+name: CI IDE
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "apps/ide/**"
+      - "scripts/validate-ide.py"
+      - ".github/workflows/ci-ide.yml"
+  pull_request:
+    branches: [main]
+    paths:
+      - "apps/ide/**"
+      - "scripts/validate-ide.py"
+      - ".github/workflows/ci-ide.yml"
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: Validate IDE adapter (files, syntax, no 0.0.0.0)
+        run: python scripts/validate-ide.py

--- a/apps/core/tests/test_ide_scaffold.py
+++ b/apps/core/tests/test_ide_scaffold.py
@@ -1,0 +1,152 @@
+"""IDE adapter scaffold (#65): config, watermark poll, validate-ide."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from datetime import UTC, datetime
+from pathlib import Path
+
+import pytest
+
+from juno.graph.db import Database
+from juno.ingest.pipeline import IngestPipeline
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+IDE = REPO_ROOT / "apps" / "ide"
+if str(IDE) not in sys.path:
+    sys.path.insert(0, str(IDE))
+
+from config import load_config  # noqa: E402
+from cursor_vscdb import CursorSession  # noqa: E402
+from sync import due_sessions, load_watermark, save_watermark  # noqa: E402
+
+VALIDATE = REPO_ROOT / "scripts" / "validate-ide.py"
+
+
+@pytest.fixture
+async def db(settings):
+    database = Database(settings)
+    await database.migrate()
+    yield database
+    await database.dispose()
+
+
+def _session(
+    composer_id: str,
+    *,
+    updated: datetime,
+    name: str = "chat",
+    workspace: str | None = r"D:\proj\demo",
+) -> CursorSession:
+    return CursorSession(
+        composer_id=composer_id,
+        name=name,
+        created_at=updated,
+        updated_at=updated,
+        workspace_path=workspace,
+    )
+
+
+def test_validate_ide_script():
+    proc = subprocess.run(
+        [sys.executable, str(VALIDATE)],
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert proc.returncode == 0, proc.stderr or proc.stdout
+
+
+def test_load_config_from_dotenv(tmp_path, monkeypatch):
+    monkeypatch.delenv("JUNO_API_TOKEN", raising=False)
+    monkeypatch.delenv("JUNO_CURSOR_VSCDB", raising=False)
+    monkeypatch.delenv("JUNO_API_HOST", raising=False)
+    monkeypatch.delenv("JUNO_API_PORT", raising=False)
+    monkeypatch.delenv("JUNO_IDE_POLL_SECONDS", raising=False)
+    monkeypatch.delenv("JUNO_CURSOR_WORKSPACE", raising=False)
+    monkeypatch.delenv("JUNO_IDE_STATE", raising=False)
+    env = tmp_path / ".env"
+    db = tmp_path / "state.vscdb"
+    env.write_text(
+        "\n".join(
+            [
+                "JUNO_API_HOST=127.0.0.1",
+                "JUNO_API_PORT=8787",
+                "JUNO_API_TOKEN=scaffold-token",
+                f"JUNO_CURSOR_VSCDB={db}",
+                "JUNO_IDE_POLL_SECONDS=12",
+                "JUNO_CURSOR_WORKSPACE=demo",
+                f"JUNO_DATA_DIR={tmp_path / 'data'}",
+            ]
+        ),
+        encoding="utf-8",
+    )
+    cfg = load_config(start=tmp_path)
+    assert cfg.api_base_url == "http://127.0.0.1:8787"
+    assert cfg.api_token == "scaffold-token"
+    assert cfg.global_vscdb == db
+    assert cfg.poll_seconds == 12
+    assert cfg.workspace_filter == "demo"
+    assert cfg.token_is_usable()
+    assert cfg.state_path == tmp_path / "data" / "ide-adapter.json"
+
+
+def test_due_sessions_watermark_and_workspace_filter():
+    t0 = datetime(2026, 9, 1, tzinfo=UTC)
+    t1 = datetime(2026, 9, 2, tzinfo=UTC)
+    t2 = datetime(2026, 9, 3, tzinfo=UTC)
+    sessions = [
+        _session("new", updated=t2, workspace=r"D:\proj\demo"),
+        _session("other", updated=t2, workspace=r"D:\other"),
+        _session("old", updated=t0, workspace=r"D:\proj\demo"),
+    ]
+    due = due_sessions(sessions, watermark=t1, limit=8, workspace_filter="demo")
+    assert [s.composer_id for s in due] == ["new"]
+
+
+def test_watermark_roundtrip(tmp_path):
+    path = tmp_path / "ide-adapter.json"
+    when = datetime(2026, 9, 2, 12, 0, tzinfo=UTC)
+    save_watermark(path, when)
+    assert load_watermark(path) == when
+    assert json.loads(path.read_text(encoding="utf-8"))["module"] == "ide"
+
+
+@pytest.mark.asyncio
+async def test_ide_ingest_respects_pause(settings, db):
+    from juno.api import create_app
+
+    pipeline = IngestPipeline(db)
+    app = create_app(settings, db=db, pipeline=pipeline)
+
+    import httpx
+
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+        resp = await client.post(
+            "/ingest",
+            json={"source_type": "ide", "title": "scaffold", "text": "hi"},
+            headers={"Authorization": "Bearer test-token"},
+        )
+        assert resp.status_code == 200
+        app.state.capture_paused = True
+        paused = await client.post(
+            "/ingest",
+            json={"source_type": "ide", "title": "paused", "text": "nope"},
+            headers={"Authorization": "Bearer test-token"},
+        )
+        assert paused.status_code == 423
+
+    from api import post_ingest
+
+    result = post_ingest(
+        "http://127.0.0.1:9",
+        "x",
+        {"source_type": "ide", "text": "offline"},
+        timeout=1,
+    )
+    assert result.ok is False
+    assert result.status == 0

--- a/apps/ide/README.md
+++ b/apps/ide/README.md
@@ -1,34 +1,50 @@
-# Juno IDE adapter (Spike S3)
+# Juno IDE adapter
 
-Loopback **HTTP client** for Cursor chat history. Reads `state.vscdb` **read-only** and posts to `juno serve` `POST /ingest`. It is not a second daemon and does not open Juno's SQLite or Chroma ([ADR-01](../../docs/adr/001-shared-event-loop.md), [ADR-06](../../docs/adr/006-ide-adapter-client.md)).
+Loopback **HTTP client** for Cursor chat history ([ADR-06](../../docs/adr/006-ide-adapter-client.md)). Reads `state.vscdb` **read-only** and posts to `juno serve`. Not a second daemon; no Juno SQLite/Chroma handles.
+
+## Layout
+
+| File | Role |
+|------|------|
+| `config.py` | Paths + token from env / `.env` |
+| `cursor_vscdb.py` | Read-only exporter (`composerHeaders` / `bubbleId:`) |
+| `api.py` | `GET /status`, `POST /ingest` |
+| `smoke.py` | Discover / export one session |
+| `sync.py` | Poll watermarked sessions (`--once` or `--watch`) |
+
+## Config
+
+Set in repo-root `.env` (same file as `juno serve`):
+
+| Variable | Default |
+|----------|---------|
+| `JUNO_API_HOST` / `JUNO_API_PORT` | `127.0.0.1` / `8787` |
+| `JUNO_API_TOKEN` | required for POST |
+| `JUNO_CURSOR_VSCDB` | platform Cursor global `state.vscdb` |
+| `JUNO_CURSOR_WORKSPACE_STORAGE` | sibling `workspaceStorage/` |
+| `JUNO_CURSOR_WORKSPACE` | optional path substring filter |
+| `JUNO_IDE_POLL_SECONDS` | `60` (`--watch`) |
+| `JUNO_IDE_STATE` | `{JUNO_DATA_DIR}/ide-adapter.json` watermark |
 
 ## Smoke
-
-With `juno serve` running and `JUNO_API_TOKEN` in the environment:
 
 ```powershell
 python apps/ide/smoke.py discover
 python apps/ide/smoke.py export --latest --post
 ```
 
-Override the DB path or token:
+## Poll / watch
 
 ```powershell
-python apps/ide/smoke.py export --latest --post --db $env:APPDATA\Cursor\User\globalStorage\state.vscdb --token $env:JUNO_API_TOKEN
+python apps/ide/sync.py --once --dry-run
+python apps/ide/sync.py --once
+python apps/ide/sync.py --watch
 ```
 
-Confirm: `GET /search?q=<session title>` with Bearer returns the capture (`source_type=ide`).
+`--watch` polls until Ctrl+C. Global `/pause` returns 423; the adapter backs off that pass. Duplicate capture rows on re-sync are handled in #66.
 
-## Storage we wrap
+## CI
 
-Cursor (3.x on this machine) stores chats in `%APPDATA%\Cursor\User\globalStorage\state.vscdb`:
-
-| Location | Role |
-|----------|------|
-| `composerHeaders` | Central session index (id, workspace, timestamps) |
-| `cursorDiskKV` `composerData:{id}` | Session envelope + bubble header list |
-| `cursorDiskKV` `bubbleId:{id}:{bubbleId}` | Message text |
-
-Empty tool-only bubbles are skipped. Schema is unofficial — if Cursor changes keys, discover will return 0 rows or missing text; see ADR-06 breakage notes.
-
-Watch/poll, config settings, and CI layout land in later M3 issues (#65+).
+```powershell
+python scripts/validate-ide.py
+```

--- a/apps/ide/api.py
+++ b/apps/ide/api.py
@@ -1,0 +1,67 @@
+"""Loopback HTTP helpers for juno serve (ADR-06). Stdlib only."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from urllib.error import HTTPError, URLError
+from urllib.request import Request, urlopen
+
+
+@dataclass(frozen=True)
+class ApiResult:
+    ok: bool
+    status: int
+    body: dict
+    paused: bool = False
+
+
+def _request(
+    method: str,
+    url: str,
+    *,
+    token: str,
+    payload: dict | None = None,
+    timeout: float = 30,
+) -> ApiResult:
+    headers = {
+        "Authorization": f"Bearer {token}",
+        "Content-Type": "application/json",
+        "Accept": "application/json",
+    }
+    data = json.dumps(payload).encode("utf-8") if payload is not None else None
+    req = Request(url, data=data, method=method, headers=headers)
+    try:
+        with urlopen(req, timeout=timeout) as resp:
+            raw = resp.read().decode("utf-8")
+            body = json.loads(raw) if raw else {}
+            return ApiResult(ok=True, status=resp.status, body=body if isinstance(body, dict) else {})
+    except HTTPError as exc:
+        detail = exc.read().decode("utf-8", errors="replace")
+        try:
+            parsed = json.loads(detail) if detail else {}
+        except json.JSONDecodeError:
+            parsed = {"detail": detail}
+        body = parsed if isinstance(parsed, dict) else {"detail": detail}
+        return ApiResult(
+            ok=False,
+            status=exc.code,
+            body=body,
+            paused=exc.code == 423,
+        )
+    except URLError as exc:
+        return ApiResult(ok=False, status=0, body={"detail": str(exc.reason)})
+
+
+def get_status(base_url: str, token: str, *, timeout: float = 30) -> ApiResult:
+    return _request("GET", base_url.rstrip("/") + "/status", token=token, timeout=timeout)
+
+
+def post_ingest(base_url: str, token: str, payload: dict, *, timeout: float = 30) -> ApiResult:
+    return _request(
+        "POST",
+        base_url.rstrip("/") + "/ingest",
+        token=token,
+        payload=payload,
+        timeout=timeout,
+    )

--- a/apps/ide/config.py
+++ b/apps/ide/config.py
@@ -1,0 +1,107 @@
+"""IDE adapter settings from env / .env (HTTP client — not juno Settings)."""
+
+from __future__ import annotations
+
+import os
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+
+def default_global_vscdb() -> Path:
+    if sys.platform == "win32":
+        appdata = os.environ.get("APPDATA") or str(Path.home() / "AppData" / "Roaming")
+        return Path(appdata) / "Cursor" / "User" / "globalStorage" / "state.vscdb"
+    if sys.platform == "darwin":
+        return (
+            Path.home()
+            / "Library"
+            / "Application Support"
+            / "Cursor"
+            / "User"
+            / "globalStorage"
+            / "state.vscdb"
+        )
+    xdg = os.environ.get("XDG_CONFIG_HOME")
+    base = Path(xdg) if xdg else Path.home() / ".config"
+    return base / "Cursor" / "User" / "globalStorage" / "state.vscdb"
+
+
+def default_workspace_storage() -> Path:
+    return default_global_vscdb().parent.parent / "workspaceStorage"
+
+
+def resolve_env_file(*, start: Path | None = None) -> Path | None:
+    if start is not None:
+        candidate = start.resolve() / ".env"
+        return candidate if candidate.is_file() else None
+    here = Path.cwd().resolve()
+    for base in (here, *here.parents):
+        candidate = base / ".env"
+        if candidate.is_file():
+            return candidate
+    return None
+
+
+def _load_dotenv(path: Path) -> dict[str, str]:
+    loaded: dict[str, str] = {}
+    for raw in path.read_text(encoding="utf-8").splitlines():
+        line = raw.strip()
+        if not line or line.startswith("#") or "=" not in line:
+            continue
+        key, _, value = line.partition("=")
+        key = key.strip()
+        value = value.strip().strip("'").strip('"')
+        if key:
+            loaded[key] = value
+    return loaded
+
+
+def _env(mapping: dict[str, str], key: str, default: str = "") -> str:
+    return (os.environ.get(key) or mapping.get(key) or default).strip()
+
+
+@dataclass(frozen=True)
+class IdeConfig:
+    api_base_url: str
+    api_token: str
+    global_vscdb: Path
+    workspace_storage: Path
+    poll_seconds: float
+    state_path: Path
+    workspace_filter: str | None = None
+
+    def token_is_usable(self) -> bool:
+        token = self.api_token.strip().lower()
+        return bool(token) and token != "change-me"
+
+
+def load_config(*, start: Path | None = None) -> IdeConfig:
+    """Resolve Cursor paths + loopback API settings. Env wins over .env."""
+    file_vals: dict[str, str] = {}
+    env_path = resolve_env_file(start=start)
+    if env_path is not None:
+        file_vals = _load_dotenv(env_path)
+
+    host = _env(file_vals, "JUNO_API_HOST", "127.0.0.1") or "127.0.0.1"
+    port = _env(file_vals, "JUNO_API_PORT", "8787") or "8787"
+    base = _env(file_vals, "JUNO_API_BASE_URL") or f"http://{host}:{port}"
+
+    vscdb = _env(file_vals, "JUNO_CURSOR_VSCDB")
+    workspace = _env(file_vals, "JUNO_CURSOR_WORKSPACE_STORAGE")
+    data_dir = _env(file_vals, "JUNO_DATA_DIR", "./data") or "./data"
+    state = _env(file_vals, "JUNO_IDE_STATE")
+    poll = _env(file_vals, "JUNO_IDE_POLL_SECONDS", "60") or "60"
+    filt = _env(file_vals, "JUNO_CURSOR_WORKSPACE") or None
+
+    return IdeConfig(
+        api_base_url=base.rstrip("/"),
+        api_token=_env(file_vals, "JUNO_API_TOKEN"),
+        global_vscdb=Path(vscdb).expanduser() if vscdb else default_global_vscdb(),
+        workspace_storage=(
+            Path(workspace).expanduser() if workspace else default_workspace_storage()
+        ),
+        poll_seconds=max(5.0, float(poll)),
+        state_path=Path(state).expanduser() if state else Path(data_dir) / "ide-adapter.json",
+        workspace_filter=filt,
+    )

--- a/apps/ide/smoke.py
+++ b/apps/ide/smoke.py
@@ -1,52 +1,21 @@
 #!/usr/bin/env python3
 """Spike S3 smoke: read one Cursor session from state.vscdb and POST /ingest.
 
-Stdlib only. Token from JUNO_API_TOKEN or --token. Never writes Cursor's DB.
+Stdlib only. Uses apps/ide config + api (ADR-06). Never writes Cursor's DB.
 """
 
 from __future__ import annotations
 
 import argparse
 import json
-import os
 import sys
 from pathlib import Path
-from urllib.error import HTTPError, URLError
-from urllib.request import Request, urlopen
 
-# Allow `python apps/ide/smoke.py` from repo root without installing a package.
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 
-from cursor_vscdb import (  # noqa: E402
-    connect_readonly,
-    default_global_vscdb,
-    list_sessions,
-    load_session,
-    to_ingest_payload,
-)
-
-
-def _post_ingest(payload: dict, *, base_url: str, token: str) -> dict:
-    url = base_url.rstrip("/") + "/ingest"
-    body = json.dumps(payload).encode("utf-8")
-    req = Request(
-        url,
-        data=body,
-        method="POST",
-        headers={
-            "Authorization": f"Bearer {token}",
-            "Content-Type": "application/json",
-        },
-    )
-    try:
-        with urlopen(req, timeout=30) as resp:
-            raw = resp.read().decode("utf-8")
-            return json.loads(raw) if raw else {"status_code": resp.status}
-    except HTTPError as exc:
-        detail = exc.read().decode("utf-8", errors="replace")
-        raise SystemExit(f"POST {url} failed: {exc.code} {detail}") from exc
-    except URLError as exc:
-        raise SystemExit(f"POST {url} failed: {exc.reason}") from exc
+from api import post_ingest  # noqa: E402
+from config import load_config  # noqa: E402
+from cursor_vscdb import connect_readonly, list_sessions, load_session, to_ingest_payload  # noqa: E402
 
 
 def main(argv: list[str] | None = None) -> None:
@@ -60,17 +29,20 @@ def main(argv: list[str] | None = None) -> None:
         "--db",
         type=Path,
         default=None,
-        help="Path to global state.vscdb (default: platform Cursor path)",
+        help="Path to global state.vscdb (default: JUNO_CURSOR_VSCDB or platform path)",
     )
     parser.add_argument("--composer-id", default=None, help="Export this composer id")
     parser.add_argument("--latest", action="store_true", help="Export the newest session")
     parser.add_argument("--limit", type=int, default=8, help="discover: max rows to print")
     parser.add_argument("--post", action="store_true", help="POST the export to /ingest")
-    parser.add_argument("--base-url", default="http://127.0.0.1:8787")
-    parser.add_argument("--token", default=os.environ.get("JUNO_API_TOKEN", ""))
+    parser.add_argument("--base-url", default=None)
+    parser.add_argument("--token", default=None)
     args = parser.parse_args(argv)
 
-    db_path = args.db or default_global_vscdb()
+    cfg = load_config()
+    db_path = args.db or cfg.global_vscdb
+    base_url = args.base_url or cfg.api_base_url
+    token = args.token if args.token is not None else cfg.api_token
     conn = connect_readonly(db_path)
     try:
         sessions = list_sessions(conn)
@@ -100,11 +72,12 @@ def main(argv: list[str] | None = None) -> None:
         print(f"bubbles={len(loaded.bubbles)} text_chars={len(payload.get('text') or '')}")
         if not args.post:
             return
-        token = (args.token or "").strip()
-        if not token or token.lower() == "change-me":
+        if not (token or "").strip() or token.strip().lower() == "change-me":
             raise SystemExit("Set --token or JUNO_API_TOKEN (not change-me)")
-        result = _post_ingest(payload, base_url=args.base_url, token=token)
-        print(json.dumps(result, indent=2))
+        result = post_ingest(base_url, token, payload)
+        if not result.ok:
+            raise SystemExit(f"POST {base_url}/ingest failed: {result.status} {result.body}")
+        print(json.dumps(result.body, indent=2))
     finally:
         conn.close()
 

--- a/apps/ide/sync.py
+++ b/apps/ide/sync.py
@@ -1,0 +1,161 @@
+#!/usr/bin/env python3
+"""Poll Cursor state.vscdb and POST new/updated chats to loopback /ingest.
+
+HTTP client only (ADR-06). Watermark is a local JSON file, not Juno SQLite/Chroma.
+Idempotent capture rows land in #66; this scaffold posts sessions newer than the watermark.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+import time
+from datetime import UTC, datetime
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from api import post_ingest  # noqa: E402
+from config import IdeConfig, load_config  # noqa: E402
+from cursor_vscdb import (  # noqa: E402
+    CursorSession,
+    connect_readonly,
+    list_sessions,
+    load_session,
+    to_ingest_payload,
+)
+
+
+def _parse_iso(value: str | None) -> datetime | None:
+    if not value:
+        return None
+    text = value.strip()
+    if text.endswith("Z"):
+        text = text[:-1] + "+00:00"
+    try:
+        parsed = datetime.fromisoformat(text)
+    except ValueError:
+        return None
+    if parsed.tzinfo is None:
+        return parsed.replace(tzinfo=UTC)
+    return parsed.astimezone(UTC)
+
+
+def load_watermark(path: Path) -> datetime | None:
+    if not path.is_file():
+        return None
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return None
+    if not isinstance(data, dict):
+        return None
+    return _parse_iso(str(data.get("watermark") or ""))
+
+
+def save_watermark(path: Path, when: datetime) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps({"watermark": when.astimezone(UTC).isoformat(), "module": "ide"}, indent=2)
+        + "\n",
+        encoding="utf-8",
+    )
+
+
+def _matches_workspace(session: CursorSession, filt: str | None) -> bool:
+    if not filt:
+        return True
+    needle = filt.casefold()
+    hay = " ".join(
+        part for part in (session.workspace_path, session.workspace_id, session.name) if part
+    )
+    return needle in hay.casefold()
+
+
+def due_sessions(
+    sessions: list[CursorSession],
+    *,
+    watermark: datetime | None,
+    limit: int,
+    workspace_filter: str | None,
+) -> list[CursorSession]:
+    newer: list[CursorSession] = []
+    for session in sessions:
+        if not _matches_workspace(session, workspace_filter):
+            continue
+        if watermark is not None and session.updated_at is not None:
+            if session.updated_at <= watermark:
+                continue
+        newer.append(session)
+    batch = newer[: max(1, limit)]
+    return list(reversed(batch))
+
+
+def sync_once(cfg: IdeConfig, *, limit: int, dry_run: bool) -> tuple[int, int]:
+    """Return (posted, paused_or_failed)."""
+    conn = connect_readonly(cfg.global_vscdb)
+    try:
+        sessions = list_sessions(conn)
+        watermark = load_watermark(cfg.state_path)
+        due = due_sessions(
+            sessions,
+            watermark=watermark,
+            limit=limit,
+            workspace_filter=cfg.workspace_filter,
+        )
+        posted = 0
+        blocked = 0
+        latest = watermark
+        for meta in due:
+            loaded = load_session(conn, meta.composer_id)
+            if loaded is None or not loaded.bubbles:
+                continue
+            payload = to_ingest_payload(loaded)
+            if dry_run:
+                print(f"dry-run {payload['uri']} {payload['title']!r}")
+                posted += 1
+                if loaded.updated_at and (latest is None or loaded.updated_at > latest):
+                    latest = loaded.updated_at
+                continue
+            if not cfg.token_is_usable():
+                raise SystemExit("Set JUNO_API_TOKEN (not change-me)")
+            result = post_ingest(cfg.api_base_url, cfg.api_token, payload)
+            if result.paused:
+                print("capture paused (423) — backing off")
+                blocked += 1
+                break
+            if not result.ok:
+                print(f"ingest failed {result.status}: {result.body}")
+                blocked += 1
+                continue
+            print(f"committed {result.body.get('capture_id')} {payload['uri']}")
+            posted += 1
+            if loaded.updated_at and (latest is None or loaded.updated_at > latest):
+                latest = loaded.updated_at
+        if not dry_run and latest is not None and posted:
+            save_watermark(cfg.state_path, latest)
+        return posted, blocked
+    finally:
+        conn.close()
+
+
+def main(argv: list[str] | None = None) -> None:
+    parser = argparse.ArgumentParser(description="Poll Cursor chats → POST /ingest")
+    parser.add_argument("--once", action="store_true", help="Single pass (default)")
+    parser.add_argument("--watch", action="store_true", help="Poll until interrupted")
+    parser.add_argument("--limit", type=int, default=8, help="Max sessions per pass")
+    parser.add_argument("--dry-run", action="store_true")
+    args = parser.parse_args(argv)
+    cfg = load_config()
+    watch = args.watch
+    while True:
+        posted, blocked = sync_once(cfg, limit=args.limit, dry_run=args.dry_run)
+        print(f"sync posted={posted} blocked={blocked} db={cfg.global_vscdb}")
+        if not watch:
+            return
+        time.sleep(cfg.poll_seconds)
+
+
+if __name__ == "__main__":
+    main()

--- a/docs/adr/006-ide-adapter-client.md
+++ b/docs/adr/006-ide-adapter-client.md
@@ -52,7 +52,7 @@ Cursor's storage is unofficial and has already migrated once (per-workspace `com
 - Guard missing fields; skip empty tool bubbles; do not assume `conversationMap` still holds text.
 - Mitigation: keep a fixture `state.vscdb` in tests; bump the reader when a live discover fails; record the Cursor version in the session log.
 
-Watch/poll, config paths, idempotent re-sync, terminal errors, HITL, and module health stay in later M3 issues (#65–#72).
+Watch/poll, config paths, and CI layout: [#65](https://github.com/Anna-Hax/JUNO/issues/65). Idempotent re-sync, terminal errors, HITL, and module health stay in later M3 issues (#66–#72).
 
 ## Consequences
 

--- a/docs/next-work.md
+++ b/docs/next-work.md
@@ -103,7 +103,7 @@ Milestone: [M3: v1.2 IDE Capture](https://github.com/Anna-Hax/JUNO/milestone/9).
 | Order | Issue | Title |
 | ----- | ----- | ----- |
 | 1 | [#64](https://github.com/Anna-Hax/JUNO/issues/64) | Spike S3 — Cursor state.vscdb / exporter POST /ingest smoke — ✅ [session 29](sessions/29-session-spike-s3.md) |
-| 2 | [#65](https://github.com/Anna-Hax/JUNO/issues/65) | IDE adapter scaffold — wrap exporter, config paths, CI |
+| 2 | [#65](https://github.com/Anna-Hax/JUNO/issues/65) | IDE adapter scaffold — wrap exporter, config paths, CI — ✅ [session 30](sessions/30-session-ide-scaffold.md) |
 | 3 | [#66](https://github.com/Anna-Hax/JUNO/issues/66) | Chat/composer bubbles — ingest Cursor sessions via /ingest |
 | 4 | [#67](https://github.com/Anna-Hax/JUNO/issues/67) | Terminal error capture from IDE sessions |
 | 5 | [#68](https://github.com/Anna-Hax/JUNO/issues/68) | HITL — confirm IDE error-match / review sensitive chat batches |
@@ -113,7 +113,7 @@ Milestone: [M3: v1.2 IDE Capture](https://github.com/Anna-Hax/JUNO/milestone/9).
 | 9 | [#72](https://github.com/Anna-Hax/JUNO/issues/72) | Module health — ide sync freshness in /status + respect /pause |
 | 10 | [#73](https://github.com/Anna-Hax/JUNO/issues/73) | M3 gate — IDE tests, ADR, README, v1.2 release gate |
 
-**First coding task:** Spike S3 ([#64](https://github.com/Anna-Hax/JUNO/issues/64)) — ✅ done 2026-09-02 ([session 29](sessions/29-session-spike-s3.md)). Next: [#65](https://github.com/Anna-Hax/JUNO/issues/65) IDE adapter scaffold.
+**First coding task:** Spike S3 ([#64](https://github.com/Anna-Hax/JUNO/issues/64)) — ✅ done 2026-09-02 ([session 29](sessions/29-session-spike-s3.md)). Adapter scaffold ([#65](https://github.com/Anna-Hax/JUNO/issues/65)) — ✅ [session 30](sessions/30-session-ide-scaffold.md). Next: [#66](https://github.com/Anna-Hax/JUNO/issues/66) chat/composer ingest.
 
 ### M3 design constraints (do not violate)
 

--- a/docs/sessions/02-codebase-map.md
+++ b/docs/sessions/02-codebase-map.md
@@ -63,7 +63,7 @@ Optional: `--extra embeddings` for sentence-transformers; `--extra dev` for pyte
 ## IDE adapter (M3 / Spike S3)
 
 - `apps/ide/cursor_vscdb.py` — read-only Cursor `state.vscdb` wrapper
-- `apps/ide/smoke.py` — discover / export / `POST /ingest` ([ADR-06](../adr/006-ide-adapter-client.md))
+- `apps/ide/config.py` / `api.py` / `sync.py` — env paths, loopback HTTP, poll/watch ([ADR-06](../adr/006-ide-adapter-client.md))
 
 ---
 

--- a/docs/sessions/30-session-ide-scaffold.md
+++ b/docs/sessions/30-session-ide-scaffold.md
@@ -1,0 +1,21 @@
+# Session 30 — IDE adapter scaffold (#65)
+
+**Date:** 2026-09-02  
+**Issue:** [#65](https://github.com/Anna-Hax/JUNO/issues/65)  
+**Branch:** `feat/ide-scaffold-65`
+
+## What changed
+
+- Split `apps/ide/` into `config.py` + `api.py` + `cursor_vscdb.py`; `smoke.py` stays one-shot export.
+- `sync.py` polls Cursor paths (`--once` / `--watch`), watermark in `data/ide-adapter.json`, backs off on 423.
+- `.env.example` Cursor path + poll settings; `scripts/validate-ide.py` + CI IDE workflow.
+
+## Verify
+
+```powershell
+python scripts/validate-ide.py
+python apps/ide/sync.py --once --dry-run
+cd apps/core
+$env:EMBEDDING_BACKEND='stub'
+uv run pytest tests/test_ide_scaffold.py tests/test_ide_vscdb.py -q
+```

--- a/docs/sessions/README.md
+++ b/docs/sessions/README.md
@@ -35,6 +35,7 @@ Living notes for what was implemented, how GitHub is set up, and what to do next
 | [27-session-digest-enrichment.md](27-session-digest-enrichment.md) | **#52** — Digest enrichment (browser vs uploads) |
 | [28-session-m2-gate.md](28-session-m2-gate.md) | **#53** — M2 gate + extension validation |
 | [29-session-spike-s3.md](29-session-spike-s3.md) | **#64** — Spike S3 Cursor vscdb → /ingest |
+| [30-session-ide-scaffold.md](30-session-ide-scaffold.md) | **#65** — IDE adapter scaffold |
 | [v1.0-release-gate.md](../v1.0-release-gate.md) | M1 checklist (all P0 closed) |
 | [v1.1-release-gate.md](../v1.1-release-gate.md) | M2 checklist (browser capture) |
 

--- a/scripts/validate-ide.py
+++ b/scripts/validate-ide.py
@@ -1,0 +1,48 @@
+#!/usr/bin/env python3
+"""Validate apps/ide layout, required modules, and Python syntax."""
+
+from __future__ import annotations
+
+import py_compile
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+IDE = ROOT / "apps" / "ide"
+
+REQUIRED_FILES = (
+    "README.md",
+    "cursor_vscdb.py",
+    "config.py",
+    "api.py",
+    "sync.py",
+    "smoke.py",
+)
+
+
+def _fail(msg: str) -> None:
+    print(f"validate-ide: {msg}", file=sys.stderr)
+    sys.exit(1)
+
+
+def main() -> None:
+    if not IDE.is_dir():
+        _fail(f"ide dir not found: {IDE}")
+    for rel in REQUIRED_FILES:
+        path = IDE / rel
+        if not path.is_file():
+            _fail(f"missing required file: {rel}")
+    py_files = sorted(IDE.glob("*.py"))
+    for path in py_files:
+        text = path.read_text(encoding="utf-8")
+        if "0.0.0.0" in text:
+            _fail(f"{path.name} must not bind 0.0.0.0")
+        try:
+            py_compile.compile(str(path), doraise=True)
+        except py_compile.PyCompileError as exc:
+            _fail(f"syntax error in {path.name}: {exc}")
+    print(f"validate-ide: OK ({len(REQUIRED_FILES)} required files, {len(py_files)} py)")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- Package layout: `config.py` / `api.py` / `sync.py` wrapping the Spike S3 exporter.
- Env settings for global/workspace `state.vscdb` paths, poll interval, and a local watermark file.
- CI `validate-ide.py` (required files, syntax, no `0.0.0.0` bind).

## Linked issue
Closes #65

## Test plan
- [x] `python scripts/validate-ide.py`
- [x] `uv run pytest tests/test_ide_scaffold.py tests/test_ide_vscdb.py`
- [x] `uv run ruff check src tests`
- [x] `python apps/ide/sync.py --once --dry-run`