### PR TITLE
feat(ingest): idempotent IDE chat captures by composer uri

### DIFF
--- a/apps/core/src/juno/graph/vectors.py
+++ b/apps/core/src/juno/graph/vectors.py
@@ -190,3 +190,6 @@ class VectorStore:
 
     async def query_async(self, text: str, *, n_results: int = 8) -> list[VectorHit]:
         return await asyncio.to_thread(self.query, text, n_results=n_results)
+
+    async def delete_async(self, ids: Sequence[str]) -> None:
+        await asyncio.to_thread(self.delete, ids)

--- a/apps/core/src/juno/ingest/pipeline.py
+++ b/apps/core/src/juno/ingest/pipeline.py
@@ -9,6 +9,7 @@ from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any, Protocol
 
+from sqlalchemy import delete, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from juno.graph.db import Database
@@ -164,12 +165,24 @@ class IngestPipeline:
                 browser_raw["metrics"] = raw["metrics"]
             if raw and isinstance(raw.get("highlights"), list):
                 browser_raw["highlights"] = raw["highlights"]
+        ide_raw = raw
+        if source_type == "ide":
+            ide_raw = {
+                **(raw or {}),
+                "kind": (raw or {}).get("kind") or "cursor_chat",
+                "visited_at": (visited_at or datetime.now(UTC)).isoformat(),
+                "uri": uri,
+                "title": title,
+            }
+            if raw and isinstance(raw.get("bubbles"), list):
+                ide_raw["bubbles"] = raw["bubbles"]
+        stored_raw = browser_raw if source_type == "browser" else ide_raw
         return await self.ingest_text(
             text=str(text) if text is not None else "",
             source_type=source_type,
             uri=str(uri) if uri else None,
             title=str(title) if title else None,
-            raw=browser_raw if source_type == "browser" else raw,
+            raw=stored_raw,
             captured_at=visited_at,
         )
 
@@ -182,19 +195,52 @@ class IngestPipeline:
     ) -> IngestResult:
         pieces = chunk_text(extracted.text or "")
 
-        async def write(session: AsyncSession) -> tuple[int, list[tuple[str, str]]]:
-            capture = Capture(
-                source_type=source_type,
-                uri=extracted.uri,
-                title=extracted.title,
-                text=extracted.text or None,
-                raw_json=extracted.raw or None,
-                status="committed",
-            )
-            if captured_at is not None:
-                capture.captured_at = captured_at
-            session.add(capture)
-            await session.flush()
+        async def write(
+            session: AsyncSession,
+        ) -> tuple[int, list[tuple[str, str]], list[str]]:
+            stale: list[str] = []
+            capture: Capture | None = None
+            if source_type == "ide" and extracted.uri:
+                found = await session.execute(
+                    select(Capture).where(
+                        Capture.source_type == "ide",
+                        Capture.uri == extracted.uri,
+                    )
+                )
+                capture = found.scalar_one_or_none()
+                if capture is not None and _ide_unchanged(capture, extracted):
+                    existing = await session.execute(
+                        select(Chunk).where(Chunk.capture_id == capture.id)
+                    )
+                    stored = [
+                        (row.chroma_id, row.text) for row in existing.scalars() if row.chroma_id
+                    ]
+                    await _touch_health(session, ok=True)
+                    return capture.id, stored, []
+                if capture is not None:
+                    old = await session.execute(select(Chunk).where(Chunk.capture_id == capture.id))
+                    stale = [row.chroma_id for row in old.scalars() if row.chroma_id]
+                    await session.execute(delete(Chunk).where(Chunk.capture_id == capture.id))
+                    capture.title = extracted.title
+                    capture.text = extracted.text or None
+                    capture.raw_json = extracted.raw or None
+                    capture.status = "committed"
+                    capture.error_reason = None
+                    if captured_at is not None:
+                        capture.captured_at = captured_at
+            if capture is None:
+                capture = Capture(
+                    source_type=source_type,
+                    uri=extracted.uri,
+                    title=extracted.title,
+                    text=extracted.text or None,
+                    raw_json=extracted.raw or None,
+                    status="committed",
+                )
+                if captured_at is not None:
+                    capture.captured_at = captured_at
+                session.add(capture)
+                await session.flush()
             stored: list[tuple[str, str]] = []
             for ordinal, piece in enumerate(pieces):
                 chroma_id = f"c{capture.id}-n{ordinal}"
@@ -207,12 +253,15 @@ class IngestPipeline:
                     )
                 )
                 stored.append((chroma_id, piece))
+            reused = {item[0] for item in stored}
+            stale = [cid for cid in stale if cid not in reused]
             await _touch_health(session, ok=True)
             if source_type == "browser":
                 await _touch_health(session, ok=True, module="extension")
-            return capture.id, stored
+            return capture.id, stored, stale
 
-        capture_id, stored = await self.db.write(write)
+        capture_id, stored, stale = await self.db.write(write)
+        await self._delete_vectors(stale)
         await self._upsert_vectors(capture_id, source_type, stored)
         return IngestResult(
             accepted=True,
@@ -279,6 +328,34 @@ class IngestPipeline:
             )
         except Exception:  # noqa: BLE001
             logger.exception("vector upsert failed for capture %s", capture_id)
+
+    async def _delete_vectors(self, ids: Sequence[str]) -> None:
+        if self.vectors is None or not ids:
+            return
+        deleter = getattr(self.vectors, "delete_async", None)
+        if deleter is None:
+            deleter = getattr(self.vectors, "delete", None)
+            if deleter is None:
+                return
+            try:
+                deleter(ids)
+            except Exception:  # noqa: BLE001
+                logger.exception("vector delete failed")
+            return
+        try:
+            await deleter(ids)
+        except Exception:  # noqa: BLE001
+            logger.exception("vector delete failed")
+
+
+def _ide_unchanged(capture: Capture, extracted: Extracted) -> bool:
+    old = capture.raw_json if isinstance(capture.raw_json, dict) else {}
+    new = extracted.raw if isinstance(extracted.raw, dict) else {}
+    if (capture.text or "") != (extracted.text or ""):
+        return False
+    if old.get("updated_at") and new.get("updated_at"):
+        return old.get("updated_at") == new.get("updated_at")
+    return old.get("composer_id") == new.get("composer_id") and bool(old.get("composer_id"))
 
 
 async def _touch_health(

--- a/apps/core/tests/test_ide_vscdb.py
+++ b/apps/core/tests/test_ide_vscdb.py
@@ -11,11 +11,12 @@ from pathlib import Path
 
 import httpx
 import pytest
+from sqlalchemy import func, select
 
 from juno.api import create_app
 from juno.graph.db import Database
 from juno.ingest.pipeline import IngestPipeline
-from juno.models import Capture
+from juno.models import Capture, Chunk
 
 REPO_ROOT = Path(__file__).resolve().parents[3]
 _IDE_MOD = REPO_ROOT / "apps" / "ide" / "cursor_vscdb.py"
@@ -177,6 +178,9 @@ async def test_ide_payload_commits_via_pipeline(db, pipeline: IngestPipeline, vs
         assert row.uri == payload["uri"]
         assert row.raw_json is not None
         assert row.raw_json.get("composer_id") == COMPOSER_ID
+        assert row.raw_json.get("kind") == "cursor_chat"
+        assert isinstance(row.raw_json.get("bubbles"), list)
+        assert row.raw_json["bubbles"][0]["role"] == "user"
         return row
 
     await db.read(read)
@@ -202,6 +206,84 @@ async def test_ide_ingest_http_roundtrip(db, pipeline: IngestPipeline, settings)
     assert body["accepted"] is True
     assert body["source_type"] == "ide"
     assert body["status"] == "committed"
+
+
+@pytest.mark.asyncio
+async def test_ide_ingest_is_idempotent_on_replay(db, pipeline: IngestPipeline):
+    payload = {
+        "source_type": "ide",
+        "uri": "cursor://composer/replay",
+        "title": "Replay chat",
+        "text": "user:\nhello\n\nassistant:\nworld\n",
+        "visited_at": "2026-09-02T12:00:00+00:00",
+        "raw_json": {
+            "kind": "cursor_chat",
+            "composer_id": "replay",
+            "updated_at": "2026-09-02T12:00:00+00:00",
+            "bubbles": [
+                {"bubble_id": "u1", "role": "user", "text": "hello"},
+                {"bubble_id": "a1", "role": "assistant", "text": "world"},
+            ],
+        },
+    }
+    first = await pipeline.ingest_payload(payload)
+    second = await pipeline.ingest_payload(payload)
+    assert first.capture_id == second.capture_id
+
+    async def count(session):
+        n = await session.scalar(
+            select(func.count()).select_from(Capture).where(Capture.uri == payload["uri"])
+        )
+        return int(n or 0)
+
+    assert await db.read(count) == 1
+
+
+@pytest.mark.asyncio
+async def test_ide_ingest_updates_same_uri_when_chat_grows(db, pipeline: IngestPipeline):
+    uri = "cursor://composer/grow"
+    first = await pipeline.ingest_payload(
+        {
+            "source_type": "ide",
+            "uri": uri,
+            "title": "Growing chat",
+            "text": "user:\nlock\n",
+            "raw_json": {
+                "composer_id": "grow",
+                "updated_at": "2026-09-02T12:00:00+00:00",
+                "bubbles": [{"bubble_id": "u1", "role": "user", "text": "lock"}],
+            },
+        }
+    )
+    second = await pipeline.ingest_payload(
+        {
+            "source_type": "ide",
+            "uri": uri,
+            "title": "Growing chat",
+            "text": "user:\nlock\n\nassistant:\nuse WAL\n",
+            "raw_json": {
+                "composer_id": "grow",
+                "updated_at": "2026-09-02T13:00:00+00:00",
+                "bubbles": [
+                    {"bubble_id": "u1", "role": "user", "text": "lock"},
+                    {"bubble_id": "a1", "role": "assistant", "text": "use WAL"},
+                ],
+            },
+        }
+    )
+    assert first.capture_id == second.capture_id
+
+    async def read(session):
+        row = await session.get(Capture, second.capture_id)
+        assert row is not None
+        assert "use WAL" in (row.text or "")
+        chunks = list(
+            (await session.execute(select(Chunk).where(Chunk.capture_id == row.id))).scalars()
+        )
+        assert chunks
+        return row
+
+    await db.read(read)
 
 
 def test_format_session_text_includes_workspace(vscdb: Path):

--- a/apps/ide/README.md
+++ b/apps/ide/README.md
@@ -41,7 +41,7 @@ python apps/ide/sync.py --once
 python apps/ide/sync.py --watch
 ```
 
-`--watch` polls until Ctrl+C. Global `/pause` returns 423; the adapter backs off that pass. Duplicate capture rows on re-sync are handled in #66.
+`--watch` polls until Ctrl+C. Global `/pause` returns 423; the adapter backs off that pass. Re-posting the same `cursor://composer/{id}` updates one capture (no duplicate storms).
 
 ## CI
 

--- a/docs/next-work.md
+++ b/docs/next-work.md
@@ -104,7 +104,7 @@ Milestone: [M3: v1.2 IDE Capture](https://github.com/Anna-Hax/JUNO/milestone/9).
 | ----- | ----- | ----- |
 | 1 | [#64](https://github.com/Anna-Hax/JUNO/issues/64) | Spike S3 — Cursor state.vscdb / exporter POST /ingest smoke — ✅ [session 29](sessions/29-session-spike-s3.md) |
 | 2 | [#65](https://github.com/Anna-Hax/JUNO/issues/65) | IDE adapter scaffold — wrap exporter, config paths, CI — ✅ [session 30](sessions/30-session-ide-scaffold.md) |
-| 3 | [#66](https://github.com/Anna-Hax/JUNO/issues/66) | Chat/composer bubbles — ingest Cursor sessions via /ingest |
+| 3 | [#66](https://github.com/Anna-Hax/JUNO/issues/66) | Chat/composer bubbles — ingest Cursor sessions via /ingest — ✅ [session 31](sessions/31-session-ide-chat.md) |
 | 4 | [#67](https://github.com/Anna-Hax/JUNO/issues/67) | Terminal error capture from IDE sessions |
 | 5 | [#68](https://github.com/Anna-Hax/JUNO/issues/68) | HITL — confirm IDE error-match / review sensitive chat batches |
 | 6 | [#69](https://github.com/Anna-Hax/JUNO/issues/69) | Error-matching retrieval — have I seen this error before? |
@@ -113,7 +113,7 @@ Milestone: [M3: v1.2 IDE Capture](https://github.com/Anna-Hax/JUNO/milestone/9).
 | 9 | [#72](https://github.com/Anna-Hax/JUNO/issues/72) | Module health — ide sync freshness in /status + respect /pause |
 | 10 | [#73](https://github.com/Anna-Hax/JUNO/issues/73) | M3 gate — IDE tests, ADR, README, v1.2 release gate |
 
-**First coding task:** Spike S3 ([#64](https://github.com/Anna-Hax/JUNO/issues/64)) — ✅ done 2026-09-02 ([session 29](sessions/29-session-spike-s3.md)). Adapter scaffold ([#65](https://github.com/Anna-Hax/JUNO/issues/65)) — ✅ [session 30](sessions/30-session-ide-scaffold.md). Next: [#66](https://github.com/Anna-Hax/JUNO/issues/66) chat/composer ingest.
+**First coding task:** Spike S3 ([#64](https://github.com/Anna-Hax/JUNO/issues/64)) — ✅. Adapter scaffold ([#65](https://github.com/Anna-Hax/JUNO/issues/65)) — ✅. Chat ingest ([#66](https://github.com/Anna-Hax/JUNO/issues/66)) — ✅ [session 31](sessions/31-session-ide-chat.md). Next: [#67](https://github.com/Anna-Hax/JUNO/issues/67) terminal errors.
 
 ### M3 design constraints (do not violate)
 

--- a/docs/sessions/31-session-ide-chat.md
+++ b/docs/sessions/31-session-ide-chat.md
@@ -1,0 +1,18 @@
+# Session 31 — Chat/composer ingest (#66)
+
+**Date:** 2026-09-02  
+**Issue:** [#66](https://github.com/Anna-Hax/JUNO/issues/66)  
+**Branch:** `feat/ide-chat-66`
+
+## What changed
+
+- `source_type=ide` stores `raw_json.kind=cursor_chat` plus bubble list.
+- Re-sync is keyed by `uri` (`cursor://composer/{id}`): unchanged payloads keep one row; newer `updated_at` / text replaces chunks in place.
+
+## Verify
+
+```powershell
+cd apps/core
+$env:EMBEDDING_BACKEND='stub'
+uv run pytest tests/test_ide_vscdb.py -q
+```

--- a/docs/sessions/README.md
+++ b/docs/sessions/README.md
@@ -36,6 +36,7 @@ Living notes for what was implemented, how GitHub is set up, and what to do next
 | [28-session-m2-gate.md](28-session-m2-gate.md) | **#53** — M2 gate + extension validation |
 | [29-session-spike-s3.md](29-session-spike-s3.md) | **#64** — Spike S3 Cursor vscdb → /ingest |
 | [30-session-ide-scaffold.md](30-session-ide-scaffold.md) | **#65** — IDE adapter scaffold |
+| [31-session-ide-chat.md](31-session-ide-chat.md) | **#66** — Chat/composer ingest |
 | [v1.0-release-gate.md](../v1.0-release-gate.md) | M1 checklist (all P0 closed) |
 | [v1.1-release-gate.md](../v1.1-release-gate.md) | M2 checklist (browser capture) |
 


### PR DESCRIPTION
## Summary
- `source_type=ide` stores chat bubbles in `raw_json` (`kind=cursor_chat`).
- Re-sync upserts by `cursor://composer/{id}`: unchanged payloads keep one row; newer text replaces chunks.

## Linked issue
Closes #66

## Test plan
- [x] `uv run pytest tests/test_ide_vscdb.py tests/test_ingest.py`
- [x] `uv run ruff check src tests`