### PR TITLE
feat(ide): capture terminal command errors from Cursor sessions

### DIFF
--- a/apps/core/tests/test_ide_vscdb.py
+++ b/apps/core/tests/test_ide_vscdb.py
@@ -27,9 +27,11 @@ sys.modules["cursor_vscdb"] = _cursor
 _SPEC.loader.exec_module(_cursor)
 
 connect_readonly = _cursor.connect_readonly
+extract_errors = _cursor.extract_errors
 format_session_text = _cursor.format_session_text
 list_sessions = _cursor.list_sessions
 load_session = _cursor.load_session
+to_error_ingest_payload = _cursor.to_error_ingest_payload
 to_ingest_payload = _cursor.to_ingest_payload
 
 COMPOSER_ID = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
@@ -69,7 +71,20 @@ def _write_fixture(path: Path) -> None:
         ],
     }
     user_bubble = {"bubbleId": BID_USER, "type": 1, "text": "database is locked on ingest"}
-    tool_bubble = {"bubbleId": BID_TOOL, "type": 2, "text": ""}
+    tool_bubble = {
+        "bubbleId": BID_TOOL,
+        "type": 2,
+        "text": "",
+        "createdAt": "2026-09-02T00:00:30Z",
+        "toolFormerData": {
+            "name": "run_terminal_command_v2",
+            "status": "error",
+            "params": {"command": "uv run pytest", "cwd": r"D:\proj\demo"},
+            "result": {
+                "output": "database is locked\nTraceback (most recent call last):\n  File ingest.py"
+            },
+        },
+    }
     asst_bubble = {
         "bubbleId": BID_ASST,
         "type": 2,
@@ -297,3 +312,49 @@ def test_format_session_text_includes_workspace(vscdb: Path):
     assert "Workspace:" in text
     assert "demo" in text
     assert "database is locked" in text
+
+
+def test_extract_terminal_errors_from_tool_bubbles(vscdb: Path):
+    conn = connect_readonly(vscdb)
+    try:
+        errors = extract_errors(conn, COMPOSER_ID, workspace_path=r"D:\proj\demo")
+        loaded = load_session(conn, COMPOSER_ID)
+    finally:
+        conn.close()
+    assert len(errors) == 1
+    err = errors[0]
+    assert err.uri == f"cursor://error/{COMPOSER_ID}/{BID_TOOL}"
+    assert err.command == "uv run pytest"
+    assert "database is locked" in err.message
+    assert "Traceback" in err.stack
+    payload = to_error_ingest_payload(err)
+    assert payload["source_type"] == "ide"
+    assert payload["raw_json"]["kind"] == "cursor_error"
+    assert loaded is not None
+    assert len(loaded.bubbles) == 2
+
+
+@pytest.mark.asyncio
+async def test_ide_error_ingest_commits_and_is_idempotent(
+    db, pipeline: IngestPipeline, vscdb: Path
+):
+    conn = connect_readonly(vscdb)
+    try:
+        errors = extract_errors(conn, COMPOSER_ID, workspace_path=r"D:\proj\demo")
+        payload = to_error_ingest_payload(errors[0])
+    finally:
+        conn.close()
+    first = await pipeline.ingest_payload(payload)
+    second = await pipeline.ingest_payload(payload)
+    assert first.capture_id == second.capture_id
+
+    async def read(session):
+        row = await session.get(Capture, first.capture_id)
+        assert row is not None
+        assert row.source_type == "ide"
+        assert row.raw_json is not None
+        assert row.raw_json.get("kind") == "cursor_error"
+        assert "Traceback" in (row.text or "")
+        return row
+
+    await db.read(read)

--- a/apps/ide/README.md
+++ b/apps/ide/README.md
@@ -41,7 +41,7 @@ python apps/ide/sync.py --once
 python apps/ide/sync.py --watch
 ```
 
-`--watch` polls until Ctrl+C. Global `/pause` returns 423; the adapter backs off that pass. Re-posting the same `cursor://composer/{id}` updates one capture (no duplicate storms).
+`--watch` polls until Ctrl+C. Global `/pause` returns 423; the adapter backs off that pass. Re-posting the same `cursor://composer/{id}` or `cursor://error/{id}/{bubble}` updates one capture (no duplicate storms). Terminal command failures (`run_terminal_command_v2` / error-like output) ingest as `raw_json.kind=cursor_error`.
 
 ## CI
 

--- a/apps/ide/cursor_vscdb.py
+++ b/apps/ide/cursor_vscdb.py
@@ -21,6 +21,17 @@ from pathlib import Path
 from typing import Any
 
 ROLE_BY_TYPE = {1: "user", 2: "assistant"}
+TERMINAL_TOOLS = frozenset({"run_terminal_command", "run_terminal_command_v2"})
+ERROR_MARKERS = (
+    "Traceback",
+    "Error:",
+    "error:",
+    "FAILED",
+    "panic:",
+    "cannot use",
+    "Exception",
+    "error NG",
+)
 
 
 @dataclass(frozen=True)
@@ -45,6 +56,22 @@ class CursorSession:
     @property
     def uri(self) -> str:
         return f"cursor://composer/{self.composer_id}"
+
+
+@dataclass(frozen=True)
+class IdeError:
+    composer_id: str
+    bubble_id: str
+    message: str
+    stack: str
+    command: str | None = None
+    workspace_path: str | None = None
+    created_at: datetime | None = None
+    tool_name: str | None = None
+
+    @property
+    def uri(self) -> str:
+        return f"cursor://error/{self.composer_id}/{self.bubble_id}"
 
 
 def default_global_vscdb() -> Path:
@@ -336,6 +363,116 @@ def load_session(conn: sqlite3.Connection, composer_id: str) -> CursorSession | 
         mode=str(payload.get("unifiedMode") or payload.get("forceMode") or "") or None,
         bubbles=tuple(bubbles),
     )
+
+
+def _tool_output(tf: dict[str, Any]) -> str:
+    result = tf.get("result")
+    if isinstance(result, dict):
+        return str(result.get("output") or result.get("stderr") or result.get("error") or "")
+    if isinstance(result, str):
+        parsed = _parse_json(result)
+        if parsed:
+            return str(parsed.get("output") or parsed.get("stderr") or parsed.get("error") or result)
+        return result
+    return ""
+
+
+def _tool_command(tf: dict[str, Any]) -> str | None:
+    params = tf.get("params")
+    if isinstance(params, str):
+        params = _parse_json(params)
+    if isinstance(params, dict):
+        cmd = params.get("command")
+        if cmd:
+            return str(cmd)
+    raw_args = tf.get("rawArgs")
+    if isinstance(raw_args, str):
+        parsed = _parse_json(raw_args)
+        cmd = parsed.get("command") if parsed else None
+        if cmd:
+            return str(cmd)
+    return None
+
+
+def _looks_like_error(text: str) -> bool:
+    return any(marker in text for marker in ERROR_MARKERS)
+
+
+def extract_errors(
+    conn: sqlite3.Connection,
+    composer_id: str,
+    *,
+    workspace_path: str | None = None,
+) -> list[IdeError]:
+    """Terminal / tool failures from a composer session (empty tool bubbles included)."""
+    data = _kv_get(conn, f"composerData:{composer_id}")
+    headers = data.get("fullConversationHeadersOnly") or []
+    errors: list[IdeError] = []
+    for header in headers:
+        if not isinstance(header, dict):
+            continue
+        bubble_id = str(header.get("bubbleId") or header.get("id") or "")
+        if not bubble_id:
+            continue
+        raw = _kv_get(conn, f"bubbleId:{composer_id}:{bubble_id}")
+        tf = raw.get("toolFormerData")
+        if not isinstance(tf, dict):
+            continue
+        name = str(tf.get("name") or "")
+        status = str(tf.get("status") or "").lower()
+        output = _tool_output(tf).strip()
+        is_terminal = name in TERMINAL_TOOLS
+        if status == "error" and (is_terminal or output):
+            pass
+        elif is_terminal and _looks_like_error(output):
+            pass
+        else:
+            continue
+        if not output:
+            output = f"{name} failed ({status or 'error'})"
+        first = next((line.strip() for line in output.splitlines() if line.strip()), output)
+        created = _ms_or_iso(raw.get("createdAt") or header.get("createdAt"))
+        errors.append(
+            IdeError(
+                composer_id=composer_id,
+                bubble_id=bubble_id,
+                message=first[:240],
+                stack=output[:4000],
+                command=_tool_command(tf),
+                workspace_path=workspace_path,
+                created_at=created,
+                tool_name=name or None,
+            )
+        )
+    return errors
+
+
+def to_error_ingest_payload(error: IdeError) -> dict[str, Any]:
+    lines = [error.message]
+    if error.workspace_path:
+        lines.append(f"Workspace: {error.workspace_path}")
+    if error.command:
+        lines.append(f"$ {error.command}")
+    if error.stack and error.stack != error.message:
+        lines.append(error.stack)
+    visited = _iso(error.created_at) or datetime.now(UTC).isoformat()
+    return {
+        "source_type": "ide",
+        "uri": error.uri,
+        "title": error.message,
+        "text": "\n".join(lines),
+        "visited_at": visited,
+        "raw_json": {
+            "kind": "cursor_error",
+            "composer_id": error.composer_id,
+            "bubble_id": error.bubble_id,
+            "workspace_path": error.workspace_path,
+            "command": error.command,
+            "tool_name": error.tool_name,
+            "message": error.message,
+            "stack": error.stack,
+        },
+    }
 
 
 def format_session_text(session: CursorSession) -> str:

--- a/apps/ide/sync.py
+++ b/apps/ide/sync.py
@@ -21,8 +21,10 @@ from config import IdeConfig, load_config  # noqa: E402
 from cursor_vscdb import (  # noqa: E402
     CursorSession,
     connect_readonly,
+    extract_errors,
     list_sessions,
     load_session,
+    to_error_ingest_payload,
     to_ingest_payload,
 )
 
@@ -109,28 +111,55 @@ def sync_once(cfg: IdeConfig, *, limit: int, dry_run: bool) -> tuple[int, int]:
         latest = watermark
         for meta in due:
             loaded = load_session(conn, meta.composer_id)
-            if loaded is None or not loaded.bubbles:
+            if loaded is None:
                 continue
-            payload = to_ingest_payload(loaded)
-            if dry_run:
-                print(f"dry-run {payload['uri']} {payload['title']!r}")
+            errors = extract_errors(
+                conn, loaded.composer_id, workspace_path=loaded.workspace_path
+            )
+            if not loaded.bubbles and not errors:
+                continue
+            if loaded.bubbles:
+                payload = to_ingest_payload(loaded)
+                if dry_run:
+                    print(f"dry-run {payload['uri']} {payload['title']!r}")
+                    posted += 1
+                else:
+                    if not cfg.token_is_usable():
+                        raise SystemExit("Set JUNO_API_TOKEN (not change-me)")
+                    result = post_ingest(cfg.api_base_url, cfg.api_token, payload)
+                    if result.paused:
+                        print("capture paused (423) — backing off")
+                        blocked += 1
+                        break
+                    if not result.ok:
+                        print(f"ingest failed {result.status}: {result.body}")
+                        blocked += 1
+                    else:
+                        print(f"committed {result.body.get('capture_id')} {payload['uri']}")
+                        posted += 1
+            stop = False
+            for err in errors:
+                err_payload = to_error_ingest_payload(err)
+                if dry_run:
+                    print(f"dry-run {err_payload['uri']} {err_payload['title']!r}")
+                    posted += 1
+                    continue
+                if not cfg.token_is_usable():
+                    raise SystemExit("Set JUNO_API_TOKEN (not change-me)")
+                err_result = post_ingest(cfg.api_base_url, cfg.api_token, err_payload)
+                if err_result.paused:
+                    print("capture paused (423) — backing off")
+                    blocked += 1
+                    stop = True
+                    break
+                if not err_result.ok:
+                    print(f"ingest failed {err_result.status}: {err_result.body}")
+                    blocked += 1
+                    continue
+                print(f"committed {err_result.body.get('capture_id')} {err_payload['uri']}")
                 posted += 1
-                if loaded.updated_at and (latest is None or loaded.updated_at > latest):
-                    latest = loaded.updated_at
-                continue
-            if not cfg.token_is_usable():
-                raise SystemExit("Set JUNO_API_TOKEN (not change-me)")
-            result = post_ingest(cfg.api_base_url, cfg.api_token, payload)
-            if result.paused:
-                print("capture paused (423) — backing off")
-                blocked += 1
+            if stop:
                 break
-            if not result.ok:
-                print(f"ingest failed {result.status}: {result.body}")
-                blocked += 1
-                continue
-            print(f"committed {result.body.get('capture_id')} {payload['uri']}")
-            posted += 1
             if loaded.updated_at and (latest is None or loaded.updated_at > latest):
                 latest = loaded.updated_at
         if not dry_run and latest is not None and posted:

--- a/docs/next-work.md
+++ b/docs/next-work.md
@@ -105,7 +105,7 @@ Milestone: [M3: v1.2 IDE Capture](https://github.com/Anna-Hax/JUNO/milestone/9).
 | 1 | [#64](https://github.com/Anna-Hax/JUNO/issues/64) | Spike S3 — Cursor state.vscdb / exporter POST /ingest smoke — ✅ [session 29](sessions/29-session-spike-s3.md) |
 | 2 | [#65](https://github.com/Anna-Hax/JUNO/issues/65) | IDE adapter scaffold — wrap exporter, config paths, CI — ✅ [session 30](sessions/30-session-ide-scaffold.md) |
 | 3 | [#66](https://github.com/Anna-Hax/JUNO/issues/66) | Chat/composer bubbles — ingest Cursor sessions via /ingest — ✅ [session 31](sessions/31-session-ide-chat.md) |
-| 4 | [#67](https://github.com/Anna-Hax/JUNO/issues/67) | Terminal error capture from IDE sessions |
+| 4 | [#67](https://github.com/Anna-Hax/JUNO/issues/67) | Terminal error capture from IDE sessions — ✅ [session 32](sessions/32-session-ide-errors.md) |
 | 5 | [#68](https://github.com/Anna-Hax/JUNO/issues/68) | HITL — confirm IDE error-match / review sensitive chat batches |
 | 6 | [#69](https://github.com/Anna-Hax/JUNO/issues/69) | Error-matching retrieval — have I seen this error before? |
 | 7 | [#70](https://github.com/Anna-Hax/JUNO/issues/70) | Cross-reference IDE captures vs browser + inbox |
@@ -113,7 +113,7 @@ Milestone: [M3: v1.2 IDE Capture](https://github.com/Anna-Hax/JUNO/milestone/9).
 | 9 | [#72](https://github.com/Anna-Hax/JUNO/issues/72) | Module health — ide sync freshness in /status + respect /pause |
 | 10 | [#73](https://github.com/Anna-Hax/JUNO/issues/73) | M3 gate — IDE tests, ADR, README, v1.2 release gate |
 
-**First coding task:** Spike S3 ([#64](https://github.com/Anna-Hax/JUNO/issues/64)) — ✅. Adapter scaffold ([#65](https://github.com/Anna-Hax/JUNO/issues/65)) — ✅. Chat ingest ([#66](https://github.com/Anna-Hax/JUNO/issues/66)) — ✅ [session 31](sessions/31-session-ide-chat.md). Next: [#67](https://github.com/Anna-Hax/JUNO/issues/67) terminal errors.
+**First coding task:** Spike S3–chat ingest (#64–#66) ✅. Terminal errors ([#67](https://github.com/Anna-Hax/JUNO/issues/67)) — ✅ [session 32](sessions/32-session-ide-errors.md). Next: [#68](https://github.com/Anna-Hax/JUNO/issues/68) HITL.
 
 ### M3 design constraints (do not violate)
 

--- a/docs/sessions/32-session-ide-errors.md
+++ b/docs/sessions/32-session-ide-errors.md
@@ -1,0 +1,20 @@
+# Session 32 — Terminal error capture (#67)
+
+**Date:** 2026-09-02  
+**Issue:** [#67](https://github.com/Anna-Hax/JUNO/issues/67)  
+**Branch:** `feat/ide-errors-67`
+
+## What changed
+
+- `extract_errors()` reads `toolFormerData` on composer bubbles (`run_terminal_command_v2` + `status=error` or error-like output).
+- Ingest as `source_type=ide` with `raw_json.kind=cursor_error` (`cursor://error/{composer}/{bubble}`).
+- `sync.py` posts errors next to chat sessions.
+
+## Verify
+
+```powershell
+cd apps/core
+$env:EMBEDDING_BACKEND='stub'
+uv run pytest tests/test_ide_vscdb.py -q
+python ..\..\apps\ide\sync.py --once --dry-run
+```

--- a/docs/sessions/README.md
+++ b/docs/sessions/README.md
@@ -37,6 +37,7 @@ Living notes for what was implemented, how GitHub is set up, and what to do next
 | [29-session-spike-s3.md](29-session-spike-s3.md) | **#64** — Spike S3 Cursor vscdb → /ingest |
 | [30-session-ide-scaffold.md](30-session-ide-scaffold.md) | **#65** — IDE adapter scaffold |
 | [31-session-ide-chat.md](31-session-ide-chat.md) | **#66** — Chat/composer ingest |
+| [32-session-ide-errors.md](32-session-ide-errors.md) | **#67** — Terminal error capture |
 | [v1.0-release-gate.md](../v1.0-release-gate.md) | M1 checklist (all P0 closed) |
 | [v1.1-release-gate.md](../v1.1-release-gate.md) | M2 checklist (browser capture) |
 


### PR DESCRIPTION
## Summary
- Read `toolFormerData` on composer bubbles for terminal command failures.
- Ingest as `source_type=ide` / `raw_json.kind=cursor_error` with workspace, command, stack, timestamp.
- `sync.py` posts errors next to chat sessions (same loopback `/ingest`).

## Linked issue
Closes #67

## Test plan
- [x] `uv run pytest tests/test_ide_vscdb.py`
- [x] `uv run ruff check src tests`
- [x] `python scripts/validate-ide.py`