### PR TITLE
feat(hitl): review IDE error-match and chat batches

### DIFF
--- a/apps/core/src/juno/bot/handlers.py
+++ b/apps/core/src/juno/bot/handlers.py
@@ -36,7 +36,7 @@ HELP_TEXT = (
     "/pause — stop all ingest\n"
     "/resume — resume ingest (processes inbox backlog)\n"
     "/status — capture + module health\n"
-    "/review — HITL queue (Approve / Reject / Skip)\n"
+    "/review — HITL queue (Approve / Reject / Skip: merges, IDE error-match, chat batches)\n"
     "Ask a question to search the graph.\n"
     "Forward a message, send a link, or attach a doc to capture."
 )

--- a/apps/core/src/juno/hitl/queue.py
+++ b/apps/core/src/juno/hitl/queue.py
@@ -15,6 +15,8 @@ from juno.models import Edge, Node, ReviewItem
 Decision = Literal["approve", "reject", "skip"]
 
 KIND_MERGE = "merge"
+KIND_ERROR_MATCH = "error_match"
+KIND_IDE_BATCH = "ide_batch"
 STATUS_PENDING = "pending"
 STATUS_SKIPPED = "skipped"
 STATUS_DECIDED = "decided"
@@ -47,6 +49,23 @@ class ReviewCard:
             if reason:
                 lines.append(str(reason))
             lines.append("This merge stays pending until you Approve.")
+        elif self.kind == KIND_ERROR_MATCH:
+            new_title = str(self.payload.get("new_title") or "new error")
+            past_title = str(self.payload.get("past_title") or "past error")
+            lines.append(f'Is this the same root cause?\nNew: "{new_title}"\nPast: "{past_title}"')
+            reason = self.payload.get("reason")
+            if reason:
+                lines.append(str(reason))
+            lines.append("Approve only if it is the same root cause, not just a similar stack.")
+        elif self.kind == KIND_IDE_BATCH:
+            n = self.payload.get("capture_ids") or []
+            count = len(n) if isinstance(n, list) else 0
+            title = str(self.payload.get("title") or "IDE chat batch")
+            lines.append(f"Review sensitive/bulk IDE sync: {title} ({count} capture(s)).")
+            reason = self.payload.get("reason")
+            if reason:
+                lines.append(str(reason))
+            lines.append("Approve to keep this batch in the graph; Reject to leave it unconfirmed.")
         else:
             preview = str(self.payload)[:500]
             if preview:
@@ -133,6 +152,50 @@ class ReviewQueue:
             return _card(item)
 
         return await self.db.write(write)
+
+    async def propose_error_match(
+        self,
+        *,
+        new_title: str,
+        past_title: str,
+        confidence: float,
+        new_capture_id: int | None = None,
+        past_capture_id: int | None = None,
+        reason: str | None = None,
+    ) -> ReviewCard:
+        """Queue HITL before treating a past IDE error as the same root cause (#68)."""
+        return await self.enqueue(
+            kind=KIND_ERROR_MATCH,
+            confidence=confidence,
+            payload={
+                "new_title": new_title,
+                "past_title": past_title,
+                "new_capture_id": new_capture_id,
+                "past_capture_id": past_capture_id,
+                "reason": reason,
+                "confirmed": False,
+            },
+        )
+
+    async def propose_ide_batch(
+        self,
+        *,
+        title: str,
+        capture_ids: list[int],
+        confidence: float = 0.5,
+        reason: str | None = None,
+    ) -> ReviewCard:
+        """Queue HITL for sensitive or bulk IDE chat sync batches (#68)."""
+        return await self.enqueue(
+            kind=KIND_IDE_BATCH,
+            confidence=confidence,
+            payload={
+                "title": title,
+                "capture_ids": list(capture_ids),
+                "reason": reason,
+                "confirmed": False,
+            },
+        )
 
     async def next_open(self) -> ReviewCard | None:
         async def load(session: AsyncSession) -> ReviewCard | None:
@@ -266,6 +329,11 @@ async def _pending_edge(
 
 
 async def _apply(session: AsyncSession, row: ReviewItem) -> bool:
+    if row.kind in {KIND_ERROR_MATCH, KIND_IDE_BATCH}:
+        payload = dict(row.payload or {})
+        payload["confirmed"] = True
+        row.payload = payload
+        return True
     if row.kind != KIND_MERGE:
         return False
     edge_id = (row.payload or {}).get("edge_id")
@@ -279,6 +347,11 @@ async def _apply(session: AsyncSession, row: ReviewItem) -> bool:
 
 
 async def _reject(session: AsyncSession, row: ReviewItem) -> None:
+    if row.kind in {KIND_ERROR_MATCH, KIND_IDE_BATCH}:
+        payload = dict(row.payload or {})
+        payload["confirmed"] = False
+        row.payload = payload
+        return
     if row.kind != KIND_MERGE:
         return
     edge_id = (row.payload or {}).get("edge_id")

--- a/apps/core/tests/test_review.py
+++ b/apps/core/tests/test_review.py
@@ -130,3 +130,49 @@ async def test_generic_enqueue_has_no_graph_side_effect(queue):
     result = await queue.decide(card.id, "approve")
     assert result.applied is False
     assert await _committed_edge_count(queue.db) == 0
+
+
+@pytest.mark.asyncio
+async def test_error_match_stays_unconfirmed_until_approve(queue):
+    card = await queue.propose_error_match(
+        new_title="database is locked",
+        past_title="sqlite lock on ingest",
+        confidence=0.82,
+        new_capture_id=10,
+        past_capture_id=3,
+        reason="similar stack only until you confirm",
+    )
+    assert card.kind == "error_match"
+    assert card.status == "pending"
+    assert card.payload.get("confirmed") is False
+    assert "same root cause" in card.summary()
+
+    rejected = await queue.decide(card.id, "reject")
+    assert rejected.applied is False
+    assert rejected.card.payload.get("confirmed") is False
+
+    other = await queue.propose_error_match(
+        new_title="WAL busy",
+        past_title="database is locked",
+        confidence=0.9,
+        new_capture_id=11,
+        past_capture_id=10,
+    )
+    approved = await queue.decide(other.id, "approve")
+    assert approved.applied is True
+    assert approved.card.payload.get("confirmed") is True
+
+
+@pytest.mark.asyncio
+async def test_ide_batch_review_confirms_on_approve(queue):
+    card = await queue.propose_ide_batch(
+        title="Cursor chats 2026-09-02",
+        capture_ids=[1, 2, 3],
+        reason="bulk sync of composer sessions",
+    )
+    assert card.kind == "ide_batch"
+    assert "bulk IDE sync" in card.summary()
+    result = await queue.decide(card.id, "approve")
+    assert result.applied is True
+    assert result.card.payload.get("confirmed") is True
+    assert result.card.payload.get("capture_ids") == [1, 2, 3]

--- a/docs/next-work.md
+++ b/docs/next-work.md
@@ -106,14 +106,14 @@ Milestone: [M3: v1.2 IDE Capture](https://github.com/Anna-Hax/JUNO/milestone/9).
 | 2 | [#65](https://github.com/Anna-Hax/JUNO/issues/65) | IDE adapter scaffold — wrap exporter, config paths, CI — ✅ [session 30](sessions/30-session-ide-scaffold.md) |
 | 3 | [#66](https://github.com/Anna-Hax/JUNO/issues/66) | Chat/composer bubbles — ingest Cursor sessions via /ingest — ✅ [session 31](sessions/31-session-ide-chat.md) |
 | 4 | [#67](https://github.com/Anna-Hax/JUNO/issues/67) | Terminal error capture from IDE sessions — ✅ [session 32](sessions/32-session-ide-errors.md) |
-| 5 | [#68](https://github.com/Anna-Hax/JUNO/issues/68) | HITL — confirm IDE error-match / review sensitive chat batches |
+| 5 | [#68](https://github.com/Anna-Hax/JUNO/issues/68) | HITL — confirm IDE error-match / review sensitive chat batches — ✅ [session 33](sessions/33-session-ide-hitl.md) |
 | 6 | [#69](https://github.com/Anna-Hax/JUNO/issues/69) | Error-matching retrieval — have I seen this error before? |
 | 7 | [#70](https://github.com/Anna-Hax/JUNO/issues/70) | Cross-reference IDE captures vs browser + inbox |
 | 8 | [#71](https://github.com/Anna-Hax/JUNO/issues/71) | Digest enrichment — IDE chats/errors in /digest today\|week |
 | 9 | [#72](https://github.com/Anna-Hax/JUNO/issues/72) | Module health — ide sync freshness in /status + respect /pause |
 | 10 | [#73](https://github.com/Anna-Hax/JUNO/issues/73) | M3 gate — IDE tests, ADR, README, v1.2 release gate |
 
-**First coding task:** Spike S3–chat ingest (#64–#66) ✅. Terminal errors ([#67](https://github.com/Anna-Hax/JUNO/issues/67)) — ✅ [session 32](sessions/32-session-ide-errors.md). Next: [#68](https://github.com/Anna-Hax/JUNO/issues/68) HITL.
+**First coding task:** #64–#67 ✅. HITL ([#68](https://github.com/Anna-Hax/JUNO/issues/68)) — ✅ [session 33](sessions/33-session-ide-hitl.md). Next: [#69](https://github.com/Anna-Hax/JUNO/issues/69) error-matching retrieval.
 
 ### M3 design constraints (do not violate)
 

--- a/docs/sessions/33-session-ide-hitl.md
+++ b/docs/sessions/33-session-ide-hitl.md
@@ -1,0 +1,19 @@
+# Session 33 — HITL for IDE error-match and chat batches (#68)
+
+**Date:** 2026-09-02  
+**Issue:** [#68](https://github.com/Anna-Hax/JUNO/issues/68)  
+**Branch:** `feat/ide-hitl-68`
+
+## What changed
+
+- Review kinds `error_match` and `ide_batch` (same Approve / Reject / Skip as merges).
+- Error-match stays unconfirmed until Approve (same root cause vs similar stack).
+- Bulk/sensitive IDE chat batches stay reviewable.
+
+## Verify
+
+```powershell
+cd apps/core
+$env:EMBEDDING_BACKEND='stub'
+uv run pytest tests/test_review.py tests/test_bot_review.py -q
+```

--- a/docs/sessions/README.md
+++ b/docs/sessions/README.md
@@ -38,6 +38,7 @@ Living notes for what was implemented, how GitHub is set up, and what to do next
 | [30-session-ide-scaffold.md](30-session-ide-scaffold.md) | **#65** — IDE adapter scaffold |
 | [31-session-ide-chat.md](31-session-ide-chat.md) | **#66** — Chat/composer ingest |
 | [32-session-ide-errors.md](32-session-ide-errors.md) | **#67** — Terminal error capture |
+| [33-session-ide-hitl.md](33-session-ide-hitl.md) | **#68** — HITL IDE error-match / batches |
 | [v1.0-release-gate.md](../v1.0-release-gate.md) | M1 checklist (all P0 closed) |
 | [v1.1-release-gate.md](../v1.1-release-gate.md) | M2 checklist (browser capture) |
 


### PR DESCRIPTION
## Summary
- New review kinds `error_match` and `ide_batch` using the existing `/review` buttons.
- Approve confirms same-root-cause reuse or a sensitive/bulk IDE chat batch; Reject leaves them unconfirmed.

## Linked issue
Closes #68

## Test plan
- [x] `uv run pytest tests/test_review.py tests/test_bot_review.py tests/test_bot.py`
- [x] `uv run ruff check src tests`