### PR TITLE
feat(rag): match past IDE errors with retrieve fallback

### DIFF
--- a/apps/core/src/juno/bot/services.py
+++ b/apps/core/src/juno/bot/services.py
@@ -15,6 +15,7 @@ from juno.config import Settings
 from juno.graph.db import Database
 from juno.ingest.pipeline import IngestResult
 from juno.models import AppSetting, Capture, ModuleHealth
+from juno.rag.engine import looks_like_error_query, match_past_errors
 from juno.rag.engine import search as rag_search
 
 BOT_DATA_KEY = "juno"
@@ -129,14 +130,28 @@ async def answer_user_query(svc: BotServices, text: str) -> str:
     if svc.vectors is None:
         return f"Received ({len(text)} chars). Search is not attached in this runtime."
     chat = getattr(svc.app.state, "chat", None) if svc.app is not None else None
-    outcome = await rag_search(
-        text,
-        vectors=svc.vectors,
-        db=svc.db,
-        chat=chat,
-        n_results=5,
-        mode="auto",
-    )
+    review = None
+    if svc.db is not None and looks_like_error_query(text):
+        from juno.hitl.queue import ReviewQueue
+
+        review = ReviewQueue(svc.db)
+        outcome = await match_past_errors(
+            text,
+            vectors=svc.vectors,
+            db=svc.db,
+            chat=chat,
+            review=review,
+            n_results=5,
+        )
+    else:
+        outcome = await rag_search(
+            text,
+            vectors=svc.vectors,
+            db=svc.db,
+            chat=chat,
+            n_results=5,
+            mode="auto",
+        )
     reply = format_search_outcome(outcome)
     if svc.db is None:
         return reply

--- a/apps/core/src/juno/rag/engine.py
+++ b/apps/core/src/juno/rag/engine.py
@@ -20,6 +20,16 @@ logger = logging.getLogger("juno.rag")
 DEFAULT_K = 8
 MAX_SOURCE_CHARS = 1200
 _CITE_RE = re.compile(r"\[(\d+)\]")
+ERROR_QUERY_HINTS = (
+    "error",
+    "traceback",
+    "exception",
+    "failed",
+    "panic:",
+    "cannot use",
+    "database is locked",
+    "have i seen this",
+)
 
 RAG_SYSTEM = (
     "You are Juno, a personal knowledge assistant. Answer using ONLY the numbered "
@@ -281,4 +291,58 @@ async def search(
         confidence=rag_confidence,
         answer=answer,
         citations=citations,
+    )
+
+
+def looks_like_error_query(query: str) -> bool:
+    q = (query or "").casefold()
+    return any(hint in q for hint in ERROR_QUERY_HINTS)
+
+
+async def match_past_errors(
+    query: str,
+    *,
+    vectors: Any,
+    db: Database | None,
+    chat: Any = None,
+    review: Any = None,
+    n_results: int = DEFAULT_K,
+) -> SearchOutcome:
+    """Semantic 'have I seen this error before?' over IDE chats/errors (#69).
+
+    Uses retrieve-only when the LLM is unhealthy (same as ``search``).
+    High-scoring IDE hits are queued for HITL before reuse as canonical (#68).
+    """
+    outcome = await search(
+        query,
+        vectors=vectors,
+        db=db,
+        chat=chat,
+        n_results=n_results,
+        mode="auto",
+    )
+    ide = [hit for hit in outcome.results if hit.source_type == "ide"]
+    others = [hit for hit in outcome.results if hit.source_type != "ide"]
+    ordered = ide + others
+    confidence = _confidence(ordered if ordered else outcome.results)
+    if review is not None and ide:
+        top = ide[0]
+        if top.score >= 0.45:
+            try:
+                await review.propose_error_match(
+                    new_title=(query or "")[:120],
+                    past_title=top.title or top.uri or "past IDE capture",
+                    confidence=float(top.score),
+                    past_capture_id=top.capture_id,
+                    reason="Similar IDE error/chat — confirm same root cause before reuse.",
+                )
+            except Exception:  # noqa: BLE001
+                logger.exception("failed to enqueue error_match review")
+    return SearchOutcome(
+        query=outcome.query,
+        mode=outcome.mode,
+        results=ordered or list(outcome.results),
+        confidence=confidence,
+        answer=outcome.answer,
+        citations=ordered or list(outcome.citations or outcome.results),
     )

--- a/apps/core/tests/test_rag.py
+++ b/apps/core/tests/test_rag.py
@@ -227,3 +227,53 @@ async def test_offline_provider_stays_retrieve_only(settings, db, vectors, pipel
     assert body["mode"] == "retrieve"
     assert body["answer"] is None
     assert body["citations"][0]["title"] == "Rust notes"
+
+
+ERROR_NOTE = (
+    "Juno ide error marker sqlite-locked-zzz. database is locked Traceback "
+    "in ingest.py when two writers collide."
+)
+
+
+def test_looks_like_error_query():
+    from juno.rag.engine import looks_like_error_query
+
+    assert looks_like_error_query("database is locked Traceback")
+    assert looks_like_error_query("Have I seen this error before?")
+    assert not looks_like_error_query("what did I read about tomatoes")
+
+
+@pytest.mark.asyncio
+async def test_match_past_errors_prefers_ide_when_llm_unhealthy(settings, db, vectors, pipeline):
+    from juno.hitl.queue import ReviewQueue
+    from juno.rag.engine import match_past_errors
+
+    await pipeline.ingest_payload(
+        {
+            "source_type": "ide",
+            "uri": "cursor://error/abc/bubble",
+            "title": "database is locked",
+            "text": ERROR_NOTE,
+            "raw_json": {"kind": "cursor_error", "message": "database is locked"},
+        }
+    )
+    await pipeline.ingest_text(NOTE_B, source_type="upload", title="Garden")
+    review = ReviewQueue(db)
+    chat = FakeChat(healthy=False, answer="should not be used")
+    outcome = await match_past_errors(
+        ERROR_NOTE,
+        vectors=vectors,
+        db=db,
+        chat=chat,
+        review=review,
+    )
+    assert outcome.mode == "retrieve"
+    assert outcome.answer is None
+    assert outcome.results
+    assert outcome.results[0].source_type == "ide"
+    assert outcome.confidence > 0
+    assert "sqlite-locked-zzz" in (outcome.results[0].text or "")
+    card = await review.next_open()
+    assert card is not None
+    assert card.kind == "error_match"
+    assert card.payload.get("confirmed") is False

--- a/docs/next-work.md
+++ b/docs/next-work.md
@@ -107,13 +107,13 @@ Milestone: [M3: v1.2 IDE Capture](https://github.com/Anna-Hax/JUNO/milestone/9).
 | 3 | [#66](https://github.com/Anna-Hax/JUNO/issues/66) | Chat/composer bubbles — ingest Cursor sessions via /ingest — ✅ [session 31](sessions/31-session-ide-chat.md) |
 | 4 | [#67](https://github.com/Anna-Hax/JUNO/issues/67) | Terminal error capture from IDE sessions — ✅ [session 32](sessions/32-session-ide-errors.md) |
 | 5 | [#68](https://github.com/Anna-Hax/JUNO/issues/68) | HITL — confirm IDE error-match / review sensitive chat batches — ✅ [session 33](sessions/33-session-ide-hitl.md) |
-| 6 | [#69](https://github.com/Anna-Hax/JUNO/issues/69) | Error-matching retrieval — have I seen this error before? |
+| 6 | [#69](https://github.com/Anna-Hax/JUNO/issues/69) | Error-matching retrieval — have I seen this error before? — ✅ [session 34](sessions/34-session-error-match.md) |
 | 7 | [#70](https://github.com/Anna-Hax/JUNO/issues/70) | Cross-reference IDE captures vs browser + inbox |
 | 8 | [#71](https://github.com/Anna-Hax/JUNO/issues/71) | Digest enrichment — IDE chats/errors in /digest today\|week |
 | 9 | [#72](https://github.com/Anna-Hax/JUNO/issues/72) | Module health — ide sync freshness in /status + respect /pause |
 | 10 | [#73](https://github.com/Anna-Hax/JUNO/issues/73) | M3 gate — IDE tests, ADR, README, v1.2 release gate |
 
-**First coding task:** #64–#67 ✅. HITL ([#68](https://github.com/Anna-Hax/JUNO/issues/68)) — ✅ [session 33](sessions/33-session-ide-hitl.md). Next: [#69](https://github.com/Anna-Hax/JUNO/issues/69) error-matching retrieval.
+**First coding task:** #64–#68 ✅. Error-match retrieval ([#69](https://github.com/Anna-Hax/JUNO/issues/69)) — ✅ [session 34](sessions/34-session-error-match.md). Next: [#70](https://github.com/Anna-Hax/JUNO/issues/70) cross-reference.
 
 ### M3 design constraints (do not violate)
 

--- a/docs/sessions/34-session-error-match.md
+++ b/docs/sessions/34-session-error-match.md
@@ -1,0 +1,18 @@
+# Session 34 — Error-matching retrieval (#69)
+
+**Date:** 2026-09-02  
+**Issue:** [#69](https://github.com/Anna-Hax/JUNO/issues/69)  
+**Branch:** `feat/ide-error-match-69`
+
+## What changed
+
+- `match_past_errors()` prefers `source_type=ide` hits, keeps retrieve-only when the LLM is down, and queues `error_match` HITL before reuse.
+- Telegram queries that look like errors use this path.
+
+## Verify
+
+```powershell
+cd apps/core
+$env:EMBEDDING_BACKEND='stub'
+uv run pytest tests/test_rag.py -q
+```

--- a/docs/sessions/README.md
+++ b/docs/sessions/README.md
@@ -39,6 +39,7 @@ Living notes for what was implemented, how GitHub is set up, and what to do next
 | [31-session-ide-chat.md](31-session-ide-chat.md) | **#66** — Chat/composer ingest |
 | [32-session-ide-errors.md](32-session-ide-errors.md) | **#67** — Terminal error capture |
 | [33-session-ide-hitl.md](33-session-ide-hitl.md) | **#68** — HITL IDE error-match / batches |
+| [34-session-error-match.md](34-session-error-match.md) | **#69** — Error-matching retrieval |
 | [v1.0-release-gate.md](../v1.0-release-gate.md) | M1 checklist (all P0 closed) |
 | [v1.1-release-gate.md](../v1.1-release-gate.md) | M2 checklist (browser capture) |
 


### PR DESCRIPTION
## Summary
- `match_past_errors()` ranks IDE chats/errors first and returns citations + confidence.
- Retrieve-only when the LLM is unhealthy; high-scoring hits enqueue `error_match` HITL.
- Telegram error-like queries use this path.

## Linked issue
Closes #69

## Test plan
- [x] `uv run pytest tests/test_rag.py tests/test_bot.py`
- [x] `uv run ruff check src tests`