### PR TITLE
feat(bot): cross-reference IDE hits with browser and uploads

### DIFF
--- a/apps/core/src/juno/bot/services.py
+++ b/apps/core/src/juno/bot/services.py
@@ -158,15 +158,28 @@ async def answer_user_query(svc: BotServices, text: str) -> str:
     browser_hits = [
         hit for hit in outcome.results if getattr(hit, "source_type", None) == "browser"
     ]
-    if not browser_hits:
+    ide_hits = [hit for hit in outcome.results if getattr(hit, "source_type", None) == "ide"]
+    extra: list[str] = []
+    if ide_hits:
+        related = await related_captures(
+            svc.db, hits=ide_hits, source_types=("browser", "upload"), limit=3
+        )
+        if related:
+            extra.append("")
+            extra.append("You also read or uploaded notes on:")
+            for row in related:
+                label = row.title or row.uri or f"capture #{row.id}"
+                extra.append(f"• #{row.id} [{row.source_type}] {label}")
+    if browser_hits:
+        related = await related_upload_captures(svc.db, browser_hits=browser_hits)
+        if related:
+            extra.append("")
+            extra.append("You also uploaded notes on:")
+            for row in related:
+                label = row.title or row.uri or f"capture #{row.id}"
+                extra.append(f"• #{row.id} {label}")
+    if not extra:
         return reply
-    related = await related_upload_captures(svc.db, browser_hits=browser_hits)
-    if not related:
-        return reply
-    extra = ["", "You also uploaded notes on:"]
-    for row in related:
-        label = row.title or row.uri or f"capture #{row.id}"
-        extra.append(f"• #{row.id} {label}")
     return clip(reply + "\n".join(extra))
 
 
@@ -296,19 +309,23 @@ async def recent_captures(db: Database, *, since: datetime, limit: int = 20) -> 
     return await db.read(fn)
 
 
-async def related_upload_captures(
+async def related_captures(
     db: Database,
     *,
-    browser_hits: list[Any],
+    hits: list[Any],
+    source_types: tuple[str, ...],
     limit: int = 3,
 ) -> list[Capture]:
-    """Cross-reference browser hits with upload/inbox captures (#51)."""
+    """Find committed captures of the given source types matching hit titles/text."""
     titles: set[str] = set()
     hosts: set[str] = set()
-    for hit in browser_hits:
+    for hit in hits:
         title = (getattr(hit, "title", None) or "").strip()
         if title:
             titles.add(title[:80])
+        text = (getattr(hit, "text", None) or "").strip()
+        if text:
+            titles.add(text[:80])
         uri = getattr(hit, "uri", None) or ""
         if uri:
             host = urlparse(uri).netloc.lower()
@@ -319,16 +336,17 @@ async def related_upload_captures(
 
     async def fn(session: AsyncSession) -> list[Capture]:
         clauses = []
-        for title in list(titles)[:3]:
-            for word in re.findall(r"[A-Za-z]{4,}", title):
+        for title in list(titles)[:4]:
+            for word in re.findall(r"[A-Za-z]{4,}", title)[:6]:
                 clauses.append(Capture.title.ilike(f"%{word}%"))
+                clauses.append(Capture.text.ilike(f"%{word}%"))
         for host in list(hosts)[:3]:
             clauses.append(Capture.uri.ilike(f"%{host}%"))
         if not clauses:
             return []
         result = await session.execute(
             select(Capture)
-            .where(Capture.source_type != "browser")
+            .where(Capture.source_type.in_(source_types))
             .where(Capture.status == "committed")
             .where(or_(*clauses))
             .order_by(Capture.captured_at.desc())
@@ -337,6 +355,21 @@ async def related_upload_captures(
         return list(result.scalars())
 
     return await db.read(fn)
+
+
+async def related_upload_captures(
+    db: Database,
+    *,
+    browser_hits: list[Any],
+    limit: int = 3,
+) -> list[Capture]:
+    """Cross-reference browser hits with upload/inbox captures (#51)."""
+    return await related_captures(
+        db,
+        hits=browser_hits,
+        source_types=("upload", "telegram", "url", "api"),
+        limit=limit,
+    )
 
 
 async def all_module_health(db: Database) -> list[ModuleHealth]:

--- a/apps/core/tests/test_bot.py
+++ b/apps/core/tests/test_bot.py
@@ -447,3 +447,35 @@ async def test_related_upload_captures_finds_upload_for_browser_hit(db):
     assert len(related) == 1
     assert related[0].source_type == "upload"
     assert "Rust" in (related[0].title or "")
+
+
+@pytest.mark.asyncio
+async def test_related_captures_links_ide_error_to_browser(db):
+    from juno.bot.services import related_captures
+    from juno.ingest.pipeline import IngestPipeline
+    from juno.rag.engine import SourcedHit
+
+    pipeline = IngestPipeline(db)
+    await pipeline.ingest_payload(
+        {
+            "source_type": "browser",
+            "uri": "https://github.com/example/sqlite-lock",
+            "title": "database is locked GitHub issue",
+            "text": "sqlite database is locked",
+        }
+    )
+    hits = [
+        SourcedHit(
+            chroma_id="c9-n0",
+            text="database is locked Traceback ingest.py",
+            score=0.9,
+            capture_id=9,
+            title="database is locked",
+            uri="cursor://error/abc/1",
+            source_type="ide",
+        )
+    ]
+    related = await related_captures(db, hits=hits, source_types=("browser", "upload"))
+    assert related
+    assert related[0].source_type == "browser"
+    assert "locked" in (related[0].title or "").lower()

--- a/docs/next-work.md
+++ b/docs/next-work.md
@@ -108,12 +108,12 @@ Milestone: [M3: v1.2 IDE Capture](https://github.com/Anna-Hax/JUNO/milestone/9).
 | 4 | [#67](https://github.com/Anna-Hax/JUNO/issues/67) | Terminal error capture from IDE sessions — ✅ [session 32](sessions/32-session-ide-errors.md) |
 | 5 | [#68](https://github.com/Anna-Hax/JUNO/issues/68) | HITL — confirm IDE error-match / review sensitive chat batches — ✅ [session 33](sessions/33-session-ide-hitl.md) |
 | 6 | [#69](https://github.com/Anna-Hax/JUNO/issues/69) | Error-matching retrieval — have I seen this error before? — ✅ [session 34](sessions/34-session-error-match.md) |
-| 7 | [#70](https://github.com/Anna-Hax/JUNO/issues/70) | Cross-reference IDE captures vs browser + inbox |
+| 7 | [#70](https://github.com/Anna-Hax/JUNO/issues/70) | Cross-reference IDE captures vs browser + inbox — ✅ [session 35](sessions/35-session-ide-crossref.md) |
 | 8 | [#71](https://github.com/Anna-Hax/JUNO/issues/71) | Digest enrichment — IDE chats/errors in /digest today\|week |
 | 9 | [#72](https://github.com/Anna-Hax/JUNO/issues/72) | Module health — ide sync freshness in /status + respect /pause |
 | 10 | [#73](https://github.com/Anna-Hax/JUNO/issues/73) | M3 gate — IDE tests, ADR, README, v1.2 release gate |
 
-**First coding task:** #64–#68 ✅. Error-match retrieval ([#69](https://github.com/Anna-Hax/JUNO/issues/69)) — ✅ [session 34](sessions/34-session-error-match.md). Next: [#70](https://github.com/Anna-Hax/JUNO/issues/70) cross-reference.
+**First coding task:** #64–#69 ✅. Cross-ref ([#70](https://github.com/Anna-Hax/JUNO/issues/70)) — ✅ [session 35](sessions/35-session-ide-crossref.md). Next: [#71](https://github.com/Anna-Hax/JUNO/issues/71) digest.
 
 ### M3 design constraints (do not violate)
 

--- a/docs/sessions/35-session-ide-crossref.md
+++ b/docs/sessions/35-session-ide-crossref.md
@@ -1,0 +1,18 @@
+# Session 35 — Cross-reference IDE vs browser + inbox (#70)
+
+**Date:** 2026-09-02  
+**Issue:** [#70](https://github.com/Anna-Hax/JUNO/issues/70)  
+**Branch:** `feat/ide-crossref-70`
+
+## What changed
+
+- `related_captures()` matches IDE hits to browser/upload rows (GitHub-issue style).
+- Query replies append **You also read or uploaded notes on:** when IDE hits have related context.
+
+## Verify
+
+```powershell
+cd apps/core
+$env:EMBEDDING_BACKEND='stub'
+uv run pytest tests/test_bot.py -q
+```

--- a/docs/sessions/README.md
+++ b/docs/sessions/README.md
@@ -40,6 +40,7 @@ Living notes for what was implemented, how GitHub is set up, and what to do next
 | [32-session-ide-errors.md](32-session-ide-errors.md) | **#67** — Terminal error capture |
 | [33-session-ide-hitl.md](33-session-ide-hitl.md) | **#68** — HITL IDE error-match / batches |
 | [34-session-error-match.md](34-session-error-match.md) | **#69** — Error-matching retrieval |
+| [35-session-ide-crossref.md](35-session-ide-crossref.md) | **#70** — Cross-reference IDE vs browser + inbox |
 | [v1.0-release-gate.md](../v1.0-release-gate.md) | M1 checklist (all P0 closed) |
 | [v1.1-release-gate.md](../v1.1-release-gate.md) | M2 checklist (browser capture) |
 


### PR DESCRIPTION
## Summary
- `related_captures()` links IDE hits to browser and upload rows.
- Query replies mention related reading/uploads for IDE matches.

## Linked issue
Closes #70

## Test plan
- [x] `uv run pytest tests/test_bot.py`
- [x] `uv run ruff check src tests`