### PR TITLE
feat(bot): group IDE chats and errors in /digest

### DIFF
--- a/apps/core/src/juno/bot/services.py
+++ b/apps/core/src/juno/bot/services.py
@@ -195,18 +195,35 @@ def format_capture_ack(result: IngestResult) -> str:
     )
 
 
+def _ide_kind(row: Capture) -> str:
+    raw = row.raw_json if isinstance(row.raw_json, dict) else {}
+    kind = str(raw.get("kind") or "")
+    if kind == "cursor_error":
+        return "error"
+    return "chat"
+
+
 def format_digest(captures: list[Capture], window: str) -> str:
     label = "today" if window == "today" else "this week"
     if not captures:
         return f"No captures {label}."
     browser = [row for row in captures if row.source_type == "browser"]
-    other = [row for row in captures if row.source_type != "browser"]
+    ide = [row for row in captures if row.source_type == "ide"]
+    other = [row for row in captures if row.source_type not in {"browser", "ide"}]
+    ide_chat = [row for row in ide if _ide_kind(row) == "chat"]
+    ide_err = [row for row in ide if _ide_kind(row) == "error"]
     lines = [f"Digest {label} ({len(captures)}):"]
     if browser:
         lines.append(f"Browser reading ({len(browser)}):")
         lines.extend(_digest_lines(browser))
+    if ide_chat:
+        lines.append(f"IDE chats ({len(ide_chat)}):")
+        lines.extend(_digest_lines(ide_chat))
+    if ide_err:
+        lines.append(f"IDE errors ({len(ide_err)}):")
+        lines.extend(_digest_lines(ide_err))
     if other:
-        if browser:
+        if browser or ide:
             lines.append(f"Uploads / other ({len(other)}):")
         lines.extend(_digest_lines(other))
     return clip("\n".join(lines))

--- a/apps/core/tests/test_bot.py
+++ b/apps/core/tests/test_bot.py
@@ -189,6 +189,41 @@ def test_format_digest_groups_browser_reading():
     assert "Rust book" in text
 
 
+def test_format_digest_groups_ide_chats_and_errors():
+    from datetime import UTC, datetime
+
+    now = datetime.now(UTC)
+    chat = Capture(
+        id=3,
+        source_type="ide",
+        title="Fix sqlite lock",
+        status="committed",
+        captured_at=now,
+        raw_json={"kind": "cursor_chat"},
+    )
+    err = Capture(
+        id=4,
+        source_type="ide",
+        title="database is locked",
+        status="committed",
+        captured_at=now,
+        raw_json={"kind": "cursor_error"},
+    )
+    upload = Capture(
+        id=2,
+        source_type="upload",
+        title="Notes",
+        status="committed",
+        captured_at=now,
+    )
+    text = format_digest([upload, chat, err], "week")
+    assert "IDE chats (1):" in text
+    assert "IDE errors (1):" in text
+    assert "Uploads / other (1):" in text
+    assert "Fix sqlite lock" in text
+    assert "database is locked" in text
+
+
 def test_format_retrieve_reply_hits():
     hit = VectorHit(
         id="c1-n0",

--- a/docs/next-work.md
+++ b/docs/next-work.md
@@ -109,11 +109,11 @@ Milestone: [M3: v1.2 IDE Capture](https://github.com/Anna-Hax/JUNO/milestone/9).
 | 5 | [#68](https://github.com/Anna-Hax/JUNO/issues/68) | HITL — confirm IDE error-match / review sensitive chat batches — ✅ [session 33](sessions/33-session-ide-hitl.md) |
 | 6 | [#69](https://github.com/Anna-Hax/JUNO/issues/69) | Error-matching retrieval — have I seen this error before? — ✅ [session 34](sessions/34-session-error-match.md) |
 | 7 | [#70](https://github.com/Anna-Hax/JUNO/issues/70) | Cross-reference IDE captures vs browser + inbox — ✅ [session 35](sessions/35-session-ide-crossref.md) |
-| 8 | [#71](https://github.com/Anna-Hax/JUNO/issues/71) | Digest enrichment — IDE chats/errors in /digest today\|week |
+| 8 | [#71](https://github.com/Anna-Hax/JUNO/issues/71) | Digest enrichment — IDE chats/errors in /digest today\|week — ✅ [session 36](sessions/36-session-ide-digest.md) |
 | 9 | [#72](https://github.com/Anna-Hax/JUNO/issues/72) | Module health — ide sync freshness in /status + respect /pause |
 | 10 | [#73](https://github.com/Anna-Hax/JUNO/issues/73) | M3 gate — IDE tests, ADR, README, v1.2 release gate |
 
-**First coding task:** #64–#69 ✅. Cross-ref ([#70](https://github.com/Anna-Hax/JUNO/issues/70)) — ✅ [session 35](sessions/35-session-ide-crossref.md). Next: [#71](https://github.com/Anna-Hax/JUNO/issues/71) digest.
+**First coding task:** #64–#70 ✅. Digest ([#71](https://github.com/Anna-Hax/JUNO/issues/71)) — ✅ [session 36](sessions/36-session-ide-digest.md). Next: [#72](https://github.com/Anna-Hax/JUNO/issues/72) module health.
 
 ### M3 design constraints (do not violate)
 

--- a/docs/sessions/36-session-ide-digest.md
+++ b/docs/sessions/36-session-ide-digest.md
@@ -1,0 +1,17 @@
+# Session 36 — Digest enrichment for IDE (#71)
+
+**Date:** 2026-09-02  
+**Issue:** [#71](https://github.com/Anna-Hax/JUNO/issues/71)  
+**Branch:** `feat/ide-digest-71`
+
+## What changed
+
+- `/digest today|week` groups **IDE chats** and **IDE errors** beside browser reading and uploads.
+
+## Verify
+
+```powershell
+cd apps/core
+$env:EMBEDDING_BACKEND='stub'
+uv run pytest tests/test_bot.py::test_format_digest_groups_ide_chats_and_errors -q
+```

--- a/docs/sessions/README.md
+++ b/docs/sessions/README.md
@@ -41,6 +41,7 @@ Living notes for what was implemented, how GitHub is set up, and what to do next
 | [33-session-ide-hitl.md](33-session-ide-hitl.md) | **#68** — HITL IDE error-match / batches |
 | [34-session-error-match.md](34-session-error-match.md) | **#69** — Error-matching retrieval |
 | [35-session-ide-crossref.md](35-session-ide-crossref.md) | **#70** — Cross-reference IDE vs browser + inbox |
+| [36-session-ide-digest.md](36-session-ide-digest.md) | **#71** — Digest enrichment for IDE |
 | [v1.0-release-gate.md](../v1.0-release-gate.md) | M1 checklist (all P0 closed) |
 | [v1.1-release-gate.md](../v1.1-release-gate.md) | M2 checklist (browser capture) |
 


### PR DESCRIPTION
## Summary
- `/digest today|week` groups IDE chats and IDE errors separately from browser reading and uploads.
- Scheduled push digests stay M4.

## Linked issue
Closes #71

## Test plan
- [x] `uv run pytest tests/test_bot.py`
- [x] `uv run ruff check src tests`