### PR TITLE
feat(api): record ide module health on ingest

### DIFF
--- a/apps/core/src/juno/ingest/pipeline.py
+++ b/apps/core/src/juno/ingest/pipeline.py
@@ -216,6 +216,8 @@ class IngestPipeline:
                         (row.chroma_id, row.text) for row in existing.scalars() if row.chroma_id
                     ]
                     await _touch_health(session, ok=True)
+                    if source_type == "ide":
+                        await _touch_health(session, ok=True, module="ide")
                     return capture.id, stored, []
                 if capture is not None:
                     old = await session.execute(select(Chunk).where(Chunk.capture_id == capture.id))
@@ -258,6 +260,8 @@ class IngestPipeline:
             await _touch_health(session, ok=True)
             if source_type == "browser":
                 await _touch_health(session, ok=True, module="extension")
+            if source_type == "ide":
+                await _touch_health(session, ok=True, module="ide")
             return capture.id, stored, stale
 
         capture_id, stored, stale = await self.db.write(write)
@@ -295,6 +299,8 @@ class IngestPipeline:
             await _touch_health(session, ok=False, error=reason)
             if source_type == "browser":
                 await _touch_health(session, ok=False, error=reason, module="extension")
+            if source_type == "ide":
+                await _touch_health(session, ok=False, error=reason, module="ide")
             return capture.id
 
         capture_id = await self.db.write(write)

--- a/apps/core/tests/test_ingest.py
+++ b/apps/core/tests/test_ingest.py
@@ -356,3 +356,24 @@ async def test_browser_ingest_updates_extension_module_health(db, pipeline):
         return row
 
     await db.read(read)
+
+
+@pytest.mark.asyncio
+async def test_ide_ingest_updates_ide_module_health(db, pipeline):
+    await pipeline.ingest_payload(
+        {
+            "source_type": "ide",
+            "uri": "cursor://composer/health",
+            "title": "Health chat",
+            "text": "user:\nhi\n",
+        }
+    )
+
+    async def read(session):
+        row = await session.get(ModuleHealth, "ide")
+        assert row is not None
+        assert row.last_success_at is not None
+        assert row.last_error is None
+        return row
+
+    await db.read(read)

--- a/docs/next-work.md
+++ b/docs/next-work.md
@@ -110,10 +110,10 @@ Milestone: [M3: v1.2 IDE Capture](https://github.com/Anna-Hax/JUNO/milestone/9).
 | 6 | [#69](https://github.com/Anna-Hax/JUNO/issues/69) | Error-matching retrieval — have I seen this error before? — ✅ [session 34](sessions/34-session-error-match.md) |
 | 7 | [#70](https://github.com/Anna-Hax/JUNO/issues/70) | Cross-reference IDE captures vs browser + inbox — ✅ [session 35](sessions/35-session-ide-crossref.md) |
 | 8 | [#71](https://github.com/Anna-Hax/JUNO/issues/71) | Digest enrichment — IDE chats/errors in /digest today\|week — ✅ [session 36](sessions/36-session-ide-digest.md) |
-| 9 | [#72](https://github.com/Anna-Hax/JUNO/issues/72) | Module health — ide sync freshness in /status + respect /pause |
+| 9 | [#72](https://github.com/Anna-Hax/JUNO/issues/72) | Module health — ide sync freshness in /status + respect /pause — ✅ [session 37](sessions/37-session-ide-health.md) |
 | 10 | [#73](https://github.com/Anna-Hax/JUNO/issues/73) | M3 gate — IDE tests, ADR, README, v1.2 release gate |
 
-**First coding task:** #64–#70 ✅. Digest ([#71](https://github.com/Anna-Hax/JUNO/issues/71)) — ✅ [session 36](sessions/36-session-ide-digest.md). Next: [#72](https://github.com/Anna-Hax/JUNO/issues/72) module health.
+**First coding task:** #64–#71 ✅. Module health ([#72](https://github.com/Anna-Hax/JUNO/issues/72)) — ✅ [session 37](sessions/37-session-ide-health.md). Next: [#73](https://github.com/Anna-Hax/JUNO/issues/73) M3 gate.
 
 ### M3 design constraints (do not violate)
 

--- a/docs/sessions/37-session-ide-health.md
+++ b/docs/sessions/37-session-ide-health.md
@@ -1,0 +1,18 @@
+# Session 37 — IDE module health (#72)
+
+**Date:** 2026-09-02  
+**Issue:** [#72](https://github.com/Anna-Hax/JUNO/issues/72)  
+**Branch:** `feat/ide-module-health-72`
+
+## What changed
+
+- Successful `source_type=ide` ingest updates `module_health.ide` (visible on `GET /status` and Telegram `/status`).
+- Adapter already backs off on `/pause` (HTTP 423).
+
+## Verify
+
+```powershell
+cd apps/core
+$env:EMBEDDING_BACKEND='stub'
+uv run pytest tests/test_ingest.py::test_ide_ingest_updates_ide_module_health -q
+```

--- a/docs/sessions/README.md
+++ b/docs/sessions/README.md
@@ -42,6 +42,7 @@ Living notes for what was implemented, how GitHub is set up, and what to do next
 | [34-session-error-match.md](34-session-error-match.md) | **#69** — Error-matching retrieval |
 | [35-session-ide-crossref.md](35-session-ide-crossref.md) | **#70** — Cross-reference IDE vs browser + inbox |
 | [36-session-ide-digest.md](36-session-ide-digest.md) | **#71** — Digest enrichment for IDE |
+| [37-session-ide-health.md](37-session-ide-health.md) | **#72** — IDE module health |
 | [v1.0-release-gate.md](../v1.0-release-gate.md) | M1 checklist (all P0 closed) |
 | [v1.1-release-gate.md](../v1.1-release-gate.md) | M2 checklist (browser capture) |
 


### PR DESCRIPTION
## Summary
- `source_type=ide` ingest updates `module_health.ide` for `GET /status` and Telegram `/status`.
- Adapter already respects global `/pause` (HTTP 423).

## Linked issue
Closes #72

## Test plan
- [x] `uv run pytest tests/test_ingest.py tests/test_ide_vscdb.py`
- [x] `uv run ruff check src tests`