### PR TITLE
chore(release): v1.2 IDE capture gate

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Personal knowledge-graph agent: passively (and manually) capture what you read, code, and discuss — query it from **Telegram**. Local-first on your PC.
 
-**Status:** **v1.1 browser capture** (M2 complete) — v1.0 foundation plus MV3 extension → loopback ingest, metrics, highlights, grouped digests. IDE capture (M3) is next.
+**Status:** **v1.2 IDE capture** (M3 complete) — v1.1 browser capture plus a read-only Cursor adapter → loopback ingest of chats and terminal errors, error-match retrieval, grouped digests. Proactive push (M4) is next.
 
 ## Architecture (v1)
 
@@ -10,7 +10,7 @@ Personal knowledge-graph agent: passively (and manually) capture what you read, 
 - **SQLite + write queue** for the graph ([ADR-02](docs/adr/002-sqlite-write-queue.md)); **Alembic** for schema changes ([ADR-03](docs/adr/003-alembic.md))
 - **Chroma** for vectors — persistent client, one collection per embedding model ([ADR-04](docs/adr/004-chroma-collections.md)); **stub embedder** in CI
 - **Browser extension** (`apps/extension`): MV3 loopback client ([ADR-05](docs/adr/005-browser-extension-client.md)); Spike S2 captures tabs → `POST /ingest`
-- **IDE adapter** (`apps/ide`): read-only Cursor `state.vscdb` client ([ADR-06](docs/adr/006-ide-adapter-client.md)); Spike S3 posts chats → `POST /ingest`
+- **IDE adapter** (`apps/ide`): read-only Cursor `state.vscdb` client ([ADR-06](docs/adr/006-ide-adapter-client.md)); poll/watch posts chats + terminal errors → `POST /ingest` (runbook in [`apps/ide/README.md`](apps/ide/README.md))
 - **Inbox** (`inbox/`): drop `.txt` / `.md` / `.pdf` / `.url` (or a one-line http(s) text file). `juno serve` watches the folder; good files move to `inbox/.processed/`, unreadable PDFs to `inbox/.failed/`.
 - **HITL** (`/review`): inline Approve / Reject / Skip for pending graph merges
 

--- a/apps/core/pyproject.toml
+++ b/apps/core/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "juno"
-version = "1.1.0"
+version = "1.2.0"
 description = "Personal knowledge graph agent — local-first second brain via Telegram"
 requires-python = ">=3.12"
 dependencies = [

--- a/apps/core/src/juno/__init__.py
+++ b/apps/core/src/juno/__init__.py
@@ -1,3 +1,3 @@
 """Juno — personal knowledge graph agent."""
 
-__version__ = "1.1.0"
+__version__ = "1.2.0"

--- a/apps/core/uv.lock
+++ b/apps/core/uv.lock
@@ -1070,7 +1070,7 @@ wheels = [
 
 [[package]]
 name = "juno"
-version = "1.1.0"
+version = "1.2.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiosqlite" },

--- a/apps/ide/README.md
+++ b/apps/ide/README.md
@@ -1,6 +1,6 @@
 # Juno IDE adapter
 
-Loopback **HTTP client** for Cursor chat history ([ADR-06](../../docs/adr/006-ide-adapter-client.md)). Reads `state.vscdb` **read-only** and posts to `juno serve`. Not a second daemon; no Juno SQLite/Chroma handles.
+Loopback **HTTP client** for Cursor chat history and terminal errors ([ADR-06](../../docs/adr/006-ide-adapter-client.md)). Reads `state.vscdb` **read-only** and posts to `juno serve`. Not a second daemon; no Juno SQLite/Chroma handles.
 
 ## Layout
 
@@ -11,6 +11,33 @@ Loopback **HTTP client** for Cursor chat history ([ADR-06](../../docs/adr/006-id
 | `api.py` | `GET /status`, `POST /ingest` |
 | `smoke.py` | Discover / export one session |
 | `sync.py` | Poll watermarked sessions (`--once` or `--watch`) |
+
+## Operator runbook
+
+1. Fill repo-root `.env` (`JUNO_API_TOKEN` not `change-me`). Cursor paths default to the platform `state.vscdb` if unset.
+2. Start the core: `cd apps/core` then `uv run juno serve`.
+3. Confirm `GET http://127.0.0.1:8787/health` → `{"status":"ok"}`.
+4. From the **repo root**, dry-run then commit:
+
+```powershell
+python apps/ide/sync.py --once --dry-run
+python apps/ide/sync.py --once
+```
+
+5. Telegram `/status` should show an `ide` module with `last_success`. `/digest today` groups IDE chats vs IDE errors vs browser vs uploads.
+6. Error-like queries use past IDE errors even if the LLM is down. HITL `/review` can confirm `error_match` and `ide_batch` cards.
+
+Leave `--watch` running in a terminal (or a Startup shortcut) if you want continuous poll. Global Telegram `/pause` returns HTTP 423; the adapter backs off that pass.
+
+### Default Cursor paths
+
+| OS | Global `state.vscdb` |
+|----|----------------------|
+| Windows | `%APPDATA%\Cursor\User\globalStorage\state.vscdb` |
+| macOS | `~/Library/Application Support/Cursor/User/globalStorage/state.vscdb` |
+| Linux | `~/.config/Cursor/User/globalStorage/state.vscdb` |
+
+Open the DB with SQLite `mode=ro` (copy-to-temp if Cursor has it locked). **Never write** Cursor files.
 
 ## Config
 
@@ -26,12 +53,14 @@ Set in repo-root `.env` (same file as `juno serve`):
 | `JUNO_IDE_POLL_SECONDS` | `60` (`--watch`) |
 | `JUNO_IDE_STATE` | `{JUNO_DATA_DIR}/ide-adapter.json` watermark |
 
-## Smoke
+## Smoke (one session)
 
 ```powershell
 python apps/ide/smoke.py discover
 python apps/ide/smoke.py export --latest --post
 ```
+
+Then `GET /search?q=<session title>` with Bearer token.
 
 ## Poll / watch
 
@@ -41,10 +70,32 @@ python apps/ide/sync.py --once
 python apps/ide/sync.py --watch
 ```
 
-`--watch` polls until Ctrl+C. Global `/pause` returns 423; the adapter backs off that pass. Re-posting the same `cursor://composer/{id}` or `cursor://error/{id}/{bubble}` updates one capture (no duplicate storms). Terminal command failures (`run_terminal_command_v2` / error-like output) ingest as `raw_json.kind=cursor_error`.
+`--watch` polls until Ctrl+C. Re-posting the same `cursor://composer/{id}` or `cursor://error/{id}/{bubble}` updates one capture (no duplicate storms). Terminal command failures (`run_terminal_command_v2` / error-like output) ingest as `raw_json.kind=cursor_error`.
+
+## What lands in the graph
+
+| Kind | `source_type` | URI | `raw_json.kind` |
+|------|---------------|-----|-----------------|
+| Composer chat | `ide` | `cursor://composer/{id}` | `cursor_chat` |
+| Terminal / tool error | `ide` | `cursor://error/{composer}/{bubble}` | `cursor_error` |
+
+Successful ingest updates `module_health.ide` (`GET /status` and Telegram `/status`).
+
+## Troubleshooting
+
+| Symptom | Check |
+|---------|--------|
+| `discover` returns 0 | Cursor 3.x `composerHeaders` present? Override `JUNO_CURSOR_VSCDB`. Cursor may have migrated keys. |
+| Locked DB | Wrapper copies to a temp file; close Cursor only if copy still fails. |
+| 401 | Token in `.env` must match `JUNO_API_TOKEN` used by `juno serve`. |
+| 423 | Capture is paused (`/resume` in Telegram). |
+| Empty assistant bubbles | Tool-call rows are skipped on purpose. |
 
 ## CI
 
 ```powershell
 python scripts/validate-ide.py
+cd apps/core
+$env:EMBEDDING_BACKEND='stub'
+uv run pytest tests/test_ide_scaffold.py tests/test_ide_vscdb.py -q
 ```

--- a/apps/ide/sync.py
+++ b/apps/ide/sync.py
@@ -1,8 +1,8 @@
 #!/usr/bin/env python3
-"""Poll Cursor state.vscdb and POST new/updated chats to loopback /ingest.
+"""Poll Cursor state.vscdb and POST new/updated chats + errors to loopback /ingest.
 
 HTTP client only (ADR-06). Watermark is a local JSON file, not Juno SQLite/Chroma.
-Idempotent capture rows land in #66; this scaffold posts sessions newer than the watermark.
+Core upserts by URI so re-posts update one capture.
 """
 
 from __future__ import annotations

--- a/docs/adr/006-ide-adapter-client.md
+++ b/docs/adr/006-ide-adapter-client.md
@@ -52,7 +52,7 @@ Cursor's storage is unofficial and has already migrated once (per-workspace `com
 - Guard missing fields; skip empty tool bubbles; do not assume `conversationMap` still holds text.
 - Mitigation: keep a fixture `state.vscdb` in tests; bump the reader when a live discover fails; record the Cursor version in the session log.
 
-Watch/poll, config paths, and CI layout: [#65](https://github.com/Anna-Hax/JUNO/issues/65). Idempotent re-sync, terminal errors, HITL, and module health stay in later M3 issues (#66–#72).
+M3 landed on this client (#65–#72): poll/watch + config/CI, idempotent chat + terminal-error ingest, HITL `error_match` / `ide_batch`, retrieve-even-if-LLM-down, cross-ref vs browser/inbox, grouped `/digest`, and `module_health.ide`. See [`docs/v1.2-release-gate.md`](../v1.2-release-gate.md).
 
 ## Consequences
 
@@ -70,3 +70,5 @@ Watch/poll, config paths, and CI layout: [#65](https://github.com/Anna-Hax/JUNO/
 ## Spike S3 proof
 
 Issue [#64](https://github.com/Anna-Hax/JUNO/issues/64): fixture + live `state.vscdb` export → `POST /ingest` with Bearer token (see [session 29](../sessions/29-session-spike-s3.md)).
+
+Operator runbook: [`apps/ide/README.md`](../../apps/ide/README.md).

--- a/docs/next-work.md
+++ b/docs/next-work.md
@@ -2,7 +2,7 @@
 
 **Last updated:** 2026-09-02  
 **Track issues on:** [https://github.com/Anna-Hax/JUNO/issues](https://github.com/Anna-Hax/JUNO/issues)  
-**Package:** `1.1.0` (M2 complete — M3 IDE capture expanded; [`docs/v1.1-release-gate.md`](v1.1-release-gate.md))
+**Package:** `1.2.0` (M3 complete — [`docs/v1.2-release-gate.md`](v1.2-release-gate.md))
 
 Prefer one open issue ≈ one PR (`Closes #N`). This file is kept as-is across branch merges (`merge=ours`).
 
@@ -111,9 +111,9 @@ Milestone: [M3: v1.2 IDE Capture](https://github.com/Anna-Hax/JUNO/milestone/9).
 | 7 | [#70](https://github.com/Anna-Hax/JUNO/issues/70) | Cross-reference IDE captures vs browser + inbox — ✅ [session 35](sessions/35-session-ide-crossref.md) |
 | 8 | [#71](https://github.com/Anna-Hax/JUNO/issues/71) | Digest enrichment — IDE chats/errors in /digest today\|week — ✅ [session 36](sessions/36-session-ide-digest.md) |
 | 9 | [#72](https://github.com/Anna-Hax/JUNO/issues/72) | Module health — ide sync freshness in /status + respect /pause — ✅ [session 37](sessions/37-session-ide-health.md) |
-| 10 | [#73](https://github.com/Anna-Hax/JUNO/issues/73) | M3 gate — IDE tests, ADR, README, v1.2 release gate |
+| 10 | [#73](https://github.com/Anna-Hax/JUNO/issues/73) | M3 gate — IDE tests, ADR, README, v1.2 release gate — ✅ [session 38](sessions/38-session-m3-gate.md) |
 
-**First coding task:** #64–#71 ✅. Module health ([#72](https://github.com/Anna-Hax/JUNO/issues/72)) — ✅ [session 37](sessions/37-session-ide-health.md). Next: [#73](https://github.com/Anna-Hax/JUNO/issues/73) M3 gate.
+**First coding task:** #64–#72 ✅. M3 gate ([#73](https://github.com/Anna-Hax/JUNO/issues/73)) — ✅ [session 38](sessions/38-session-m3-gate.md).
 
 ### M3 design constraints (do not violate)
 
@@ -124,7 +124,20 @@ Milestone: [M3: v1.2 IDE Capture](https://github.com/Anna-Hax/JUNO/milestone/9).
 5. Loopback + token auth only ([#21](https://github.com/Anna-Hax/JUNO/issues/21)) — never bind `0.0.0.0` for the adapter.
 6. HITL: error-match reuse and sensitive chat batches stay reviewable ([#68](https://github.com/Anna-Hax/JUNO/issues/68), [#20](https://github.com/Anna-Hax/JUNO/issues/20) patterns).
 
-### Explicitly **not** M3 (keep in later epics)
+---
+
+## M3 — **complete** (2026-09-02)
+
+Epic [#26](https://github.com/Anna-Hax/JUNO/issues/26) closed; milestone [M3: v1.2 IDE Capture](https://github.com/Anna-Hax/JUNO/milestone/9) complete. Gate: [`docs/v1.2-release-gate.md`](v1.2-release-gate.md).
+
+---
+
+## Unlock M4 (planning)
+
+Epic: [#27](https://github.com/Anna-Hax/JUNO/issues/27) — *Epic: M4 Proactive + mobile (v1.3)*.  
+Do **not** start M4 coding until this epic is expanded into child issues.
+
+### Explicitly **not** M3 / still later
 
 | Epic | Milestone | Scope |
 | ---- | --------- | ----- |

--- a/docs/sessions/38-session-m3-gate.md
+++ b/docs/sessions/38-session-m3-gate.md
@@ -1,0 +1,23 @@
+# Session 38 — M3 gate: IDE tests + v1.2 (#73)
+
+**Date:** 2026-09-02  
+**Issue:** [#73](https://github.com/Anna-Hax/JUNO/issues/73)  
+**Branch:** `feat/m3-gate-73`
+
+## What changed
+
+- Operator runbook in [`apps/ide/README.md`](../../apps/ide/README.md).
+- [ADR-06](../adr/006-ide-adapter-client.md) records landed M3 client behaviour (#65–#72).
+- [`docs/v1.2-release-gate.md`](../v1.2-release-gate.md) — M3 checklist; package **1.2.0**.
+
+## Verify
+
+```powershell
+python scripts/validate-ide.py
+cd apps/core
+$env:EMBEDDING_BACKEND='stub'
+uv run pytest tests/test_ide_scaffold.py tests/test_ide_vscdb.py -q
+uv run juno version   # expect 1.2.0
+```
+
+Poll Cursor chats per the adapter runbook.

--- a/docs/sessions/README.md
+++ b/docs/sessions/README.md
@@ -43,7 +43,9 @@ Living notes for what was implemented, how GitHub is set up, and what to do next
 | [35-session-ide-crossref.md](35-session-ide-crossref.md) | **#70** — Cross-reference IDE vs browser + inbox |
 | [36-session-ide-digest.md](36-session-ide-digest.md) | **#71** — Digest enrichment for IDE |
 | [37-session-ide-health.md](37-session-ide-health.md) | **#72** — IDE module health |
+| [38-session-m3-gate.md](38-session-m3-gate.md) | **#73** — M3 gate + v1.2 |
 | [v1.0-release-gate.md](../v1.0-release-gate.md) | M1 checklist (all P0 closed) |
 | [v1.1-release-gate.md](../v1.1-release-gate.md) | M2 checklist (browser capture) |
+| [v1.2-release-gate.md](../v1.2-release-gate.md) | M3 checklist (IDE capture) |
 
 Architecture decisions live in [`../adr/`](../adr/). Product requirements: [`../../personal-knowledge-graph-prd.md](../../personal-knowledge-graph-prd.md).

--- a/docs/v1.2-release-gate.md
+++ b/docs/v1.2-release-gate.md
@@ -1,0 +1,65 @@
+# v1.2 release gate (M3: IDE Capture)
+
+**Date:** 2026-09-02  
+**Milestone:** [M3: v1.2 IDE Capture](https://github.com/Anna-Hax/JUNO/milestone/9)  
+**Package version:** `1.2.0` (`apps/core`)  
+**Epic:** [#26](https://github.com/Anna-Hax/JUNO/issues/26)
+
+This checklist closes issue **#73**. Acceptance: **all M3 child issues closed** and IDE CI green.
+
+---
+
+## M3 issues (#64–#73)
+
+| Issue | Capability | Status | PR |
+|-------|------------|--------|-----|
+| [#64](https://github.com/Anna-Hax/JUNO/issues/64) | Spike S3 — Cursor vscdb → POST /ingest | ✅ Closed | [#74](https://github.com/Anna-Hax/JUNO/pull/74) |
+| [#65](https://github.com/Anna-Hax/JUNO/issues/65) | IDE adapter scaffold | ✅ Closed | [#75](https://github.com/Anna-Hax/JUNO/pull/75) |
+| [#66](https://github.com/Anna-Hax/JUNO/issues/66) | Chat / composer ingest | ✅ Closed | [#76](https://github.com/Anna-Hax/JUNO/pull/76) |
+| [#67](https://github.com/Anna-Hax/JUNO/issues/67) | Terminal error capture | ✅ Closed | [#77](https://github.com/Anna-Hax/JUNO/pull/77) |
+| [#68](https://github.com/Anna-Hax/JUNO/issues/68) | HITL error-match / ide_batch | ✅ Closed | [#78](https://github.com/Anna-Hax/JUNO/pull/78) |
+| [#69](https://github.com/Anna-Hax/JUNO/issues/69) | Error-matching retrieval | ✅ Closed | [#79](https://github.com/Anna-Hax/JUNO/pull/79) |
+| [#70](https://github.com/Anna-Hax/JUNO/issues/70) | Cross-reference IDE vs browser + inbox | ✅ Closed | [#80](https://github.com/Anna-Hax/JUNO/pull/80) |
+| [#71](https://github.com/Anna-Hax/JUNO/issues/71) | Digest enrichment | ✅ Closed | [#81](https://github.com/Anna-Hax/JUNO/pull/81) |
+| [#72](https://github.com/Anna-Hax/JUNO/issues/72) | Module health (`ide`) + pause | ✅ Closed | [#82](https://github.com/Anna-Hax/JUNO/pull/82) |
+| [#73](https://github.com/Anna-Hax/JUNO/issues/73) | IDE tests + this gate | ✅ Closed | (this doc + PR) |
+
+**M3:** 10 / 10 closed.
+
+---
+
+## CI / quality gate
+
+- [x] `uv run pytest` — **140** tests including IDE vscdb fixture, ingest, HITL, retrieve, digest, module health
+- [x] `uv run ruff check` + format check
+- [x] `CI IDE` — `scripts/validate-ide.py` (layout, syntax, no `0.0.0.0`)
+- [x] PR hygiene (`Closes #N`, conventional title)
+
+---
+
+## Manual smoke (operator)
+
+1. `uv run juno serve` with repo-root `.env`
+2. `python apps/ide/sync.py --once --dry-run` then `--once` per [`apps/ide/README.md`](../apps/ide/README.md)
+3. Telegram: `/status` shows `ide` module; `/digest today` groups IDE chats vs errors
+4. Error-like query returns a past IDE error even if the LLM is down
+
+---
+
+## What v1.2 means
+
+Phase 3 IDE capture from the PRD:
+
+- Read-only Cursor `state.vscdb` wrapper as loopback client ([ADR-06](adr/006-ide-adapter-client.md))
+- Composer chats + terminal errors → `POST /ingest` (`source_type=ide`)
+- Idempotent URIs; HITL for error-match / sensitive batches
+- Error-match retrieval; cross-reference vs browser/inbox; grouped digests
+- `ide` module health on `/status`; adapter respects global `/pause` (423)
+
+**Not in v1.2:** proactive push digests / voice (M4), polish (M5).
+
+---
+
+## Next milestone
+
+Epic [#27](https://github.com/Anna-Hax/JUNO/issues/27) — M4 Proactive + mobile.


### PR DESCRIPTION
## Summary
- Operator runbook for `apps/ide`; ADR-06 records landed M3 client behaviour.
- `docs/v1.2-release-gate.md` + package **1.2.0**.

## Linked issue
Closes #73

## Test plan
- [x] `python scripts/validate-ide.py`
- [x] `uv run pytest` (140 passed)
- [x] `uv run ruff check src tests`
- [x] `uv run juno version` → 1.2.0