### PR TITLE
feat(jobs): scheduler scaffold and cron job registry

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -32,6 +32,13 @@ EMBEDDING_BACKEND=sentence_transformers
 # JUNO_JOBS_TIMEZONE=UTC
 # Spike S4: one allowlisted Telegram line ~2s after start; leave off after proving
 # JUNO_JOBS_SMOKE=false
+# Cron jobs (5-field crontab). Bodies for digest/resurfacing land in #88/#89.
+# JUNO_JOBS_DIGEST_DAILY=true
+# JUNO_JOBS_DIGEST_DAILY_CRON=0 7 * * *
+# JUNO_JOBS_DIGEST_WEEKLY=true
+# JUNO_JOBS_DIGEST_WEEKLY_CRON=0 7 * * mon
+# JUNO_JOBS_RESURFACING=false
+# JUNO_JOBS_RESURFACING_CRON=0 * * * *
 
 # IDE adapter (apps/ide) — HTTP client only; empty path = platform Cursor default
 # JUNO_CURSOR_VSCDB=

--- a/apps/core/src/juno/config.py
+++ b/apps/core/src/juno/config.py
@@ -71,6 +71,12 @@ class Settings(BaseSettings):
     juno_jobs_enabled: bool = True
     juno_jobs_timezone: str = "UTC"
     juno_jobs_smoke: bool = False
+    juno_jobs_digest_daily: bool = True
+    juno_jobs_digest_daily_cron: str = "0 7 * * *"
+    juno_jobs_digest_weekly: bool = True
+    juno_jobs_digest_weekly_cron: str = "0 7 * * mon"
+    juno_jobs_resurfacing: bool = False
+    juno_jobs_resurfacing_cron: str = "0 * * * *"
 
     def allowed_user_id_set(self) -> set[int]:
         if not self.allowed_telegram_user_ids.strip():

--- a/apps/core/src/juno/jobs/__init__.py
+++ b/apps/core/src/juno/jobs/__init__.py
@@ -1,9 +1,18 @@
 """Scheduled jobs on the shared asyncio loop (M4 / ADR-07)."""
 
+from juno.jobs.registry import (
+    DIGEST_DAILY_JOB_ID,
+    DIGEST_WEEKLY_JOB_ID,
+    RESURFACING_JOB_ID,
+    JobSpec,
+    builtin_job_specs,
+    enabled_job_ids,
+)
 from juno.jobs.scheduler import (
     SMOKE_JOB_ID,
     SMOKE_TEXT,
     create_scheduler,
+    register_job_specs,
     register_smoke_job,
     send_allowlisted_push,
     start_jobs,
@@ -11,9 +20,16 @@ from juno.jobs.scheduler import (
 )
 
 __all__ = [
+    "DIGEST_DAILY_JOB_ID",
+    "DIGEST_WEEKLY_JOB_ID",
+    "RESURFACING_JOB_ID",
     "SMOKE_JOB_ID",
     "SMOKE_TEXT",
+    "JobSpec",
+    "builtin_job_specs",
     "create_scheduler",
+    "enabled_job_ids",
+    "register_job_specs",
     "register_smoke_job",
     "send_allowlisted_push",
     "start_jobs",

--- a/apps/core/src/juno/jobs/handlers.py
+++ b/apps/core/src/juno/jobs/handlers.py
@@ -1,0 +1,20 @@
+"""Job bodies. Digest/resurfacing pushes land in later M4 issues — ticks only log here."""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+logger = logging.getLogger("juno.jobs")
+
+
+async def digest_daily(app: Any) -> None:
+    logger.info("job digest_daily tick (push body deferred to #88)")
+
+
+async def digest_weekly(app: Any) -> None:
+    logger.info("job digest_weekly tick (push body deferred to #88)")
+
+
+async def resurfacing(app: Any) -> None:
+    logger.info("job resurfacing tick (push body deferred to #89)")

--- a/apps/core/src/juno/jobs/registry.py
+++ b/apps/core/src/juno/jobs/registry.py
@@ -1,0 +1,61 @@
+"""Named job specs from settings. Pure — no Telegram, no running scheduler."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from zoneinfo import ZoneInfo
+
+from apscheduler.triggers.cron import CronTrigger
+
+from juno.config import Settings
+
+DIGEST_DAILY_JOB_ID = "digest_daily"
+DIGEST_WEEKLY_JOB_ID = "digest_weekly"
+RESURFACING_JOB_ID = "resurfacing"
+
+
+@dataclass(frozen=True)
+class JobSpec:
+    id: str
+    crontab: str
+    enabled: bool
+    timezone: str = "UTC"
+    misfire_grace_time: int = 3600
+
+    def trigger(self) -> CronTrigger:
+        return CronTrigger.from_crontab(self.crontab, timezone=ZoneInfo(self.timezone))
+
+
+def builtin_job_specs(settings: Settings) -> tuple[JobSpec, ...]:
+    tz = settings.juno_jobs_timezone
+    return (
+        JobSpec(
+            id=DIGEST_DAILY_JOB_ID,
+            crontab=settings.juno_jobs_digest_daily_cron,
+            enabled=settings.juno_jobs_digest_daily,
+            timezone=tz,
+        ),
+        JobSpec(
+            id=DIGEST_WEEKLY_JOB_ID,
+            crontab=settings.juno_jobs_digest_weekly_cron,
+            enabled=settings.juno_jobs_digest_weekly,
+            timezone=tz,
+        ),
+        JobSpec(
+            id=RESURFACING_JOB_ID,
+            crontab=settings.juno_jobs_resurfacing_cron,
+            enabled=settings.juno_jobs_resurfacing,
+            timezone=tz,
+        ),
+    )
+
+
+def enabled_job_ids(
+    specs: tuple[JobSpec, ...] | None = None,
+    settings: Settings | None = None,
+) -> list[str]:
+    if specs is None:
+        if settings is None:
+            raise ValueError("specs or settings required")
+        specs = builtin_job_specs(settings)
+    return [spec.id for spec in specs if spec.enabled]

--- a/apps/core/src/juno/jobs/scheduler.py
+++ b/apps/core/src/juno/jobs/scheduler.py
@@ -11,11 +11,25 @@ from zoneinfo import ZoneInfo
 from apscheduler.schedulers.asyncio import AsyncIOScheduler
 
 from juno.config import Settings
+from juno.jobs.handlers import digest_daily, digest_weekly, resurfacing
+from juno.jobs.registry import (
+    DIGEST_DAILY_JOB_ID,
+    DIGEST_WEEKLY_JOB_ID,
+    RESURFACING_JOB_ID,
+    JobSpec,
+    builtin_job_specs,
+)
 
 logger = logging.getLogger("juno.jobs")
 
 SMOKE_JOB_ID = "spike_s4_smoke"
 SMOKE_TEXT = "Juno jobs smoke: AsyncIOScheduler fired on the shared serve loop."
+
+_HANDLER_BY_ID = {
+    DIGEST_DAILY_JOB_ID: digest_daily,
+    DIGEST_WEEKLY_JOB_ID: digest_weekly,
+    RESURFACING_JOB_ID: resurfacing,
+}
 
 
 def create_scheduler(timezone: str = "UTC") -> AsyncIOScheduler:
@@ -54,6 +68,39 @@ async def send_allowlisted_push(
     return sent
 
 
+def register_job_specs(
+    scheduler: AsyncIOScheduler,
+    specs: tuple[JobSpec, ...] | list[JobSpec],
+    *,
+    app: Any | None = None,
+) -> list[str]:
+    """Add enabled cron jobs. Safe without a live Telegram bot (handlers are ticks until #88)."""
+    added: list[str] = []
+    for spec in specs:
+        if not spec.enabled:
+            logger.info("job %s disabled", spec.id)
+            continue
+        handler = _HANDLER_BY_ID.get(spec.id)
+        if handler is None:
+            logger.warning("job %s has no handler — skipped", spec.id)
+            continue
+        trigger = spec.trigger()
+
+        async def run(*, fn=handler) -> None:
+            await fn(app)
+
+        scheduler.add_job(
+            run,
+            trigger=trigger,
+            id=spec.id,
+            replace_existing=True,
+            misfire_grace_time=spec.misfire_grace_time,
+        )
+        added.append(spec.id)
+        logger.info("job %s registered cron=%s tz=%s", spec.id, spec.crontab, spec.timezone)
+    return added
+
+
 def register_smoke_job(
     scheduler: AsyncIOScheduler,
     *,
@@ -73,14 +120,18 @@ def register_smoke_job(
 
 
 def start_jobs(app: Any) -> AsyncIOScheduler | None:
-    """Start AsyncIOScheduler on the serve loop. Optional one-shot Telegram smoke push."""
+    """Start AsyncIOScheduler on the serve loop and register builtin cron jobs."""
     settings: Settings = app.state.settings
     if not settings.juno_jobs_enabled:
         logger.info("jobs scheduler disabled (JUNO_JOBS_ENABLED=false)")
         app.state.scheduler = None
+        app.state.job_specs = ()
         return None
 
     scheduler = create_scheduler(settings.juno_jobs_timezone)
+    specs = builtin_job_specs(settings)
+    app.state.job_specs = specs
+    register_job_specs(scheduler, specs, app=app)
     scheduler.start()
     app.state.scheduler = scheduler
     logger.info(

--- a/apps/core/tests/test_jobs.py
+++ b/apps/core/tests/test_jobs.py
@@ -10,13 +10,20 @@ from apscheduler.schedulers.asyncio import AsyncIOScheduler
 
 from juno.config import Settings
 from juno.jobs import (
+    DIGEST_DAILY_JOB_ID,
+    DIGEST_WEEKLY_JOB_ID,
+    RESURFACING_JOB_ID,
     SMOKE_JOB_ID,
+    builtin_job_specs,
     create_scheduler,
+    enabled_job_ids,
+    register_job_specs,
     register_smoke_job,
     send_allowlisted_push,
     start_jobs,
     stop_jobs,
 )
+from juno.jobs.registry import JobSpec
 
 
 def test_create_scheduler_is_asyncio_scheduler():
@@ -77,6 +84,7 @@ async def test_start_jobs_disabled_does_not_start_scheduler(settings: Settings):
     app = SimpleNamespace(state=SimpleNamespace(settings=settings, ptb=None, capture_paused=False))
     assert start_jobs(app) is None
     assert app.state.scheduler is None
+    assert app.state.job_specs == ()
     stop_jobs(app)
 
 
@@ -104,3 +112,55 @@ async def test_start_jobs_smoke_registers_one_shot(settings: Settings):
     finally:
         stop_jobs(app)
     assert app.state.scheduler is None
+
+
+def test_builtin_registry_defaults_without_telegram(settings: Settings):
+    specs = builtin_job_specs(settings)
+    ids = [spec.id for spec in specs]
+    assert ids == [DIGEST_DAILY_JOB_ID, DIGEST_WEEKLY_JOB_ID, RESURFACING_JOB_ID]
+    assert enabled_job_ids(specs) == [DIGEST_DAILY_JOB_ID, DIGEST_WEEKLY_JOB_ID]
+    daily = next(spec for spec in specs if spec.id == DIGEST_DAILY_JOB_ID)
+    assert daily.crontab == "0 7 * * *"
+    assert daily.trigger() is not None
+
+
+def test_disabled_job_is_not_added_to_scheduler(settings: Settings):
+    settings.juno_jobs_digest_daily = False
+    settings.juno_jobs_digest_weekly = False
+    settings.juno_jobs_resurfacing = False
+    scheduler = create_scheduler("UTC")
+    added = register_job_specs(scheduler, builtin_job_specs(settings), app=None)
+    assert added == []
+    assert scheduler.get_job(DIGEST_DAILY_JOB_ID) is None
+
+
+def test_register_job_specs_without_starting_or_telegram(settings: Settings):
+    settings.juno_jobs_resurfacing = True
+    scheduler = create_scheduler("UTC")
+    added = register_job_specs(scheduler, builtin_job_specs(settings), app=None)
+    assert DIGEST_DAILY_JOB_ID in added
+    assert DIGEST_WEEKLY_JOB_ID in added
+    assert RESURFACING_JOB_ID in added
+    assert scheduler.get_job(DIGEST_DAILY_JOB_ID) is not None
+    assert scheduler.running is False
+
+
+def test_invalid_crontab_raises(settings: Settings):
+    spec = JobSpec(id="bad", crontab="not-a-cron", enabled=True, timezone="UTC")
+    with pytest.raises(ValueError):
+        spec.trigger()
+
+
+@pytest.mark.asyncio
+async def test_start_jobs_registers_enabled_cron_jobs(settings: Settings):
+    settings.juno_jobs_enabled = True
+    settings.juno_jobs_smoke = False
+    settings.juno_jobs_digest_weekly = False
+    app = SimpleNamespace(state=SimpleNamespace(settings=settings, ptb=None, capture_paused=False))
+    scheduler = start_jobs(app)
+    try:
+        assert scheduler.get_job(DIGEST_DAILY_JOB_ID) is not None
+        assert scheduler.get_job(DIGEST_WEEKLY_JOB_ID) is None
+        assert scheduler.get_job(RESURFACING_JOB_ID) is None
+    finally:
+        stop_jobs(app)

--- a/docs/adr/007-proactive-jobs-shared-loop.md
+++ b/docs/adr/007-proactive-jobs-shared-loop.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-Accepted (M4 / Spike S4)
+Accepted (M4 / Spike S4 + scheduler scaffold)
 
 ## Date
 
@@ -42,9 +42,10 @@ Concrete rules (`juno.jobs.scheduler`):
    - `JUNO_JOBS_ENABLED` (default `true`) — start the scheduler at all
    - `JUNO_JOBS_TIMEZONE` (default `UTC`) — cron/date interpretation
    - `JUNO_JOBS_SMOKE` (default `false`) — Spike S4 one-shot Telegram line ~2s after start
-6. Tests and CI must not require live Telegram: call job helpers with a mock bot; keep `JUNO_JOBS_SMOKE` off unless an operator is proving the loop.
+   - Per-job enable + 5-field crontab: `JUNO_JOBS_DIGEST_DAILY` / `_CRON` (default `0 7 * * *`), `JUNO_JOBS_DIGEST_WEEKLY` / `_CRON` (default `0 7 * * mon`), `JUNO_JOBS_RESURFACING` / `_CRON` (default off, `0 * * * *`)
+6. Tests and CI must not require live Telegram: `builtin_job_specs` / `register_job_specs` import and register without a bot; keep `JUNO_JOBS_SMOKE` off unless an operator is proving the loop.
 
-A full job registry (named cron jobs, enable/disable per job) lands in [#87](https://github.com/Anna-Hax/JUNO/issues/87). Daily/weekly digest push, resurfacing, and `module_health.jobs` stay later M4 issues.
+Named jobs live in `juno.jobs.registry` (`digest_daily`, `digest_weekly`, `resurfacing`). Invalid crontab fails at serve start (`CronTrigger.from_crontab`). Push bodies for digest/resurfacing land in [#88](https://github.com/Anna-Hax/JUNO/issues/88) / [#89](https://github.com/Anna-Hax/JUNO/issues/89); `module_health.jobs` stays [#94](https://github.com/Anna-Hax/JUNO/issues/94).
 
 ## Consequences
 
@@ -63,3 +64,7 @@ A full job registry (named cron jobs, enable/disable per job) lands in [#87](htt
 ## Spike S4 proof
 
 Issue [#86](https://github.com/Anna-Hax/JUNO/issues/86): `AsyncIOScheduler` date job fires on `asyncio.get_running_loop()`; `send_allowlisted_push` is the Telegram path (see [session 39](../sessions/39-session-spike-s4.md)).
+
+## Scaffold (#87)
+
+Issue [#87](https://github.com/Anna-Hax/JUNO/issues/87): `builtin_job_specs` + `register_job_specs` on the serve loop; CI registers cron jobs without sending Telegram (see [session 40](../sessions/40-session-jobs-scaffold.md)).

--- a/docs/next-work.md
+++ b/docs/next-work.md
@@ -142,7 +142,7 @@ Milestone: [M4: v1.3 Proactive & Mobile](https://github.com/Anna-Hax/JUNO/milest
 | Order | Issue | Title |
 | ----- | ----- | ----- |
 | 1 | [#86](https://github.com/Anna-Hax/JUNO/issues/86) | Spike S4 — APScheduler on shared loop + one Telegram push smoke — ✅ [session 39](sessions/39-session-spike-s4.md) |
-| 2 | [#87](https://github.com/Anna-Hax/JUNO/issues/87) | Scheduler scaffold — APScheduler in serve lifespan + job registry |
+| 2 | [#87](https://github.com/Anna-Hax/JUNO/issues/87) | Scheduler scaffold — APScheduler in serve lifespan + job registry — ✅ [session 40](sessions/40-session-jobs-scaffold.md) |
 | 3 | [#88](https://github.com/Anna-Hax/JUNO/issues/88) | Scheduled push digests — morning daily + weekly |
 | 4 | [#89](https://github.com/Anna-Hax/JUNO/issues/89) | Contextual resurfacing — push when something comes up again |
 | 5 | [#90](https://github.com/Anna-Hax/JUNO/issues/90) | Temporal queries — how has my understanding of X evolved |
@@ -152,7 +152,7 @@ Milestone: [M4: v1.3 Proactive & Mobile](https://github.com/Anna-Hax/JUNO/milest
 | 9 | [#94](https://github.com/Anna-Hax/JUNO/issues/94) | Module health — jobs scheduler freshness + respect /pause |
 | 10 | [#95](https://github.com/Anna-Hax/JUNO/issues/95) | M4 gate — jobs tests, ADR, README, v1.3 release gate |
 
-**First coding task:** #86 ✅. Next: scheduler scaffold ([#87](https://github.com/Anna-Hax/JUNO/issues/87)).
+**First coding task:** #86–#87 ✅. Next: scheduled push digests ([#88](https://github.com/Anna-Hax/JUNO/issues/88)).
 
 ### M4 design constraints (do not violate)
 

--- a/docs/sessions/02-codebase-map.md
+++ b/docs/sessions/02-codebase-map.md
@@ -31,7 +31,7 @@ JUNO/
 | Config | `config.py` | pydantic-settings from `.env` |
 | CLI | `cli.py` | `juno serve` / `db-init` / `export` / `wipe` / `version` |
 | Runtime | `runtime.py` | Shared asyncio: uvicorn + PTB + inbox watcher + jobs scheduler lifespan |
-| Jobs | `jobs/scheduler.py` | AsyncIOScheduler on the serve loop (ADR-07 / Spike S4); cron registry later |
+| Jobs | `jobs/scheduler.py`, `jobs/registry.py` | AsyncIOScheduler + named cron registry (ADR-07) |
 | API | `api/__init__.py` | FastAPI routes + token + loopback middleware |
 | Bot | `bot/handlers.py`, `bot/services.py`, `bot/review.py` | Telegram allowlist, query, capture, pause/digest/status ([#18](https://github.com/Anna-Hax/JUNO/issues/18) / [#19](https://github.com/Anna-Hax/JUNO/issues/19)); HITL `/review` ([#20](https://github.com/Anna-Hax/JUNO/issues/20)) |
 | Graph DB | `graph/db.py`, `graph/migrations.py`, `graph/ownership.py` | Engine, WAL, write queue, Alembic upgrade/stamp; export/wipe ([#23](https://github.com/Anna-Hax/JUNO/issues/23)) |

--- a/docs/sessions/40-session-jobs-scaffold.md
+++ b/docs/sessions/40-session-jobs-scaffold.md
@@ -1,0 +1,30 @@
+# Session 40 — Scheduler scaffold (#87)
+
+**Date:** 2026-09-04  
+**Issue:** [#87](https://github.com/Anna-Hax/JUNO/issues/87)  
+**Branch:** `feat/jobs-scaffold-87`
+
+## What changed
+
+- `juno.jobs.registry` — named specs `digest_daily`, `digest_weekly`, `resurfacing` with enable + crontab from settings.
+- Serve lifespan registers enabled cron jobs (tick handlers only; no Telegram until #88/#89).
+- CI imports/registers jobs without a bot.
+
+## Verify
+
+```powershell
+cd apps/core
+$env:EMBEDDING_BACKEND='stub'
+uv run pytest tests/test_jobs.py -q
+```
+
+## Deferred
+
+Digest push text (#88), resurfacing body (#89), module health (#94).
+
+## Links
+
+| Doc | Role |
+|-----|------|
+| [007-proactive-jobs-shared-loop.md](../adr/007-proactive-jobs-shared-loop.md) | ADR |
+| [next-work.md](../next-work.md) | M4 queue |

--- a/docs/sessions/README.md
+++ b/docs/sessions/README.md
@@ -45,6 +45,7 @@ Living notes for what was implemented, how GitHub is set up, and what to do next
 | [37-session-ide-health.md](37-session-ide-health.md) | **#72** — IDE module health |
 | [38-session-m3-gate.md](38-session-m3-gate.md) | **#73** — M3 gate + v1.2 |
 | [39-session-spike-s4.md](39-session-spike-s4.md) | **#86** — Spike S4 APScheduler shared-loop smoke |
+| [40-session-jobs-scaffold.md](40-session-jobs-scaffold.md) | **#87** — Jobs scheduler scaffold + registry |
 | [v1.0-release-gate.md](../v1.0-release-gate.md) | M1 checklist (all P0 closed) |
 | [v1.1-release-gate.md](../v1.1-release-gate.md) | M2 checklist (browser capture) |
 | [v1.2-release-gate.md](../v1.2-release-gate.md) | M3 checklist (IDE capture) |


### PR DESCRIPTION
## Summary
- Named job registry (`digest_daily`, `digest_weekly`, `resurfacing`) with per-job enable + crontab settings.
- Serve lifespan registers enabled cron jobs as log-only ticks (no Telegram) so CI can import/register without a bot.
- ADR-07 records the knobs; digest/resurfacing push bodies stay #88/#89.

## Linked issue
Closes #87

## Test plan
- [x] `uv run pytest tests/test_jobs.py` (11 passed)
- [x] `uv run ruff check src tests` + format check
- [ ] Manual: `juno serve` logs job registration for daily/weekly cron