### PR TITLE
feat(jobs): resurface recurring topics with HITL fallback

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -37,7 +37,7 @@ EMBEDDING_BACKEND=sentence_transformers
 # JUNO_JOBS_DIGEST_DAILY_CRON=0 7 * * *
 # JUNO_JOBS_DIGEST_WEEKLY=true
 # JUNO_JOBS_DIGEST_WEEKLY_CRON=0 7 * * mon
-# JUNO_JOBS_RESURFACING=false
+# JUNO_JOBS_RESURFACING=true
 # JUNO_JOBS_RESURFACING_CRON=0 * * * *
 
 # IDE adapter (apps/ide) — HTTP client only; empty path = platform Cursor default

--- a/apps/core/src/juno/bot/handlers.py
+++ b/apps/core/src/juno/bot/handlers.py
@@ -33,11 +33,11 @@ HELP_TEXT = (
     "/start — hello\n"
     "/help — this message\n"
     "/digest today|week — recent captures\n"
-    "/jobs — scheduled digest on/off (daily|weekly)\n"
+    "/jobs — scheduled digest / resurfacing on|off\n"
     "/pause — stop all ingest\n"
     "/resume — resume ingest (processes inbox backlog)\n"
     "/status — capture + module health\n"
-    "/review — HITL queue (Approve / Reject / Skip: merges, IDE error-match, chat batches)\n"
+    "/review — HITL Approve/Reject/Skip (merges, IDE, chat batches, resurfacing)\n"
     "Ask a question to search the graph.\n"
     "Forward a message, send a link, or attach a doc to capture."
 )
@@ -105,7 +105,7 @@ async def jobs_cmd(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
         await update.message.reply_text(format_jobs_status(svc.app))
         return
     if len(args) != 2 or args[0] not in TOGGLEABLE_JOBS or args[1] not in {"on", "off"}:
-        await update.message.reply_text("Usage: /jobs   or   /jobs daily|weekly on|off")
+        await update.message.reply_text("Usage: /jobs   or   /jobs daily|weekly|resurface on|off")
         return
     job_id = TOGGLEABLE_JOBS[args[0]]
     msg = await set_cron_job_enabled(svc.app, job_id, enabled=args[1] == "on")

--- a/apps/core/src/juno/config.py
+++ b/apps/core/src/juno/config.py
@@ -75,7 +75,7 @@ class Settings(BaseSettings):
     juno_jobs_digest_daily_cron: str = "0 7 * * *"
     juno_jobs_digest_weekly: bool = True
     juno_jobs_digest_weekly_cron: str = "0 7 * * mon"
-    juno_jobs_resurfacing: bool = False
+    juno_jobs_resurfacing: bool = True
     juno_jobs_resurfacing_cron: str = "0 * * * *"
 
     def allowed_user_id_set(self) -> set[int]:

--- a/apps/core/src/juno/hitl/queue.py
+++ b/apps/core/src/juno/hitl/queue.py
@@ -17,6 +17,7 @@ Decision = Literal["approve", "reject", "skip"]
 KIND_MERGE = "merge"
 KIND_ERROR_MATCH = "error_match"
 KIND_IDE_BATCH = "ide_batch"
+KIND_RESURFACE = "resurface"
 STATUS_PENDING = "pending"
 STATUS_SKIPPED = "skipped"
 STATUS_DECIDED = "decided"
@@ -66,6 +67,14 @@ class ReviewCard:
             if reason:
                 lines.append(str(reason))
             lines.append("Approve to keep this batch in the graph; Reject to leave it unconfirmed.")
+        elif self.kind == KIND_RESURFACE:
+            recent = str(self.payload.get("recent_title") or "recent")
+            past = str(self.payload.get("past_title") or "earlier")
+            lines.append(f'This came up again?\nNow: "{recent}"\nEarlier: "{past}"')
+            reason = self.payload.get("reason")
+            if reason:
+                lines.append(str(reason))
+            lines.append("Approve if it is the same topic; Reject to ignore this suggestion.")
         else:
             preview = str(self.payload)[:500]
             if preview:

--- a/apps/core/src/juno/jobs/handlers.py
+++ b/apps/core/src/juno/jobs/handlers.py
@@ -48,4 +48,13 @@ async def digest_weekly(app: Any) -> None:
 
 
 async def resurfacing(app: Any) -> None:
-    logger.info("job resurfacing tick (push body deferred to #89)")
+    from juno.jobs.resurface import apply_resurface_candidates, find_resurface_candidates
+
+    db = getattr(app.state, "db", None) if app is not None else None
+    vectors = getattr(app.state, "vectors", None) if app is not None else None
+    if db is None:
+        logger.info("resurfacing skipped — database not attached")
+        return
+    candidates = await find_resurface_candidates(db, vectors)
+    stats = await apply_resurface_candidates(app, candidates)
+    logger.info("resurfacing pushed=%s queued=%s", stats["pushed"], stats["queued"])

--- a/apps/core/src/juno/jobs/registry.py
+++ b/apps/core/src/juno/jobs/registry.py
@@ -18,6 +18,7 @@ RESURFACING_JOB_ID = "resurfacing"
 TOGGLEABLE_JOBS = {
     "daily": DIGEST_DAILY_JOB_ID,
     "weekly": DIGEST_WEEKLY_JOB_ID,
+    "resurface": RESURFACING_JOB_ID,
 }
 
 

--- a/apps/core/src/juno/jobs/resurface.py
+++ b/apps/core/src/juno/jobs/resurface.py
@@ -1,0 +1,182 @@
+"""Contextual resurfacing: push when an older capture matches something recent."""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from datetime import UTC, datetime, timedelta
+from typing import Any
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from juno.bot.services import recent_captures
+from juno.graph.db import Database
+from juno.hitl.queue import KIND_RESURFACE, ReviewQueue
+from juno.models import AppSetting, Capture
+from juno.rag.engine import retrieve
+
+logger = logging.getLogger("juno.jobs")
+
+HIGH_CONFIDENCE = 0.55
+RECENT_HOURS = 48
+STALE_DAYS = 7
+
+
+@dataclass(frozen=True)
+class ResurfaceCandidate:
+    recent_id: int
+    past_id: int
+    score: float
+    recent_title: str
+    past_title: str
+    past_source: str
+    past_when: datetime | None
+    snippet: str
+
+    def seen_key(self) -> str:
+        a, b = sorted((self.recent_id, self.past_id))
+        return f"jobs.resurface.seen.{a}.{b}"
+
+
+def format_resurface_push(candidate: ResurfaceCandidate) -> str:
+    when = ""
+    if candidate.past_when is not None:
+        when = candidate.past_when.strftime("%Y-%m-%d")
+    earlier = f"{candidate.past_title} [{candidate.past_source}"
+    if when:
+        earlier += f" {when}"
+    earlier += "]"
+    return (
+        "This came up again — here's what you know:\n"
+        f"Now: {candidate.recent_title}\n"
+        f"Earlier: {earlier}\n"
+        f"Confidence: {candidate.score:.0%}"
+    )
+
+
+async def find_resurface_candidates(
+    db: Database,
+    vectors: Any,
+    *,
+    now: datetime | None = None,
+    recent_hours: int = RECENT_HOURS,
+    stale_days: int = STALE_DAYS,
+) -> list[ResurfaceCandidate]:
+    if vectors is None:
+        return []
+    now = now or datetime.now(UTC)
+    recent = await recent_captures(db, since=now - timedelta(hours=recent_hours), limit=12)
+    stale_before = now - timedelta(days=stale_days)
+    found: list[ResurfaceCandidate] = []
+    seen_pairs: set[tuple[int, int]] = set()
+    for cap in recent:
+        query = (cap.text or cap.title or "").strip()[:240]
+        if len(query) < 8:
+            continue
+        hits = await retrieve(query, vectors=vectors, db=db, n_results=6)
+        for hit in hits:
+            past_id = hit.capture_id
+            if past_id is None or past_id == cap.id:
+                continue
+            pair = (min(cap.id, past_id), max(cap.id, past_id))
+            if pair in seen_pairs:
+                continue
+            past = await _load_capture(db, past_id)
+            if past is None or past.captured_at is None:
+                continue
+            past_at = past.captured_at
+            if past_at.tzinfo is None:
+                past_at = past_at.replace(tzinfo=UTC)
+            if past_at > stale_before:
+                continue
+            seen_pairs.add(pair)
+            found.append(
+                ResurfaceCandidate(
+                    recent_id=cap.id,
+                    past_id=past.id,
+                    score=float(hit.score),
+                    recent_title=(cap.title or cap.uri or f"capture #{cap.id}"),
+                    past_title=(past.title or past.uri or f"capture #{past.id}"),
+                    past_source=past.source_type,
+                    past_when=past_at,
+                    snippet=(hit.text or "")[:180],
+                )
+            )
+            break
+    found.sort(key=lambda c: c.score, reverse=True)
+    return found[:5]
+
+
+async def apply_resurface_candidates(
+    app: Any,
+    candidates: list[ResurfaceCandidate],
+) -> dict[str, int]:
+    from juno.jobs.scheduler import send_allowlisted_push
+
+    pushed = 0
+    queued = 0
+    if not candidates:
+        return {"pushed": 0, "queued": 0}
+    if bool(getattr(app.state, "capture_paused", False)):
+        logger.info("resurfacing skipped — capture paused")
+        return {"pushed": 0, "queued": 0}
+    db: Database | None = getattr(app.state, "db", None)
+    settings = getattr(app.state, "settings", None)
+    if db is None or settings is None:
+        return {"pushed": 0, "queued": 0}
+    ptb = getattr(app.state, "ptb", None)
+    bot = getattr(ptb, "bot", None) if ptb is not None else None
+    review = ReviewQueue(db)
+    for candidate in candidates:
+        if await _already_seen(db, candidate.seen_key()):
+            continue
+        if candidate.score >= HIGH_CONFIDENCE:
+            sent = await send_allowlisted_push(
+                bot,
+                settings,
+                format_resurface_push(candidate),
+                is_paused=lambda: bool(getattr(app.state, "capture_paused", False)),
+            )
+            if sent:
+                pushed += 1
+            await _mark_seen(db, candidate.seen_key())
+        else:
+            await review.enqueue(
+                kind=KIND_RESURFACE,
+                confidence=candidate.score,
+                payload={
+                    "recent_id": candidate.recent_id,
+                    "past_id": candidate.past_id,
+                    "recent_title": candidate.recent_title,
+                    "past_title": candidate.past_title,
+                    "reason": "Low-confidence resurface; confirm it is the same topic.",
+                    "snippet": candidate.snippet,
+                },
+            )
+            queued += 1
+            await _mark_seen(db, candidate.seen_key())
+    return {"pushed": pushed, "queued": queued}
+
+
+async def _load_capture(db: Database, capture_id: int) -> Capture | None:
+    async def fn(session: AsyncSession) -> Capture | None:
+        return await session.get(Capture, capture_id)
+
+    return await db.read(fn)
+
+
+async def _already_seen(db: Database, key: str) -> bool:
+    async def fn(session: AsyncSession) -> bool:
+        row = await session.get(AppSetting, key)
+        return row is not None
+
+    return await db.read(fn)
+
+
+async def _mark_seen(db: Database, key: str) -> None:
+    async def fn(session: AsyncSession) -> None:
+        row = await session.get(AppSetting, key)
+        if row is None:
+            session.add(AppSetting(key=key, value="true"))
+
+    await db.write(fn)

--- a/apps/core/src/juno/jobs/scheduler.py
+++ b/apps/core/src/juno/jobs/scheduler.py
@@ -218,5 +218,5 @@ def format_jobs_status(app: Any) -> str:
         nxt = job.next_run_time
         when = nxt.strftime("%Y-%m-%d %H:%M %Z") if nxt is not None else "paused"
         lines.append(f"• {spec.id}: on → {when}  ({spec.crontab})")
-    lines.append("Toggle: /jobs daily on|off  /jobs weekly on|off")
+    lines.append("Toggle: /jobs daily|weekly|resurface on|off")
     return "\n".join(lines)

--- a/apps/core/tests/test_jobs.py
+++ b/apps/core/tests/test_jobs.py
@@ -118,7 +118,11 @@ def test_builtin_registry_defaults_without_telegram(settings: Settings):
     specs = builtin_job_specs(settings)
     ids = [spec.id for spec in specs]
     assert ids == [DIGEST_DAILY_JOB_ID, DIGEST_WEEKLY_JOB_ID, RESURFACING_JOB_ID]
-    assert enabled_job_ids(specs) == [DIGEST_DAILY_JOB_ID, DIGEST_WEEKLY_JOB_ID]
+    assert enabled_job_ids(specs) == [
+        DIGEST_DAILY_JOB_ID,
+        DIGEST_WEEKLY_JOB_ID,
+        RESURFACING_JOB_ID,
+    ]
     daily = next(spec for spec in specs if spec.id == DIGEST_DAILY_JOB_ID)
     assert daily.crontab == "0 7 * * *"
     assert daily.trigger() is not None
@@ -156,6 +160,7 @@ async def test_start_jobs_registers_enabled_cron_jobs(settings: Settings):
     settings.juno_jobs_enabled = True
     settings.juno_jobs_smoke = False
     settings.juno_jobs_digest_weekly = False
+    settings.juno_jobs_resurfacing = False
     app = SimpleNamespace(state=SimpleNamespace(settings=settings, ptb=None, capture_paused=False))
     scheduler = start_jobs(app)
     try:
@@ -205,4 +210,96 @@ def test_apply_enabled_overrides(settings: Settings):
 
     specs = builtin_job_specs(settings)
     patched = apply_enabled_overrides(specs, {DIGEST_DAILY_JOB_ID: False})
-    assert enabled_job_ids(patched) == [DIGEST_WEEKLY_JOB_ID]
+    assert enabled_job_ids(patched) == [DIGEST_WEEKLY_JOB_ID, RESURFACING_JOB_ID]
+
+
+@pytest.mark.asyncio
+async def test_resurface_pushes_high_confidence_and_queues_low(settings: Settings):
+    from datetime import UTC, datetime, timedelta
+
+    from sqlalchemy import select
+
+    from juno.graph.db import Database
+    from juno.graph.vectors import VectorStore
+    from juno.hitl.queue import KIND_RESURFACE, STATUS_PENDING, ReviewCard
+    from juno.ingest.pipeline import IngestPipeline
+    from juno.jobs.resurface import (
+        HIGH_CONFIDENCE,
+        ResurfaceCandidate,
+        apply_resurface_candidates,
+        find_resurface_candidates,
+    )
+    from juno.llm.embedder import StubEmbedder
+    from juno.models import Capture, ReviewItem
+
+    settings.allowed_telegram_user_ids = "42"
+    db = Database(settings)
+    await db.migrate()
+    vectors = VectorStore(settings, StubEmbedder())
+    pipe = IngestPipeline(db, vectors=vectors)
+    bot = AsyncMock()
+    app = SimpleNamespace(
+        state=SimpleNamespace(
+            settings=settings,
+            db=db,
+            vectors=vectors,
+            ptb=SimpleNamespace(bot=bot),
+            capture_paused=False,
+        )
+    )
+    note = "Ownership in Rust means each value has a single owner rust-ownership-xyz."
+    try:
+        old = await pipe.ingest_text(note, source_type="upload", title="old rust note")
+        new = await pipe.ingest_text(note, source_type="browser", title="rust ownership again")
+
+        async def backdate(session):
+            row = await session.get(Capture, old.capture_id)
+            row.captured_at = datetime.now(UTC) - timedelta(days=10)
+
+        await db.write(backdate)
+        found = await find_resurface_candidates(db, vectors)
+        assert found
+        assert found[0].past_id == old.capture_id
+        assert found[0].recent_id == new.capture_id
+        assert found[0].score >= HIGH_CONFIDENCE
+        stats = await apply_resurface_candidates(app, found)
+        assert stats["pushed"] == 1
+        text = bot.send_message.await_args.kwargs["text"]
+        assert "came up again" in text.lower()
+        bot.send_message.reset_mock()
+        again = await apply_resurface_candidates(app, found)
+        assert again["pushed"] == 0
+
+        low = ResurfaceCandidate(
+            recent_id=9001,
+            past_id=9002,
+            score=HIGH_CONFIDENCE - 0.2,
+            recent_title="new",
+            past_title="old",
+            past_source="upload",
+            past_when=datetime.now(UTC) - timedelta(days=10),
+            snippet="...",
+        )
+        queued = await apply_resurface_candidates(app, [low])
+        assert queued["queued"] == 1
+        bot.send_message.assert_not_awaited()
+
+        async def pending(session):
+            result = await session.execute(
+                select(ReviewItem).where(ReviewItem.kind == KIND_RESURFACE)
+            )
+            return list(result.scalars())
+
+        items = await db.read(pending)
+        assert items
+        summary = ReviewCard(
+            id=1,
+            kind=KIND_RESURFACE,
+            confidence=0.3,
+            payload={"recent_title": "new", "past_title": "old"},
+            status=STATUS_PENDING,
+            decision=None,
+        ).summary()
+        assert "came up again" in summary.lower()
+    finally:
+        await db.dispose()

--- a/docs/adr/007-proactive-jobs-shared-loop.md
+++ b/docs/adr/007-proactive-jobs-shared-loop.md
@@ -45,7 +45,7 @@ Concrete rules (`juno.jobs.scheduler`):
    - Per-job enable + 5-field crontab: `JUNO_JOBS_DIGEST_DAILY` / `_CRON` (default `0 7 * * *`), `JUNO_JOBS_DIGEST_WEEKLY` / `_CRON` (default `0 7 * * mon`), `JUNO_JOBS_RESURFACING` / `_CRON` (default off, `0 * * * *`)
 6. Tests and CI must not require live Telegram: `builtin_job_specs` / `register_job_specs` import and register without a bot; keep `JUNO_JOBS_SMOKE` off unless an operator is proving the loop.
 
-Named jobs live in `juno.jobs.registry` (`digest_daily`, `digest_weekly`, `resurfacing`). Invalid crontab fails at serve start (`CronTrigger.from_crontab`). Digest push bodies land in [#88](https://github.com/Anna-Hax/JUNO/issues/88) (`push_scheduled_digest` reuses `/digest` grouping; `/jobs daily|weekly on|off` persists enable flags). Resurfacing stays [#89](https://github.com/Anna-Hax/JUNO/issues/89); `module_health.jobs` stays [#94](https://github.com/Anna-Hax/JUNO/issues/94).
+Named jobs live in `juno.jobs.registry` (`digest_daily`, `digest_weekly`, `resurfacing`). Invalid crontab fails at serve start (`CronTrigger.from_crontab`). Digest push bodies land in [#88](https://github.com/Anna-Hax/JUNO/issues/88). Resurfacing ([#89](https://github.com/Anna-Hax/JUNO/issues/89)) pushes high-confidence “this came up again” notes and queues low-confidence suggestions as HITL `resurface`. `module_health.jobs` stays [#94](https://github.com/Anna-Hax/JUNO/issues/94).
 
 ## Consequences
 

--- a/docs/next-work.md
+++ b/docs/next-work.md
@@ -144,7 +144,7 @@ Milestone: [M4: v1.3 Proactive & Mobile](https://github.com/Anna-Hax/JUNO/milest
 | 1 | [#86](https://github.com/Anna-Hax/JUNO/issues/86) | Spike S4 — APScheduler on shared loop + one Telegram push smoke — ✅ [session 39](sessions/39-session-spike-s4.md) |
 | 2 | [#87](https://github.com/Anna-Hax/JUNO/issues/87) | Scheduler scaffold — APScheduler in serve lifespan + job registry — ✅ [session 40](sessions/40-session-jobs-scaffold.md) |
 | 3 | [#88](https://github.com/Anna-Hax/JUNO/issues/88) | Scheduled push digests — morning daily + weekly — ✅ [session 41](sessions/41-session-jobs-digest.md) |
-| 4 | [#89](https://github.com/Anna-Hax/JUNO/issues/89) | Contextual resurfacing — push when something comes up again |
+| 4 | [#89](https://github.com/Anna-Hax/JUNO/issues/89) | Contextual resurfacing — push when something comes up again — ✅ [session 42](sessions/42-session-jobs-resurface.md) |
 | 5 | [#90](https://github.com/Anna-Hax/JUNO/issues/90) | Temporal queries — how has my understanding of X evolved |
 | 6 | [#91](https://github.com/Anna-Hax/JUNO/issues/91) | Voice memos — Telegram voice → transcription → ingest |
 | 7 | [#92](https://github.com/Anna-Hax/JUNO/issues/92) | Mobile depth — phone captures via Telegram + sensitive HITL |
@@ -152,7 +152,7 @@ Milestone: [M4: v1.3 Proactive & Mobile](https://github.com/Anna-Hax/JUNO/milest
 | 9 | [#94](https://github.com/Anna-Hax/JUNO/issues/94) | Module health — jobs scheduler freshness + respect /pause |
 | 10 | [#95](https://github.com/Anna-Hax/JUNO/issues/95) | M4 gate — jobs tests, ADR, README, v1.3 release gate |
 
-**First coding task:** #86–#88 ✅. Next: contextual resurfacing ([#89](https://github.com/Anna-Hax/JUNO/issues/89)).
+**First coding task:** #86–#89 ✅. Next: temporal queries ([#90](https://github.com/Anna-Hax/JUNO/issues/90)).
 
 ### M4 design constraints (do not violate)
 

--- a/docs/sessions/02-codebase-map.md
+++ b/docs/sessions/02-codebase-map.md
@@ -31,7 +31,7 @@ JUNO/
 | Config | `config.py` | pydantic-settings from `.env` |
 | CLI | `cli.py` | `juno serve` / `db-init` / `export` / `wipe` / `version` |
 | Runtime | `runtime.py` | Shared asyncio: uvicorn + PTB + inbox watcher + jobs scheduler lifespan |
-| Jobs | `jobs/scheduler.py`, `jobs/registry.py` | AsyncIOScheduler + named cron registry (ADR-07) |
+| Jobs | `jobs/scheduler.py`, `jobs/registry.py`, `jobs/resurface.py` | AsyncIOScheduler + named cron registry (ADR-07) |
 | API | `api/__init__.py` | FastAPI routes + token + loopback middleware |
 | Bot | `bot/handlers.py`, `bot/services.py`, `bot/review.py` | Telegram allowlist, query, capture, pause/digest/status ([#18](https://github.com/Anna-Hax/JUNO/issues/18) / [#19](https://github.com/Anna-Hax/JUNO/issues/19)); HITL `/review` ([#20](https://github.com/Anna-Hax/JUNO/issues/20)) |
 | Graph DB | `graph/db.py`, `graph/migrations.py`, `graph/ownership.py` | Engine, WAL, write queue, Alembic upgrade/stamp; export/wipe ([#23](https://github.com/Anna-Hax/JUNO/issues/23)) |

--- a/docs/sessions/42-session-jobs-resurface.md
+++ b/docs/sessions/42-session-jobs-resurface.md
@@ -1,0 +1,25 @@
+# Session 42 — Contextual resurfacing (#89)
+
+**Date:** 2026-09-04  
+**Issue:** [#89](https://github.com/Anna-Hax/JUNO/issues/89)  
+**Branch:** `feat/jobs-resurface-89`
+
+## What changed
+
+- Hourly `resurfacing` job: recent captures vs older vector neighbors.
+- High confidence (≥ 0.55) → allowlisted Telegram “this came up again” with citations.
+- Low confidence → HITL `resurface` review card. Duplicate pairs are remembered.
+
+## Verify
+
+```powershell
+cd apps/core
+$env:EMBEDDING_BACKEND='stub'
+uv run pytest tests/test_jobs.py -q
+```
+
+## Links
+
+| Doc | Role |
+|-----|------|
+| [007-proactive-jobs-shared-loop.md](../adr/007-proactive-jobs-shared-loop.md) | ADR |

--- a/docs/sessions/README.md
+++ b/docs/sessions/README.md
@@ -47,6 +47,7 @@ Living notes for what was implemented, how GitHub is set up, and what to do next
 | [39-session-spike-s4.md](39-session-spike-s4.md) | **#86** — Spike S4 APScheduler shared-loop smoke |
 | [40-session-jobs-scaffold.md](40-session-jobs-scaffold.md) | **#87** — Jobs scheduler scaffold + registry |
 | [41-session-jobs-digest.md](41-session-jobs-digest.md) | **#88** — Scheduled daily/weekly digest push |
+| [42-session-jobs-resurface.md](42-session-jobs-resurface.md) | **#89** — Contextual resurfacing |
 | [v1.0-release-gate.md](../v1.0-release-gate.md) | M1 checklist (all P0 closed) |
 | [v1.1-release-gate.md](../v1.1-release-gate.md) | M2 checklist (browser capture) |
 | [v1.2-release-gate.md](../v1.2-release-gate.md) | M3 checklist (IDE capture) |


### PR DESCRIPTION
## Summary
- Hourly resurfacing job matches recent captures to older vector neighbors.
- High confidence pushes a Telegram `this came up again` note with citations; low confidence queues a HITL `resurface` card.

## Linked issue
Closes #89

## Test plan
- [x] `uv run pytest tests/test_jobs.py tests/test_bot.py tests/test_review.py`
- [x] `uv run ruff check src tests`