### PR TITLE
feat(rag): temporal evolution queries with dated citations

### DIFF
--- a/apps/core/src/juno/bot/services.py
+++ b/apps/core/src/juno/bot/services.py
@@ -116,6 +116,18 @@ def format_search_outcome(outcome: Any) -> str:
         lines.append("Sources:")
         for i, hit in enumerate(citations, start=1):
             lines.append(_format_sourced_hit(i, hit))
+    elif mode == "temporal":
+        q = " ".join(str(getattr(outcome, "query", "") or "").split())
+        if len(q) > 80:
+            q = q[:79].rstrip() + "…"
+        lines.append(f"How this evolved ({len(results)} source{'s' if len(results) != 1 else ''}):")
+        if q:
+            lines.append(f'Query: "{q}"')
+        for i, hit in enumerate(results, start=1):
+            lines.append(_format_sourced_hit(i, hit, with_date=True))
+            snippet = _snippet(getattr(hit, "text", None))
+            if snippet:
+                lines.append(f"   {snippet}")
     else:
         lines.append(f"Retrieve-only (confidence {confidence:.0%}):")
         for i, hit in enumerate(results, start=1):
@@ -427,13 +439,15 @@ def _format_vector_hit(i: int, hit: Any) -> str:
     return f"{i}. {label} ({_similarity(getattr(hit, 'distance', None))})"
 
 
-def _format_sourced_hit(i: int, hit: Any) -> str:
+def _format_sourced_hit(i: int, hit: Any, *, with_date: bool = False) -> str:
     source = getattr(hit, "source_type", None) or "capture"
     capture_id = getattr(hit, "capture_id", None)
     title = getattr(hit, "title", None) or getattr(hit, "uri", None) or ""
     label = f"{source} #{capture_id}" if capture_id is not None else str(source)
     if title:
         label = f"{label} — {title}"
+    if with_date:
+        label = f"{_fmt_dt(getattr(hit, 'captured_at', None))} · {label}"
     score = getattr(hit, "score", None)
     if score is not None:
         score_s = f"{float(score):.0%}"

--- a/apps/core/src/juno/rag/engine.py
+++ b/apps/core/src/juno/rag/engine.py
@@ -6,6 +6,7 @@ import logging
 import re
 from collections.abc import Sequence
 from dataclasses import dataclass
+from datetime import UTC, datetime
 from typing import Any
 
 from sqlalchemy import select
@@ -30,6 +31,15 @@ ERROR_QUERY_HINTS = (
     "database is locked",
     "have i seen this",
 )
+TEMPORAL_QUERY_HINTS = (
+    "evolved",
+    "over time",
+    "how has my",
+    "timeline",
+    "used to think",
+    "changed my",
+    "history of",
+)
 
 RAG_SYSTEM = (
     "You are Juno, a personal knowledge assistant. Answer using ONLY the numbered "
@@ -49,8 +59,12 @@ class SourcedHit:
     title: str | None = None
     uri: str | None = None
     source_type: str | None = None
+    captured_at: datetime | None = None
 
     def to_dict(self) -> dict[str, Any]:
+        captured = None
+        if self.captured_at is not None:
+            captured = self.captured_at.isoformat()
         return {
             "chroma_id": self.chroma_id,
             "capture_id": self.capture_id,
@@ -59,6 +73,7 @@ class SourcedHit:
             "title": self.title,
             "uri": self.uri,
             "source_type": self.source_type,
+            "captured_at": captured,
             "text": self.text,
             "score": round(self.score, 4),
         }
@@ -144,6 +159,7 @@ async def retrieve(
                     if capture is not None
                     else (str(meta["source_type"]) if meta.get("source_type") else None)
                 ),
+                captured_at=capture.captured_at if capture is not None else None,
             )
         )
     return sourced
@@ -224,9 +240,24 @@ async def search(
 ) -> SearchOutcome:
     """Retrieve hits; generate a sourced answer when an LLM is healthy."""
     q = (query or "").strip()
-    hits = await retrieve(q, vectors=vectors, db=db, n_results=n_results)
-    retrieve_confidence = _confidence(hits)
     requested = (mode or "auto").strip().lower()
+    n = n_results
+    if requested in {"auto", "temporal"} and looks_like_temporal_query(q):
+        n = max(n_results, 12)
+    hits = await retrieve(q, vectors=vectors, db=db, n_results=n)
+    retrieve_confidence = _confidence(hits)
+
+    if requested == "temporal" or (requested == "auto" and looks_like_temporal_query(q) and hits):
+        ordered = _sorted_by_captured_at(hits)
+        return SearchOutcome(
+            query=q,
+            mode="temporal",
+            results=ordered,
+            confidence=retrieve_confidence,
+            answer=None,
+            citations=ordered,
+        )
+
     want_rag = requested in {"auto", "rag"} and bool(hits)
 
     if requested == "retrieve" or not want_rag:
@@ -297,6 +328,23 @@ async def search(
 def looks_like_error_query(query: str) -> bool:
     q = (query or "").casefold()
     return any(hint in q for hint in ERROR_QUERY_HINTS)
+
+
+def looks_like_temporal_query(query: str) -> bool:
+    q = (query or "").casefold()
+    return any(hint in q for hint in TEMPORAL_QUERY_HINTS)
+
+
+def _sorted_by_captured_at(hits: Sequence[SourcedHit]) -> list[SourcedHit]:
+    def key(hit: SourcedHit) -> datetime:
+        when = hit.captured_at
+        if when is None:
+            return datetime.min.replace(tzinfo=UTC)
+        if when.tzinfo is None:
+            return when.replace(tzinfo=UTC)
+        return when
+
+    return sorted(hits, key=key)
 
 
 async def match_past_errors(

--- a/apps/core/tests/test_rag.py
+++ b/apps/core/tests/test_rag.py
@@ -277,3 +277,59 @@ async def test_match_past_errors_prefers_ide_when_llm_unhealthy(settings, db, ve
     assert card is not None
     assert card.kind == "error_match"
     assert card.payload.get("confirmed") is False
+
+
+def test_looks_like_temporal_query():
+    from juno.rag.engine import looks_like_temporal_query
+
+    assert looks_like_temporal_query("How has my understanding of rust evolved?")
+    assert looks_like_temporal_query("show the timeline for ownership")
+    assert not looks_like_temporal_query("what is rust ownership")
+
+
+@pytest.mark.asyncio
+async def test_temporal_search_orders_hits_by_captured_at(settings, db, vectors, pipeline):
+    from datetime import UTC, datetime, timedelta
+
+    from juno.models import Capture
+    from juno.rag.engine import search as rag_search
+
+    early = await pipeline.ingest_text(
+        "Ownership in Rust means each value has a single owner rust-ownership-xyz.",
+        source_type="upload",
+        title="first rust take",
+    )
+    later = await pipeline.ingest_text(
+        "Ownership in Rust also covers borrowing rust-ownership-xyz.",
+        source_type="upload",
+        title="later rust take",
+    )
+
+    async def backdate(session):
+        row = await session.get(Capture, early.capture_id)
+        row.captured_at = datetime.now(UTC) - timedelta(days=14)
+
+    await db.write(backdate)
+    outcome = await rag_search(
+        "How has my understanding of rust evolved?",
+        vectors=vectors,
+        db=db,
+        n_results=5,
+        mode="auto",
+    )
+    assert outcome.mode == "temporal"
+    ids = [hit.capture_id for hit in outcome.results]
+    assert early.capture_id in ids and later.capture_id in ids
+    assert ids.index(early.capture_id) < ids.index(later.capture_id)
+    assert outcome.results[0].captured_at is not None
+    client, _ = await _client(settings, db=db, vectors=vectors, pipeline=pipeline)
+    async with client:
+        resp = await client.get(
+            "/search",
+            params={"q": "how has my rust notes evolved", "mode": "temporal"},
+            headers={"Authorization": "Bearer test-token"},
+        )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["mode"] == "temporal"
+    assert body["results"][0]["captured_at"]

--- a/docs/next-work.md
+++ b/docs/next-work.md
@@ -145,14 +145,14 @@ Milestone: [M4: v1.3 Proactive & Mobile](https://github.com/Anna-Hax/JUNO/milest
 | 2 | [#87](https://github.com/Anna-Hax/JUNO/issues/87) | Scheduler scaffold — APScheduler in serve lifespan + job registry — ✅ [session 40](sessions/40-session-jobs-scaffold.md) |
 | 3 | [#88](https://github.com/Anna-Hax/JUNO/issues/88) | Scheduled push digests — morning daily + weekly — ✅ [session 41](sessions/41-session-jobs-digest.md) |
 | 4 | [#89](https://github.com/Anna-Hax/JUNO/issues/89) | Contextual resurfacing — push when something comes up again — ✅ [session 42](sessions/42-session-jobs-resurface.md) |
-| 5 | [#90](https://github.com/Anna-Hax/JUNO/issues/90) | Temporal queries — how has my understanding of X evolved |
+| 5 | [#90](https://github.com/Anna-Hax/JUNO/issues/90) | Temporal queries — how has my understanding of X evolved — ✅ [session 43](sessions/43-session-temporal.md) |
 | 6 | [#91](https://github.com/Anna-Hax/JUNO/issues/91) | Voice memos — Telegram voice → transcription → ingest |
 | 7 | [#92](https://github.com/Anna-Hax/JUNO/issues/92) | Mobile depth — phone captures via Telegram + sensitive HITL |
 | 8 | [#93](https://github.com/Anna-Hax/JUNO/issues/93) | PC-off / serve-down status for operators |
 | 9 | [#94](https://github.com/Anna-Hax/JUNO/issues/94) | Module health — jobs scheduler freshness + respect /pause |
 | 10 | [#95](https://github.com/Anna-Hax/JUNO/issues/95) | M4 gate — jobs tests, ADR, README, v1.3 release gate |
 
-**First coding task:** #86–#89 ✅. Next: temporal queries ([#90](https://github.com/Anna-Hax/JUNO/issues/90)).
+**First coding task:** #86–#90 ✅. Next: voice memos ([#91](https://github.com/Anna-Hax/JUNO/issues/91)).
 
 ### M4 design constraints (do not violate)
 

--- a/docs/sessions/43-session-temporal.md
+++ b/docs/sessions/43-session-temporal.md
@@ -1,0 +1,17 @@
+# Session 43 — Temporal queries (#90)
+
+**Date:** 2026-09-04  
+**Issue:** [#90](https://github.com/Anna-Hax/JUNO/issues/90)  
+**Branch:** `feat/rag-temporal-90`
+
+## What changed
+
+- Detect evolution/timeline phrasing; `/search` and Telegram retrieve return `mode=temporal` with hits ordered by `captured_at` and dated citations.
+
+## Verify
+
+```powershell
+cd apps/core
+$env:EMBEDDING_BACKEND='stub'
+uv run pytest tests/test_rag.py -q
+```

--- a/docs/sessions/README.md
+++ b/docs/sessions/README.md
@@ -48,6 +48,7 @@ Living notes for what was implemented, how GitHub is set up, and what to do next
 | [40-session-jobs-scaffold.md](40-session-jobs-scaffold.md) | **#87** — Jobs scheduler scaffold + registry |
 | [41-session-jobs-digest.md](41-session-jobs-digest.md) | **#88** — Scheduled daily/weekly digest push |
 | [42-session-jobs-resurface.md](42-session-jobs-resurface.md) | **#89** — Contextual resurfacing |
+| [43-session-temporal.md](43-session-temporal.md) | **#90** — Temporal queries |
 | [v1.0-release-gate.md](../v1.0-release-gate.md) | M1 checklist (all P0 closed) |
 | [v1.1-release-gate.md](../v1.1-release-gate.md) | M2 checklist (browser capture) |
 | [v1.2-release-gate.md](../v1.2-release-gate.md) | M3 checklist (IDE capture) |


### PR DESCRIPTION
## Summary
- Detect timeline/evolution phrasing and return `mode=temporal` hits ordered by `captured_at`.
- Telegram and `GET /search` citations include dates and sources.

## Linked issue
Closes #90

## Test plan
- [x] `uv run pytest tests/test_rag.py tests/test_bot.py`
- [x] `uv run ruff check src tests`