### PR TITLE
feat(bot): transcribe Telegram voice notes into captures

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -27,7 +27,9 @@ EMBEDDING_MODEL=all-MiniLM-L6-v2
 # Local MiniLM: uv sync --extra embeddings  (falls back to stub if missing)
 EMBEDDING_BACKEND=sentence_transformers
 
-# Jobs (M4 / ADR-07) — AsyncIOScheduler on the same loop as serve + Telegram
+# Voice memos (M4 / ADR-08) — auto uses OpenAI Whisper only if OPENAI_API_KEY is set
+# JUNO_VOICE_BACKEND=auto
+# OPENAI_WHISPER_MODEL=whisper-1
 # JUNO_JOBS_ENABLED=true
 # JUNO_JOBS_TIMEZONE=UTC
 # Spike S4: one allowlisted Telegram line ~2s after start; leave off after proving

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ uv run juno wipe --confirm wipe-all-data
 - API: `http://127.0.0.1:8787/health` (no token). `/status` `/ingest` `/search` need `Authorization: Bearer <JUNO_API_TOKEN>`. Serve refuses the example `change-me` token and any non-loopback `JUNO_API_HOST`.
 - Token-gated `GET /status` reports the live embedder (model / backend / dimensions) and LLM health (`llm_healthy`, `llm_provider`, `llm_model`). If Ollama is down, `llm_healthy` is false and answers stay retrieve-only.
 - Token-gated `GET /search?q=` returns citations + confidence (sourced answer when the LLM is healthy).
-- Bot runs only while this process (and PC) is on. Telegram queues updates ~24h; longer downtime can drop messages. Commands: `/start` `/help` `/digest today|week` `/jobs` `/pause` `/resume` `/status` `/review`. Forward a message, send a link, or attach a doc to capture; other text queries the graph.
+- Bot runs only while this process (and PC) is on. Telegram queues updates ~24h; longer downtime can drop messages. Commands: `/start` `/help` `/digest today|week` `/jobs` `/pause` `/resume` `/status` `/review`. Forward a message, send a link, attach a doc, or send a **voice note** to capture; other text queries the graph. Voice STT is opt-in ([ADR-08](docs/adr/008-voice-transcription.md)).
 
 ### Tests
 

--- a/apps/core/src/juno/bot/handlers.py
+++ b/apps/core/src/juno/bot/handlers.py
@@ -39,7 +39,7 @@ HELP_TEXT = (
     "/status — capture + module health\n"
     "/review — HITL Approve/Reject/Skip (merges, IDE, chat batches, resurfacing)\n"
     "Ask a question to search the graph.\n"
-    "Forward a message, send a link, or attach a doc to capture."
+    "Forward a message, send a link, attach a doc, or send a voice note to capture."
 )
 
 
@@ -215,6 +215,40 @@ async def document_msg(update: Update, context: ContextTypes.DEFAULT_TYPE) -> No
         return
     finally:
         dest.unlink(missing_ok=True)
+    await update.message.reply_text(format_capture_ack(result))
+
+
+async def voice_msg(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+    if not update.message or not _authorized(update, context):
+        return
+    svc = _services(context)
+    if svc is None or svc.pipeline is None:
+        await update.message.reply_text("Capture unavailable (ingest pipeline not attached).")
+        return
+    if svc.is_paused():
+        await update.message.reply_text("Capture is paused. /resume to ingest again.")
+        return
+    voice = update.message.voice
+    if voice is None:
+        return
+    transcriber = getattr(svc.app.state, "transcriber", None) if svc.app is not None else None
+    if transcriber is None:
+        await update.message.reply_text("Voice capture unavailable (transcriber not attached).")
+        return
+    try:
+        file = await voice.get_file()
+        blob = await file.download_as_bytearray()
+        text = await transcriber.transcribe(bytes(blob), filename="voice.ogg")
+        result = await svc.pipeline.ingest_text(
+            text,
+            source_type="telegram",
+            title="Voice memo",
+            raw={"kind": "voice", "duration": getattr(voice, "duration", None)},
+        )
+    except Exception as exc:  # noqa: BLE001
+        logger.exception("telegram voice ingest failed")
+        await update.message.reply_text(clip(f"Voice capture failed: {exc}"))
+        return
     await update.message.reply_text(format_capture_ack(result))
 
 

--- a/apps/core/src/juno/config.py
+++ b/apps/core/src/juno/config.py
@@ -67,6 +67,10 @@ class Settings(BaseSettings):
     embedding_model: str = "all-MiniLM-L6-v2"
     embedding_backend: str = "sentence_transformers"  # stub | sentence_transformers
 
+    # Voice STT (ADR-08): auto uses OpenAI Whisper only when OPENAI_API_KEY is set.
+    juno_voice_backend: str = "auto"  # auto | openai | stub | off
+    openai_whisper_model: str = "whisper-1"
+
     # M4 jobs (ADR-07): AsyncIOScheduler on the shared serve loop.
     juno_jobs_enabled: bool = True
     juno_jobs_timezone: str = "UTC"

--- a/apps/core/src/juno/llm/transcribe.py
+++ b/apps/core/src/juno/llm/transcribe.py
@@ -1,0 +1,99 @@
+"""Voice memo transcription. Audio is not stored; only the transcript is ingested."""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, Protocol
+
+import httpx
+
+logger = logging.getLogger("juno.llm")
+
+
+class Transcriber(Protocol):
+    name: str
+
+    async def transcribe(self, audio: bytes, *, filename: str = "voice.ogg") -> str: ...
+
+    async def healthy(self, *, timeout: float = 3.0) -> bool: ...
+
+
+class OfflineTranscriber:
+    """No network STT. Operator must set OPENAI_API_KEY or JUNO_VOICE_BACKEND=openai."""
+
+    name = "offline"
+
+    async def transcribe(self, audio: bytes, *, filename: str = "voice.ogg") -> str:
+        raise RuntimeError(
+            "Voice transcription is off. Set JUNO_VOICE_BACKEND=openai and OPENAI_API_KEY "
+            "(audio is sent to that API), or use JUNO_VOICE_BACKEND=stub in tests."
+        )
+
+    async def healthy(self, *, timeout: float = 3.0) -> bool:
+        return False
+
+
+class StubTranscriber:
+    name = "stub"
+
+    def __init__(self, text: str = "stub voice transcript") -> None:
+        self.text = text
+
+    async def transcribe(self, audio: bytes, *, filename: str = "voice.ogg") -> str:
+        return self.text
+
+    async def healthy(self, *, timeout: float = 3.0) -> bool:
+        return True
+
+
+class OpenAIWhisperTranscriber:
+    name = "openai_whisper"
+
+    def __init__(self, base_url: str, api_key: str, model: str = "whisper-1") -> None:
+        self.base_url = base_url.rstrip("/")
+        self.api_key = api_key
+        self.model = model
+
+    async def transcribe(self, audio: bytes, *, filename: str = "voice.ogg") -> str:
+        if not audio:
+            raise RuntimeError("empty voice note")
+        headers = {"Authorization": f"Bearer {self.api_key}"}
+        files = {"file": (filename, audio, "application/octet-stream")}
+        data = {"model": self.model}
+        async with httpx.AsyncClient(timeout=60.0) as client:
+            resp = await client.post(
+                f"{self.base_url}/audio/transcriptions",
+                headers=headers,
+                files=files,
+                data=data,
+            )
+            resp.raise_for_status()
+            payload: dict[str, Any] = resp.json()
+            text = str(payload.get("text") or "").strip()
+            if not text:
+                raise RuntimeError("whisper returned empty transcript")
+            return text
+
+    async def healthy(self, *, timeout: float = 3.0) -> bool:
+        return bool(self.api_key)
+
+
+def create_transcriber(
+    backend: str,
+    *,
+    openai_api_key: str = "",
+    openai_base_url: str = "https://api.openai.com/v1",
+    openai_whisper_model: str = "whisper-1",
+) -> Transcriber:
+    choice = (backend or "auto").strip().lower()
+    if choice == "stub":
+        return StubTranscriber()
+    if choice == "off" or choice == "offline":
+        return OfflineTranscriber()
+    if choice == "openai" or (choice == "auto" and openai_api_key.strip()):
+        if not openai_api_key.strip():
+            return OfflineTranscriber()
+        return OpenAIWhisperTranscriber(
+            openai_base_url, openai_api_key.strip(), model=openai_whisper_model
+        )
+    return OfflineTranscriber()

--- a/apps/core/src/juno/runtime.py
+++ b/apps/core/src/juno/runtime.py
@@ -27,6 +27,7 @@ from juno.bot.handlers import (
     start_cmd,
     status_cmd,
     text_msg,
+    voice_msg,
 )
 from juno.bot.review import review_callback, review_cmd
 from juno.bot.services import BOT_DATA_KEY, BotServices, load_capture_paused
@@ -39,6 +40,7 @@ from juno.ingest.watcher import InboxWatcher
 from juno.jobs import load_job_enabled_overrides, start_jobs, stop_jobs
 from juno.llm.chat import ChatProvider, create_chat_provider
 from juno.llm.embedder import Embedder, create_embedder
+from juno.llm.transcribe import create_transcriber
 from juno.models import AppSetting, ModuleHealth
 
 logger = logging.getLogger("juno.runtime")
@@ -60,6 +62,7 @@ def build_telegram_application(settings: Settings) -> Application | None:
     app.add_handler(CommandHandler("status", status_cmd))
     app.add_handler(CommandHandler("review", review_cmd))
     app.add_handler(CallbackQueryHandler(review_callback, pattern=r"^rev:"))
+    app.add_handler(MessageHandler(filters.VOICE, voice_msg))
     app.add_handler(MessageHandler(filters.Document.ALL, document_msg))
     app.add_handler(MessageHandler(filters.TEXT & ~filters.COMMAND, text_msg))
     return app
@@ -85,13 +88,18 @@ async def persist_embedder_settings(db: Database, embedder: Embedder) -> None:
 
 
 async def persist_llm_health(db: Database, chat: ChatProvider, *, ok: bool) -> None:
+    detail = f"{chat.name}:{chat.model}" if chat.model else chat.name
+    await persist_module_health(db, "llm", detail=detail, ok=ok)
+
+
+async def persist_module_health(db: Database, module: str, *, detail: str | None, ok: bool) -> None:
     async def write(session: AsyncSession) -> None:
-        row = await session.get(ModuleHealth, "llm")
+        row = await session.get(ModuleHealth, module)
         if row is None:
-            row = ModuleHealth(module="llm")
+            row = ModuleHealth(module=module)
             session.add(row)
         now = datetime.now(UTC)
-        row.detail = f"{chat.name}:{chat.model}" if chat.model else chat.name
+        row.detail = detail
         if ok:
             row.last_success_at = now
             row.last_error = None
@@ -135,6 +143,18 @@ def attach_lifespan(fastapi_app: FastAPI) -> FastAPI:
         app.state.llm_healthy = llm_healthy
         app.state.chat = chat
         await persist_llm_health(db, chat, ok=llm_healthy)
+
+        transcriber = getattr(app.state, "transcriber", None)
+        if transcriber is None:
+            transcriber = create_transcriber(
+                settings.juno_voice_backend,
+                openai_api_key=settings.openai_api_key,
+                openai_base_url=settings.openai_base_url,
+                openai_whisper_model=settings.openai_whisper_model,
+            )
+            app.state.transcriber = transcriber
+        voice_ok = await transcriber.healthy()
+        await persist_module_health(db, "voice", detail=transcriber.name, ok=voice_ok)
 
         pipeline = getattr(app.state, "pipeline", None)
         if pipeline is not None:
@@ -209,6 +229,12 @@ async def run_server(settings: Settings | None = None) -> None:
         openai_api_key=settings.openai_api_key,
         openai_model=settings.openai_model,
     )
+    transcriber = create_transcriber(
+        settings.juno_voice_backend,
+        openai_api_key=settings.openai_api_key,
+        openai_base_url=settings.openai_base_url,
+        openai_whisper_model=settings.openai_whisper_model,
+    )
     fastapi_app = create_app(
         settings,
         db=db,
@@ -222,6 +248,7 @@ async def run_server(settings: Settings | None = None) -> None:
     fastapi_app.state.embedder = embedder
     fastapi_app.state.vectors = vectors
     fastapi_app.state.pipeline = pipeline
+    fastapi_app.state.transcriber = transcriber
     fastapi_app.state.ptb = build_telegram_application(settings)
     attach_lifespan(fastapi_app)
 

--- a/apps/core/tests/test_bot.py
+++ b/apps/core/tests/test_bot.py
@@ -18,6 +18,7 @@ from juno.bot.handlers import (
     start_cmd,
     status_cmd,
     text_msg,
+    voice_msg,
 )
 from juno.bot.services import (
     BOT_DATA_KEY,
@@ -438,6 +439,28 @@ async def test_document_is_ingested(allowed_settings):
     dest = pipeline.calls[0][1]
     assert dest.name == "abc123.md"
     assert not dest.exists()
+
+
+@pytest.mark.asyncio
+async def test_voice_note_is_transcribed_and_ingested(allowed_settings):
+    from juno.llm.transcribe import StubTranscriber
+
+    pipeline = FakePipeline()
+    app = create_app(allowed_settings)
+    app.state.transcriber = StubTranscriber("hello from the phone")
+    svc = _svc(allowed_settings, pipeline=pipeline, app=app)
+    update = _update(ALLOWED_ID)
+    tg_file = MagicMock()
+    tg_file.download_as_bytearray = AsyncMock(return_value=bytearray(b"ogg-bytes"))
+    voice = MagicMock()
+    voice.duration = 2
+    voice.get_file = AsyncMock(return_value=tg_file)
+    update.message.voice = voice
+    await voice_msg(update, _context(svc))
+    assert pipeline.calls[0][0] == "text"
+    assert pipeline.calls[0][1] == "hello from the phone"
+    assert pipeline.calls[0][2]["raw"]["kind"] == "voice"
+    assert "Captured #7" in update.message.reply_text.await_args.args[0]
 
 
 class _FakeChat:

--- a/apps/core/tests/test_transcribe.py
+++ b/apps/core/tests/test_transcribe.py
@@ -1,0 +1,11 @@
+from juno.llm.transcribe import OfflineTranscriber, OpenAIWhisperTranscriber, create_transcriber
+
+
+def test_create_transcriber_auto_without_key_is_offline():
+    t = create_transcriber("auto", openai_api_key="")
+    assert isinstance(t, OfflineTranscriber)
+
+
+def test_create_transcriber_auto_with_key_is_whisper():
+    t = create_transcriber("auto", openai_api_key="sk-test")
+    assert isinstance(t, OpenAIWhisperTranscriber)

--- a/docs/adr/008-voice-transcription.md
+++ b/docs/adr/008-voice-transcription.md
@@ -1,0 +1,35 @@
+# ADR-08: Voice memo transcription privacy
+
+## Status
+
+Accepted (M4 / #91)
+
+## Date
+
+2026-09-04
+
+## Context
+
+PRD open question: transcribe Telegram voice memos **on-device vs API** (cost/privacy). Juno is local-first ([ADR-01](001-shared-event-loop.md)); audio is more sensitive than titles/URLs.
+
+Options:
+
+| Option | Summary | Why not (for v1.3) |
+|--------|---------|---------------------|
+| **A. Always on-device (faster-whisper)** | No audio leaves the PC | Heavy extra; GPU/CPU; not in the current lockfile |
+| **B. Always OpenAI Whisper API** | Simple; good quality | Sends audio off-box; wrong default for local-first |
+| **C. Opt-in API, otherwise refuse** | `JUNO_VOICE_BACKEND=auto` uses Whisper **only if** `OPENAI_API_KEY` is set; else a clear bot error | **Chosen** |
+| **D. Stub only** | Tests | Not an operator path |
+
+## Decision
+
+1. **Do not persist audio.** Download to memory, transcribe, ingest **text only** (`source_type=telegram`, `raw_json.kind=voice`).
+2. **Default `JUNO_VOICE_BACKEND=auto`:** OpenAI-compatible `/audio/transcriptions` when `OPENAI_API_KEY` is present; otherwise `offline` (no upload, bot explains how to enable).
+3. `JUNO_VOICE_BACKEND=stub` is tests-only. `off` / `offline` never calls a network STT.
+4. Failures reply in Telegram and are visible as `module_health.voice` on serve start.
+5. On-device Whisper can replace the OpenAI backend later without changing ingest shape.
+
+## Consequences
+
+- Operators who want voice must accept an API hop **or** wait for a local STT extra.
+- Empty `OPENAI_API_KEY` never silently uploads audio.

--- a/docs/next-work.md
+++ b/docs/next-work.md
@@ -146,13 +146,13 @@ Milestone: [M4: v1.3 Proactive & Mobile](https://github.com/Anna-Hax/JUNO/milest
 | 3 | [#88](https://github.com/Anna-Hax/JUNO/issues/88) | Scheduled push digests — morning daily + weekly — ✅ [session 41](sessions/41-session-jobs-digest.md) |
 | 4 | [#89](https://github.com/Anna-Hax/JUNO/issues/89) | Contextual resurfacing — push when something comes up again — ✅ [session 42](sessions/42-session-jobs-resurface.md) |
 | 5 | [#90](https://github.com/Anna-Hax/JUNO/issues/90) | Temporal queries — how has my understanding of X evolved — ✅ [session 43](sessions/43-session-temporal.md) |
-| 6 | [#91](https://github.com/Anna-Hax/JUNO/issues/91) | Voice memos — Telegram voice → transcription → ingest |
+| 6 | [#91](https://github.com/Anna-Hax/JUNO/issues/91) | Voice memos — Telegram voice → transcription → ingest — ✅ [session 44](sessions/44-session-voice.md) |
 | 7 | [#92](https://github.com/Anna-Hax/JUNO/issues/92) | Mobile depth — phone captures via Telegram + sensitive HITL |
 | 8 | [#93](https://github.com/Anna-Hax/JUNO/issues/93) | PC-off / serve-down status for operators |
 | 9 | [#94](https://github.com/Anna-Hax/JUNO/issues/94) | Module health — jobs scheduler freshness + respect /pause |
 | 10 | [#95](https://github.com/Anna-Hax/JUNO/issues/95) | M4 gate — jobs tests, ADR, README, v1.3 release gate |
 
-**First coding task:** #86–#90 ✅. Next: voice memos ([#91](https://github.com/Anna-Hax/JUNO/issues/91)).
+**First coding task:** #86–#91 ✅. Next: mobile depth HITL ([#92](https://github.com/Anna-Hax/JUNO/issues/92)).
 
 ### M4 design constraints (do not violate)
 

--- a/docs/sessions/44-session-voice.md
+++ b/docs/sessions/44-session-voice.md
@@ -1,0 +1,22 @@
+# Session 44 — Voice memos (#91)
+
+**Date:** 2026-09-04  
+**Issue:** [#91](https://github.com/Anna-Hax/JUNO/issues/91)  
+**Branch:** `feat/bot-voice-91`
+
+## Decision
+
+Opt-in OpenAI Whisper when `OPENAI_API_KEY` is set; otherwise refuse. Audio is not stored. [ADR-08](../adr/008-voice-transcription.md).
+
+## What changed
+
+- Telegram `filters.VOICE` → transcribe → `POST` ingest path (`raw_json.kind=voice`).
+- `module_health.voice` on serve start.
+
+## Verify
+
+```powershell
+cd apps/core
+$env:EMBEDDING_BACKEND='stub'
+uv run pytest tests/test_transcribe.py tests/test_bot.py -q
+```

--- a/docs/sessions/README.md
+++ b/docs/sessions/README.md
@@ -49,6 +49,7 @@ Living notes for what was implemented, how GitHub is set up, and what to do next
 | [41-session-jobs-digest.md](41-session-jobs-digest.md) | **#88** — Scheduled daily/weekly digest push |
 | [42-session-jobs-resurface.md](42-session-jobs-resurface.md) | **#89** — Contextual resurfacing |
 | [43-session-temporal.md](43-session-temporal.md) | **#90** — Temporal queries |
+| [44-session-voice.md](44-session-voice.md) | **#91** — Voice memos |
 | [v1.0-release-gate.md](../v1.0-release-gate.md) | M1 checklist (all P0 closed) |
 | [v1.1-release-gate.md](../v1.1-release-gate.md) | M2 checklist (browser capture) |
 | [v1.2-release-gate.md](../v1.2-release-gate.md) | M3 checklist (IDE capture) |


### PR DESCRIPTION
## Summary
- Telegram voice notes are transcribed (opt-in OpenAI Whisper when `OPENAI_API_KEY` is set) and ingested as text. Audio is not stored (ADR-08).
- `module_health.voice` records transcriber availability at serve start.

## Linked issue
Closes #91

## Test plan
- [x] `uv run pytest tests/test_transcribe.py tests/test_bot.py`
- [x] `uv run ruff check src tests`