### PR TITLE
feat(hitl): review phone Telegram captures before they stay

### DIFF
--- a/apps/core/src/juno/bot/handlers.py
+++ b/apps/core/src/juno/bot/handlers.py
@@ -37,7 +37,7 @@ HELP_TEXT = (
     "/pause — stop all ingest\n"
     "/resume — resume ingest (processes inbox backlog)\n"
     "/status — capture + module health\n"
-    "/review — HITL Approve/Reject/Skip (merges, IDE, chat batches, resurfacing)\n"
+    "/review — HITL Approve/Reject/Skip (merges, IDE, mobile, resurfacing)\n"
     "Ask a question to search the graph.\n"
     "Forward a message, send a link, attach a doc, or send a voice note to capture."
 )
@@ -215,7 +215,13 @@ async def document_msg(update: Update, context: ContextTypes.DEFAULT_TYPE) -> No
         return
     finally:
         dest.unlink(missing_ok=True)
-    await update.message.reply_text(format_capture_ack(result))
+    extra = await _queue_mobile_review(
+        svc,
+        result,
+        title=doc.file_name or "Telegram document",
+        reason="Phone/Telegram file — confirm this batch belongs in the graph.",
+    )
+    await update.message.reply_text(format_capture_ack(result) + extra)
 
 
 async def voice_msg(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
@@ -249,7 +255,13 @@ async def voice_msg(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
         logger.exception("telegram voice ingest failed")
         await update.message.reply_text(clip(f"Voice capture failed: {exc}"))
         return
-    await update.message.reply_text(format_capture_ack(result))
+    extra = await _queue_mobile_review(
+        svc,
+        result,
+        title="Voice memo",
+        reason="Phone voice memo — confirm before treating as graph fact.",
+    )
+    await update.message.reply_text(format_capture_ack(result) + extra)
 
 
 async def _capture_text(update: Update, context: ContextTypes.DEFAULT_TYPE, text: str) -> None:
@@ -262,11 +274,11 @@ async def _capture_text(update: Update, context: ContextTypes.DEFAULT_TYPE, text
         await update.message.reply_text("Capture is paused. /resume to ingest again.")
         return
     url = single_http_url(text)
+    title = None
     try:
         if url:
             result = await svc.pipeline.ingest_url(url, source_type="telegram")
         else:
-            title = None
             if is_forwarded(update.message):
                 title = update.message.forward_sender_name or None
             result = await svc.pipeline.ingest_text(
@@ -278,7 +290,37 @@ async def _capture_text(update: Update, context: ContextTypes.DEFAULT_TYPE, text
         logger.exception("telegram text capture failed")
         await update.message.reply_text(clip(f"Capture failed: {exc}"))
         return
-    await update.message.reply_text(format_capture_ack(result))
+    extra = ""
+    if not url:
+        extra = await _queue_mobile_review(
+            svc,
+            result,
+            title=title or "Telegram note",
+            reason="Phone/Telegram note or forward — confirm this mobile batch.",
+        )
+    await update.message.reply_text(format_capture_ack(result) + extra)
+
+
+async def _queue_mobile_review(
+    svc: BotServices,
+    result: object,
+    *,
+    title: str,
+    reason: str,
+) -> str:
+    from juno.hitl.queue import ReviewQueue
+    from juno.ingest.pipeline import IngestResult
+
+    if svc.db is None or not isinstance(result, IngestResult):
+        return ""
+    if not result.accepted or result.capture_id is None:
+        return ""
+    await ReviewQueue(svc.db).propose_mobile_batch(
+        title=title,
+        capture_ids=[result.capture_id],
+        reason=reason,
+    )
+    return " Queued for /review (mobile/sensitive)."
 
 
 async def _query_text(update: Update, context: ContextTypes.DEFAULT_TYPE, text: str) -> None:

--- a/apps/core/src/juno/hitl/queue.py
+++ b/apps/core/src/juno/hitl/queue.py
@@ -17,6 +17,7 @@ Decision = Literal["approve", "reject", "skip"]
 KIND_MERGE = "merge"
 KIND_ERROR_MATCH = "error_match"
 KIND_IDE_BATCH = "ide_batch"
+KIND_MOBILE_BATCH = "mobile_batch"
 KIND_RESURFACE = "resurface"
 STATUS_PENDING = "pending"
 STATUS_SKIPPED = "skipped"
@@ -67,6 +68,17 @@ class ReviewCard:
             if reason:
                 lines.append(str(reason))
             lines.append("Approve to keep this batch in the graph; Reject to leave it unconfirmed.")
+        elif self.kind == KIND_MOBILE_BATCH:
+            n = self.payload.get("capture_ids") or []
+            count = len(n) if isinstance(n, list) else 0
+            title = str(self.payload.get("title") or "mobile capture")
+            lines.append(f"Review phone/Telegram capture: {title} ({count} capture(s)).")
+            reason = self.payload.get("reason")
+            if reason:
+                lines.append(str(reason))
+            lines.append(
+                "Approve to keep this mobile batch in the graph; Reject if it should not stay."
+            )
         elif self.kind == KIND_RESURFACE:
             recent = str(self.payload.get("recent_title") or "recent")
             past = str(self.payload.get("past_title") or "earlier")
@@ -197,6 +209,26 @@ class ReviewQueue:
         """Queue HITL for sensitive or bulk IDE chat sync batches (#68)."""
         return await self.enqueue(
             kind=KIND_IDE_BATCH,
+            confidence=confidence,
+            payload={
+                "title": title,
+                "capture_ids": list(capture_ids),
+                "reason": reason,
+                "confirmed": False,
+            },
+        )
+
+    async def propose_mobile_batch(
+        self,
+        *,
+        title: str,
+        capture_ids: list[int],
+        confidence: float = 0.4,
+        reason: str | None = None,
+    ) -> ReviewCard:
+        """Queue HITL for phone forwards/voice (#92)."""
+        return await self.enqueue(
+            kind=KIND_MOBILE_BATCH,
             confidence=confidence,
             payload={
                 "title": title,

--- a/apps/core/tests/test_bot.py
+++ b/apps/core/tests/test_bot.py
@@ -320,6 +320,22 @@ async def test_url_and_forward_are_captured(allowed_settings):
 
 
 @pytest.mark.asyncio
+async def test_forward_queues_mobile_hitl(allowed_settings, db):
+    from juno.hitl.queue import KIND_MOBILE_BATCH, ReviewQueue
+    from juno.ingest.pipeline import IngestPipeline
+
+    pipe = IngestPipeline(db)
+    svc = _svc(allowed_settings, db=db, pipeline=pipe, app=create_app(allowed_settings, db=db))
+    fwd = _update(ALLOWED_ID, "a forwarded phone note", forwarded=True)
+    await text_msg(fwd, _context(svc))
+    body = fwd.message.reply_text.await_args.args[0]
+    assert "Queued for /review" in body
+    card = await ReviewQueue(db).next_open()
+    assert card is not None
+    assert card.kind == KIND_MOBILE_BATCH
+
+
+@pytest.mark.asyncio
 async def test_pause_blocks_telegram_and_api_ingest(allowed_settings, db):
     pipeline = FakePipeline()
     app = create_app(allowed_settings, db=db, pipeline=IngestPipeline(db))

--- a/docs/next-work.md
+++ b/docs/next-work.md
@@ -147,12 +147,12 @@ Milestone: [M4: v1.3 Proactive & Mobile](https://github.com/Anna-Hax/JUNO/milest
 | 4 | [#89](https://github.com/Anna-Hax/JUNO/issues/89) | Contextual resurfacing — push when something comes up again — ✅ [session 42](sessions/42-session-jobs-resurface.md) |
 | 5 | [#90](https://github.com/Anna-Hax/JUNO/issues/90) | Temporal queries — how has my understanding of X evolved — ✅ [session 43](sessions/43-session-temporal.md) |
 | 6 | [#91](https://github.com/Anna-Hax/JUNO/issues/91) | Voice memos — Telegram voice → transcription → ingest — ✅ [session 44](sessions/44-session-voice.md) |
-| 7 | [#92](https://github.com/Anna-Hax/JUNO/issues/92) | Mobile depth — phone captures via Telegram + sensitive HITL |
+| 7 | [#92](https://github.com/Anna-Hax/JUNO/issues/92) | Mobile depth — phone captures via Telegram + sensitive HITL — ✅ [session 45](sessions/45-session-mobile-hitl.md) |
 | 8 | [#93](https://github.com/Anna-Hax/JUNO/issues/93) | PC-off / serve-down status for operators |
 | 9 | [#94](https://github.com/Anna-Hax/JUNO/issues/94) | Module health — jobs scheduler freshness + respect /pause |
 | 10 | [#95](https://github.com/Anna-Hax/JUNO/issues/95) | M4 gate — jobs tests, ADR, README, v1.3 release gate |
 
-**First coding task:** #86–#91 ✅. Next: mobile depth HITL ([#92](https://github.com/Anna-Hax/JUNO/issues/92)).
+**First coding task:** #86–#92 ✅. Next: PC-off / serve-down status ([#93](https://github.com/Anna-Hax/JUNO/issues/93)).
 
 ### M4 design constraints (do not violate)
 

--- a/docs/sessions/45-session-mobile-hitl.md
+++ b/docs/sessions/45-session-mobile-hitl.md
@@ -1,0 +1,18 @@
+# Session 45 — Mobile depth HITL (#92)
+
+**Date:** 2026-09-04  
+**Issue:** [#92](https://github.com/Anna-Hax/JUNO/issues/92)  
+**Branch:** `feat/hitl-mobile-92`
+
+## What changed
+
+- Telegram forwards, docs, and voice notes enqueue HITL `mobile_batch` after ingest.
+- URL-only captures still auto-commit (high-confidence). Offline OS monitoring stays out of scope.
+
+## Verify
+
+```powershell
+cd apps/core
+$env:EMBEDDING_BACKEND='stub'
+uv run pytest tests/test_bot.py tests/test_review.py -q
+```

--- a/docs/sessions/README.md
+++ b/docs/sessions/README.md
@@ -50,6 +50,7 @@ Living notes for what was implemented, how GitHub is set up, and what to do next
 | [42-session-jobs-resurface.md](42-session-jobs-resurface.md) | **#89** — Contextual resurfacing |
 | [43-session-temporal.md](43-session-temporal.md) | **#90** — Temporal queries |
 | [44-session-voice.md](44-session-voice.md) | **#91** — Voice memos |
+| [45-session-mobile-hitl.md](45-session-mobile-hitl.md) | **#92** — Mobile HITL |
 | [v1.0-release-gate.md](../v1.0-release-gate.md) | M1 checklist (all P0 closed) |
 | [v1.1-release-gate.md](../v1.1-release-gate.md) | M2 checklist (browser capture) |
 | [v1.2-release-gate.md](../v1.2-release-gate.md) | M3 checklist (IDE capture) |


### PR DESCRIPTION
## Summary
- Forwards, Telegram files, and voice notes enqueue HITL `mobile_batch` after ingest.
- URL-only captures still auto-commit. Offline on-device queues stay out of M4.

## Linked issue
Closes #92

## Test plan
- [x] `uv run pytest tests/test_bot.py tests/test_review.py`
- [x] `uv run ruff check src tests`