### PR TITLE
feat(bot): record serve heartbeat and document PC-off

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,4 +79,6 @@ Create a Startup-folder shortcut to:
 uv run --directory D:\Juno\JUNO\apps\core juno serve
 ```
 
-so Juno comes back after login. This is not a service; sleep/shutdown still pauses capture.
+so Juno comes back after login. This is not a Windows service: sleep, shutdown, or a crashed `juno serve` still means **the bot cannot reply**. Telegram will queue updates for about 24 hours; longer downtime can drop messages.
+
+When Juno is running, `/status` shows a `core` module heartbeat (`last ok`) and a serve-down reminder. If `/status` never answers, the process is down — start serve (or the Startup shortcut) again.

--- a/apps/core/src/juno/bot/services.py
+++ b/apps/core/src/juno/bot/services.py
@@ -292,6 +292,10 @@ def format_status(
             lines.append(f"• {row.module}: last ok {last_ok} ({extra})")
     else:
         lines.append("Modules: none recorded yet")
+    lines.append(
+        "Serve-down: if this PC or `juno serve` is off, Telegram cannot reply "
+        "(updates queue ~24h). core.last ok is the last heartbeat."
+    )
     return clip("\n".join(lines))
 
 

--- a/apps/core/src/juno/runtime.py
+++ b/apps/core/src/juno/runtime.py
@@ -117,6 +117,7 @@ def attach_lifespan(fastapi_app: FastAPI) -> FastAPI:
         db: Database = app.state.db
         await db.migrate()
         app.state.capture_paused = await load_capture_paused(db)
+        await persist_module_health(db, "core", detail="juno serve", ok=True)
 
         embedder: Embedder | None = getattr(app.state, "embedder", None)
         if embedder is not None:

--- a/apps/core/tests/test_bot.py
+++ b/apps/core/tests/test_bot.py
@@ -431,6 +431,7 @@ async def test_status_reports_pause_and_health(allowed_settings, db):
     assert "Capture: paused" in body
     assert "retrieve-only" in body
     assert "stub-hash-v1" in body
+    assert "Serve-down" in body
 
 
 @pytest.mark.asyncio

--- a/docs/next-work.md
+++ b/docs/next-work.md
@@ -148,11 +148,11 @@ Milestone: [M4: v1.3 Proactive & Mobile](https://github.com/Anna-Hax/JUNO/milest
 | 5 | [#90](https://github.com/Anna-Hax/JUNO/issues/90) | Temporal queries — how has my understanding of X evolved — ✅ [session 43](sessions/43-session-temporal.md) |
 | 6 | [#91](https://github.com/Anna-Hax/JUNO/issues/91) | Voice memos — Telegram voice → transcription → ingest — ✅ [session 44](sessions/44-session-voice.md) |
 | 7 | [#92](https://github.com/Anna-Hax/JUNO/issues/92) | Mobile depth — phone captures via Telegram + sensitive HITL — ✅ [session 45](sessions/45-session-mobile-hitl.md) |
-| 8 | [#93](https://github.com/Anna-Hax/JUNO/issues/93) | PC-off / serve-down status for operators |
+| 8 | [#93](https://github.com/Anna-Hax/JUNO/issues/93) | PC-off / serve-down status for operators — ✅ [session 46](sessions/46-session-serve-down.md) |
 | 9 | [#94](https://github.com/Anna-Hax/JUNO/issues/94) | Module health — jobs scheduler freshness + respect /pause |
 | 10 | [#95](https://github.com/Anna-Hax/JUNO/issues/95) | M4 gate — jobs tests, ADR, README, v1.3 release gate |
 
-**First coding task:** #86–#92 ✅. Next: PC-off / serve-down status ([#93](https://github.com/Anna-Hax/JUNO/issues/93)).
+**First coding task:** #86–#93 ✅. Next: jobs module health ([#94](https://github.com/Anna-Hax/JUNO/issues/94)).
 
 ### M4 design constraints (do not violate)
 

--- a/docs/sessions/46-session-serve-down.md
+++ b/docs/sessions/46-session-serve-down.md
@@ -1,0 +1,18 @@
+# Session 46 — PC-off / serve-down status (#93)
+
+**Date:** 2026-09-04  
+**Issue:** [#93](https://github.com/Anna-Hax/JUNO/issues/93)  
+**Branch:** `feat/serve-down-93`
+
+## What changed
+
+- `module_health.core` heartbeat when `juno serve` starts.
+- `/status` and README explain that a stopped PC/process cannot answer Telegram (~24h queue).
+
+## Verify
+
+```powershell
+cd apps/core
+$env:EMBEDDING_BACKEND='stub'
+uv run pytest tests/test_bot.py -q
+```

--- a/docs/sessions/README.md
+++ b/docs/sessions/README.md
@@ -51,6 +51,7 @@ Living notes for what was implemented, how GitHub is set up, and what to do next
 | [43-session-temporal.md](43-session-temporal.md) | **#90** — Temporal queries |
 | [44-session-voice.md](44-session-voice.md) | **#91** — Voice memos |
 | [45-session-mobile-hitl.md](45-session-mobile-hitl.md) | **#92** — Mobile HITL |
+| [46-session-serve-down.md](46-session-serve-down.md) | **#93** — PC-off / serve-down |
 | [v1.0-release-gate.md](../v1.0-release-gate.md) | M1 checklist (all P0 closed) |
 | [v1.1-release-gate.md](../v1.1-release-gate.md) | M2 checklist (browser capture) |
 | [v1.2-release-gate.md](../v1.2-release-gate.md) | M3 checklist (IDE capture) |


### PR DESCRIPTION
## Summary
- `module_health.core` heartbeat on `juno serve` start.
- `/status` and README document that a stopped PC/process cannot answer Telegram (~24h queue).

## Linked issue
Closes #93

## Test plan
- [x] `uv run pytest tests/test_bot.py::test_status_reports_pause_and_health`
- [x] `uv run ruff check src tests`