### PR TITLE
feat(jobs): record scheduler freshness on module_health

### DIFF
--- a/apps/core/src/juno/jobs/handlers.py
+++ b/apps/core/src/juno/jobs/handlers.py
@@ -6,6 +6,7 @@ import logging
 from typing import Any
 
 from juno.bot.services import digest_since, format_digest, recent_captures
+from juno.jobs.health import record_jobs_health
 
 logger = logging.getLogger("juno.jobs")
 
@@ -38,13 +39,27 @@ async def push_scheduled_digest(app: Any, window: str) -> int:
 
 
 async def digest_daily(app: Any) -> None:
-    sent = await push_scheduled_digest(app, "today")
-    logger.info("digest_daily sent to %s chat(s)", sent)
+    await _run_digest_job(app, job_id="digest_daily", window="today")
 
 
 async def digest_weekly(app: Any) -> None:
-    sent = await push_scheduled_digest(app, "week")
-    logger.info("digest_weekly sent to %s chat(s)", sent)
+    await _run_digest_job(app, job_id="digest_weekly", window="week")
+
+
+async def _run_digest_job(app: Any, *, job_id: str, window: str) -> None:
+    db = getattr(app.state, "db", None) if app is not None else None
+    try:
+        if app is not None and bool(getattr(app.state, "capture_paused", False)):
+            logger.info("%s skipped — capture paused", job_id)
+            await record_jobs_health(db, detail=f"{job_id} skipped (paused)", ok=True)
+            return
+        sent = await push_scheduled_digest(app, window)
+        logger.info("%s sent to %s chat(s)", job_id, sent)
+        await record_jobs_health(db, detail=f"{job_id} sent={sent}", ok=True)
+    except Exception as exc:  # noqa: BLE001
+        logger.exception("%s failed", job_id)
+        await record_jobs_health(db, detail=job_id, ok=False, error=str(exc))
+        raise
 
 
 async def resurfacing(app: Any) -> None:
@@ -55,6 +70,19 @@ async def resurfacing(app: Any) -> None:
     if db is None:
         logger.info("resurfacing skipped — database not attached")
         return
-    candidates = await find_resurface_candidates(db, vectors)
-    stats = await apply_resurface_candidates(app, candidates)
-    logger.info("resurfacing pushed=%s queued=%s", stats["pushed"], stats["queued"])
+    try:
+        if app is not None and bool(getattr(app.state, "capture_paused", False)):
+            await record_jobs_health(db, detail="resurfacing skipped (paused)", ok=True)
+            return
+        candidates = await find_resurface_candidates(db, vectors)
+        stats = await apply_resurface_candidates(app, candidates)
+        logger.info("resurfacing pushed=%s queued=%s", stats["pushed"], stats["queued"])
+        await record_jobs_health(
+            db,
+            detail=f"resurfacing pushed={stats['pushed']} queued={stats['queued']}",
+            ok=True,
+        )
+    except Exception as exc:  # noqa: BLE001
+        logger.exception("resurfacing failed")
+        await record_jobs_health(db, detail="resurfacing", ok=False, error=str(exc))
+        raise

--- a/apps/core/src/juno/jobs/health.py
+++ b/apps/core/src/juno/jobs/health.py
@@ -1,0 +1,39 @@
+"""Persist scheduler freshness on module_health.jobs (ADR-02 writes)."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from juno.graph.db import Database
+from juno.models import ModuleHealth
+
+JOBS_MODULE = "jobs"
+
+
+async def record_jobs_health(
+    db: Database | None,
+    *,
+    detail: str,
+    ok: bool = True,
+    error: str | None = None,
+) -> None:
+    if db is None:
+        return
+
+    async def write(session: AsyncSession) -> None:
+        row = await session.get(ModuleHealth, JOBS_MODULE)
+        if row is None:
+            row = ModuleHealth(module=JOBS_MODULE)
+            session.add(row)
+        now = datetime.now(UTC)
+        row.detail = detail
+        if ok:
+            row.last_success_at = now
+            row.last_error = None
+        else:
+            row.last_error_at = now
+            row.last_error = (error or "job failed")[:500]
+
+    await db.write(write)

--- a/apps/core/src/juno/runtime.py
+++ b/apps/core/src/juno/runtime.py
@@ -38,6 +38,7 @@ from juno.hitl.queue import ReviewQueue
 from juno.ingest.pipeline import IngestPipeline
 from juno.ingest.watcher import InboxWatcher
 from juno.jobs import load_job_enabled_overrides, start_jobs, stop_jobs
+from juno.jobs.health import record_jobs_health
 from juno.llm.chat import ChatProvider, create_chat_provider
 from juno.llm.embedder import Embedder, create_embedder
 from juno.llm.transcribe import create_transcriber
@@ -186,6 +187,10 @@ def attach_lifespan(fastapi_app: FastAPI) -> FastAPI:
 
         app.state.job_enabled_overrides = await load_job_enabled_overrides(db)
         start_jobs(app)
+        if getattr(app.state, "scheduler", None) is not None:
+            await record_jobs_health(db, detail="scheduler started", ok=True)
+        else:
+            await record_jobs_health(db, detail="scheduler disabled", ok=True)
 
         yield
 

--- a/apps/core/tests/test_bot.py
+++ b/apps/core/tests/test_bot.py
@@ -424,6 +424,9 @@ async def test_status_reports_pause_and_health(allowed_settings, db):
     app.state.llm_healthy = False
     app.state.embedder = SimpleNamespace(model_id="stub-hash-v1")
     vectors = FakeVectors()
+    from juno.jobs.health import record_jobs_health
+
+    await record_jobs_health(db, detail="digest_daily skipped (paused)", ok=True)
     svc = _svc(allowed_settings, db=db, app=app, vectors=vectors)
     update = _update(ALLOWED_ID, "/status")
     await status_cmd(update, _context(svc))
@@ -432,6 +435,8 @@ async def test_status_reports_pause_and_health(allowed_settings, db):
     assert "retrieve-only" in body
     assert "stub-hash-v1" in body
     assert "Serve-down" in body
+    assert "jobs:" in body
+    assert "paused" in body
 
 
 @pytest.mark.asyncio

--- a/apps/core/tests/test_jobs.py
+++ b/apps/core/tests/test_jobs.py
@@ -205,6 +205,44 @@ async def test_push_scheduled_digest_sends_grouped_text(settings: Settings):
         await db.dispose()
 
 
+@pytest.mark.asyncio
+async def test_digest_pause_records_jobs_module_health(settings: Settings):
+    from fastapi.testclient import TestClient
+
+    from juno.api import create_app
+    from juno.graph.db import Database
+    from juno.jobs.handlers import digest_daily
+    from juno.models import ModuleHealth
+
+    db = Database(settings)
+    await db.migrate()
+    bot = AsyncMock()
+    app = create_app(settings, db=db)
+    app.state.ptb = SimpleNamespace(bot=bot)
+    app.state.capture_paused = True
+    try:
+        await digest_daily(app)
+
+        async def jobs_row(session):
+            return await session.get(ModuleHealth, "jobs")
+
+        health = await db.read(jobs_row)
+        assert health is not None
+        assert health.last_success_at is not None
+        assert health.last_error is None
+        assert "paused" in (health.detail or "")
+
+        client = TestClient(app)
+        resp = client.get("/status", headers={"Authorization": "Bearer test-token"})
+        assert resp.status_code == 200
+        modules = {row["module"]: row for row in resp.json()["modules"]}
+        assert "jobs" in modules
+        assert "paused" in (modules["jobs"]["detail"] or "")
+        bot.send_message.assert_not_awaited()
+    finally:
+        await db.dispose()
+
+
 def test_apply_enabled_overrides(settings: Settings):
     from juno.jobs import apply_enabled_overrides
 

--- a/docs/adr/007-proactive-jobs-shared-loop.md
+++ b/docs/adr/007-proactive-jobs-shared-loop.md
@@ -45,7 +45,7 @@ Concrete rules (`juno.jobs.scheduler`):
    - Per-job enable + 5-field crontab: `JUNO_JOBS_DIGEST_DAILY` / `_CRON` (default `0 7 * * *`), `JUNO_JOBS_DIGEST_WEEKLY` / `_CRON` (default `0 7 * * mon`), `JUNO_JOBS_RESURFACING` / `_CRON` (default off, `0 * * * *`)
 6. Tests and CI must not require live Telegram: `builtin_job_specs` / `register_job_specs` import and register without a bot; keep `JUNO_JOBS_SMOKE` off unless an operator is proving the loop.
 
-Named jobs live in `juno.jobs.registry` (`digest_daily`, `digest_weekly`, `resurfacing`). Invalid crontab fails at serve start (`CronTrigger.from_crontab`). Digest push bodies land in [#88](https://github.com/Anna-Hax/JUNO/issues/88). Resurfacing ([#89](https://github.com/Anna-Hax/JUNO/issues/89)) pushes high-confidence “this came up again” notes and queues low-confidence suggestions as HITL `resurface`. `module_health.jobs` stays [#94](https://github.com/Anna-Hax/JUNO/issues/94).
+Named jobs live in `juno.jobs.registry` (`digest_daily`, `digest_weekly`, `resurfacing`). Invalid crontab fails at serve start (`CronTrigger.from_crontab`). Digest push bodies land in [#88](https://github.com/Anna-Hax/JUNO/issues/88). Resurfacing ([#89](https://github.com/Anna-Hax/JUNO/issues/89)) pushes high-confidence “this came up again” notes and queues low-confidence suggestions as HITL `resurface`. `module_health.jobs` records scheduler freshness ([#94](https://github.com/Anna-Hax/JUNO/issues/94)).
 
 ## Consequences
 
@@ -68,3 +68,7 @@ Issue [#86](https://github.com/Anna-Hax/JUNO/issues/86): `AsyncIOScheduler` date
 ## Scaffold (#87)
 
 Issue [#87](https://github.com/Anna-Hax/JUNO/issues/87): `builtin_job_specs` + `register_job_specs` on the serve loop; CI registers cron jobs without sending Telegram (see [session 40](../sessions/40-session-jobs-scaffold.md)).
+
+## Module health (#94)
+
+Issue [#94](https://github.com/Anna-Hax/JUNO/issues/94): `module_health.jobs` is written through `Database.write()` on scheduler start and after each digest/resurfacing tick (including `/pause` skips). Last success/error shows on Telegram `/status` and `GET /status.modules`.

--- a/docs/next-work.md
+++ b/docs/next-work.md
@@ -149,10 +149,10 @@ Milestone: [M4: v1.3 Proactive & Mobile](https://github.com/Anna-Hax/JUNO/milest
 | 6 | [#91](https://github.com/Anna-Hax/JUNO/issues/91) | Voice memos — Telegram voice → transcription → ingest — ✅ [session 44](sessions/44-session-voice.md) |
 | 7 | [#92](https://github.com/Anna-Hax/JUNO/issues/92) | Mobile depth — phone captures via Telegram + sensitive HITL — ✅ [session 45](sessions/45-session-mobile-hitl.md) |
 | 8 | [#93](https://github.com/Anna-Hax/JUNO/issues/93) | PC-off / serve-down status for operators — ✅ [session 46](sessions/46-session-serve-down.md) |
-| 9 | [#94](https://github.com/Anna-Hax/JUNO/issues/94) | Module health — jobs scheduler freshness + respect /pause |
+| 9 | [#94](https://github.com/Anna-Hax/JUNO/issues/94) | Module health — jobs scheduler freshness + respect /pause — ✅ [session 47](sessions/47-session-jobs-health.md) |
 | 10 | [#95](https://github.com/Anna-Hax/JUNO/issues/95) | M4 gate — jobs tests, ADR, README, v1.3 release gate |
 
-**First coding task:** #86–#93 ✅. Next: jobs module health ([#94](https://github.com/Anna-Hax/JUNO/issues/94)).
+**First coding task:** #86–#94 ✅. Next: M4 gate ([#95](https://github.com/Anna-Hax/JUNO/issues/95)).
 
 ### M4 design constraints (do not violate)
 

--- a/docs/sessions/47-session-jobs-health.md
+++ b/docs/sessions/47-session-jobs-health.md
@@ -1,0 +1,19 @@
+# Session 47 — Jobs module health (#94)
+
+**Date:** 2026-09-04  
+**Issue:** [#94](https://github.com/Anna-Hax/JUNO/issues/94)  
+**Branch:** `feat/jobs-health-94`
+
+## What changed
+
+- `module_health.jobs` updates on digest/resurfacing ticks (including `/pause` skips) and scheduler start.
+- Telegram `/status` and `GET /status.modules` list the `jobs` row.
+- Global `/pause` still skips outbound pushes; the skip is recorded as a successful health tick.
+
+## Verify
+
+```powershell
+cd apps/core
+$env:EMBEDDING_BACKEND='stub'
+uv run pytest tests/test_jobs.py tests/test_bot.py::test_status_reports_pause_and_health -q
+```

--- a/docs/sessions/README.md
+++ b/docs/sessions/README.md
@@ -52,6 +52,7 @@ Living notes for what was implemented, how GitHub is set up, and what to do next
 | [44-session-voice.md](44-session-voice.md) | **#91** — Voice memos |
 | [45-session-mobile-hitl.md](45-session-mobile-hitl.md) | **#92** — Mobile HITL |
 | [46-session-serve-down.md](46-session-serve-down.md) | **#93** — PC-off / serve-down |
+| [47-session-jobs-health.md](47-session-jobs-health.md) | **#94** — Jobs module health |
 | [v1.0-release-gate.md](../v1.0-release-gate.md) | M1 checklist (all P0 closed) |
 | [v1.1-release-gate.md](../v1.1-release-gate.md) | M2 checklist (browser capture) |
 | [v1.2-release-gate.md](../v1.2-release-gate.md) | M3 checklist (IDE capture) |


### PR DESCRIPTION
## Summary
- Persist `module_health.jobs` on scheduler start and after digest/resurfacing ticks (including `/pause` skips).
- Surface last success/error on Telegram `/status` and `GET /status.modules`.

## Linked issue
Closes #94

## Test plan
- [x] `uv run pytest tests/test_jobs.py tests/test_bot.py::test_status_reports_pause_and_health` (apps/core, stub embedder)
- [x] `uv run ruff check src tests`