### PR TITLE
chore(release): v1.3 proactive and mobile gate

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -34,7 +34,7 @@ EMBEDDING_BACKEND=sentence_transformers
 # JUNO_JOBS_TIMEZONE=UTC
 # Spike S4: one allowlisted Telegram line ~2s after start; leave off after proving
 # JUNO_JOBS_SMOKE=false
-# Cron jobs (5-field crontab). Bodies for digest/resurfacing land in #88/#89.
+# Cron jobs (5-field crontab). Digest and resurfacing bodies run on the serve loop.
 # JUNO_JOBS_DIGEST_DAILY=true
 # JUNO_JOBS_DIGEST_DAILY_CRON=0 7 * * *
 # JUNO_JOBS_DIGEST_WEEKLY=true

--- a/README.md
+++ b/README.md
@@ -2,11 +2,11 @@
 
 Personal knowledge-graph agent: passively (and manually) capture what you read, code, and discuss — query it from **Telegram**. Local-first on your PC.
 
-**Status:** **v1.2 IDE capture** (M3 complete) — v1.1 browser capture plus a read-only Cursor adapter → loopback ingest of chats and terminal errors, error-match retrieval, grouped digests. Proactive push (M4) is next.
+**Status:** **v1.3 Proactive & mobile** (M4 complete) — scheduled Telegram digests and resurfacing on the shared asyncio loop, temporal queries, voice memos, and mobile HITL. Polish (M5) is next.
 
 ## Architecture (v1)
 
-- **Python core** (`apps/core`): FastAPI on `127.0.0.1` + Telegram long-polling in one shared asyncio event loop ([ADR-01](docs/adr/001-shared-event-loop.md)); APScheduler jobs on that same loop ([ADR-07](docs/adr/007-proactive-jobs-shared-loop.md))
+- **Python core** (`apps/core`): FastAPI on `127.0.0.1` + Telegram long-polling in one shared asyncio event loop ([ADR-01](docs/adr/001-shared-event-loop.md)); APScheduler jobs on that same loop ([ADR-07](docs/adr/007-proactive-jobs-shared-loop.md)); voice STT stays opt-in ([ADR-08](docs/adr/008-voice-transcription.md))
 - **SQLite + write queue** for the graph ([ADR-02](docs/adr/002-sqlite-write-queue.md)); **Alembic** for schema changes ([ADR-03](docs/adr/003-alembic.md))
 - **Chroma** for vectors — persistent client, one collection per embedding model ([ADR-04](docs/adr/004-chroma-collections.md)); **stub embedder** in CI
 - **Browser extension** (`apps/extension`): MV3 loopback client ([ADR-05](docs/adr/005-browser-extension-client.md)); Spike S2 captures tabs → `POST /ingest`

--- a/apps/core/pyproject.toml
+++ b/apps/core/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "juno"
-version = "1.2.0"
+version = "1.3.0"
 description = "Personal knowledge graph agent — local-first second brain via Telegram"
 requires-python = ">=3.12"
 dependencies = [

--- a/apps/core/src/juno/__init__.py
+++ b/apps/core/src/juno/__init__.py
@@ -1,3 +1,3 @@
 """Juno — personal knowledge graph agent."""
 
-__version__ = "1.2.0"
+__version__ = "1.3.0"

--- a/apps/core/uv.lock
+++ b/apps/core/uv.lock
@@ -1070,7 +1070,7 @@ wheels = [
 
 [[package]]
 name = "juno"
-version = "1.2.0"
+version = "1.3.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiosqlite" },

--- a/docs/adr/001-shared-event-loop.md
+++ b/docs/adr/001-shared-event-loop.md
@@ -93,6 +93,6 @@ Operator may still tap `/start`, a short query, and `/status` in Telegram for fu
 
 ### Follow-ups (not M1)
 
-- Wire **APScheduler** as `AsyncIOScheduler` on this loop ([ADR-07](007-proactive-jobs-shared-loop.md); Spike S4 [#86](https://github.com/Anna-Hax/JUNO/issues/86)). Job registry and cron digests remain later M4 issues.
+- **APScheduler** on this loop landed in M4 ([ADR-07](007-proactive-jobs-shared-loop.md); [#86](https://github.com/Anna-Hax/JUNO/issues/86)–[#89](https://github.com/Anna-Hax/JUNO/issues/89), [#94](https://github.com/Anna-Hax/JUNO/issues/94)).
 - Keep documenting “no `run_polling()`” next to any new entrypoint so this ADR is not rediscovered the hard way.
 - IDE / Cursor capture is a **loopback HTTP client** ([ADR-06](006-ide-adapter-client.md)), not a second process or event loop.

--- a/docs/adr/007-proactive-jobs-shared-loop.md
+++ b/docs/adr/007-proactive-jobs-shared-loop.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-Accepted (M4 / Spike S4 + scheduler scaffold)
+Accepted (M4 / v1.3)
 
 ## Date
 
@@ -42,7 +42,7 @@ Concrete rules (`juno.jobs.scheduler`):
    - `JUNO_JOBS_ENABLED` (default `true`) — start the scheduler at all
    - `JUNO_JOBS_TIMEZONE` (default `UTC`) — cron/date interpretation
    - `JUNO_JOBS_SMOKE` (default `false`) — Spike S4 one-shot Telegram line ~2s after start
-   - Per-job enable + 5-field crontab: `JUNO_JOBS_DIGEST_DAILY` / `_CRON` (default `0 7 * * *`), `JUNO_JOBS_DIGEST_WEEKLY` / `_CRON` (default `0 7 * * mon`), `JUNO_JOBS_RESURFACING` / `_CRON` (default off, `0 * * * *`)
+   - Per-job enable + 5-field crontab: `JUNO_JOBS_DIGEST_DAILY` / `_CRON` (default `true`, `0 7 * * *`), `JUNO_JOBS_DIGEST_WEEKLY` / `_CRON` (default `true`, `0 7 * * mon`), `JUNO_JOBS_RESURFACING` / `_CRON` (default `true`, `0 * * * *`)
 6. Tests and CI must not require live Telegram: `builtin_job_specs` / `register_job_specs` import and register without a bot; keep `JUNO_JOBS_SMOKE` off unless an operator is proving the loop.
 
 Named jobs live in `juno.jobs.registry` (`digest_daily`, `digest_weekly`, `resurfacing`). Invalid crontab fails at serve start (`CronTrigger.from_crontab`). Digest push bodies land in [#88](https://github.com/Anna-Hax/JUNO/issues/88). Resurfacing ([#89](https://github.com/Anna-Hax/JUNO/issues/89)) pushes high-confidence “this came up again” notes and queues low-confidence suggestions as HITL `resurface`. `module_health.jobs` records scheduler freshness ([#94](https://github.com/Anna-Hax/JUNO/issues/94)).
@@ -72,3 +72,10 @@ Issue [#87](https://github.com/Anna-Hax/JUNO/issues/87): `builtin_job_specs` + `
 ## Module health (#94)
 
 Issue [#94](https://github.com/Anna-Hax/JUNO/issues/94): `module_health.jobs` is written through `Database.write()` on scheduler start and after each digest/resurfacing tick (including `/pause` skips). Last success/error shows on Telegram `/status` and `GET /status.modules`.
+
+## What landed (M4)
+
+- Named cron jobs: daily/weekly digest push ([#88](https://github.com/Anna-Hax/JUNO/issues/88)), contextual resurfacing with HITL fallback ([#89](https://github.com/Anna-Hax/JUNO/issues/89)).
+- Telegram `/jobs` toggles persist via `AppSetting` (`jobs.enabled.{id}`).
+- CI covers scheduler registration, digest/resurface bodies, and pause skips **without** live Telegram (`JUNO_JOBS_SMOKE` stays off).
+- Gate: [`docs/v1.3-release-gate.md`](../v1.3-release-gate.md).

--- a/docs/next-work.md
+++ b/docs/next-work.md
@@ -2,7 +2,7 @@
 
 **Last updated:** 2026-09-04  
 **Track issues on:** [https://github.com/Anna-Hax/JUNO/issues](https://github.com/Anna-Hax/JUNO/issues)  
-**Package:** `1.2.0` (M3 complete — M4 proactive expanded; [`docs/v1.2-release-gate.md`](v1.2-release-gate.md))
+**Package:** `1.3.0` (M4 complete — [`docs/v1.3-release-gate.md`](v1.3-release-gate.md))
 
 Prefer one open issue ≈ one PR (`Closes #N`). This file is kept as-is across branch merges (`merge=ours`).
 
@@ -150,9 +150,9 @@ Milestone: [M4: v1.3 Proactive & Mobile](https://github.com/Anna-Hax/JUNO/milest
 | 7 | [#92](https://github.com/Anna-Hax/JUNO/issues/92) | Mobile depth — phone captures via Telegram + sensitive HITL — ✅ [session 45](sessions/45-session-mobile-hitl.md) |
 | 8 | [#93](https://github.com/Anna-Hax/JUNO/issues/93) | PC-off / serve-down status for operators — ✅ [session 46](sessions/46-session-serve-down.md) |
 | 9 | [#94](https://github.com/Anna-Hax/JUNO/issues/94) | Module health — jobs scheduler freshness + respect /pause — ✅ [session 47](sessions/47-session-jobs-health.md) |
-| 10 | [#95](https://github.com/Anna-Hax/JUNO/issues/95) | M4 gate — jobs tests, ADR, README, v1.3 release gate |
+| 10 | [#95](https://github.com/Anna-Hax/JUNO/issues/95) | M4 gate — jobs tests, ADR, README, v1.3 release gate — ✅ [session 48](sessions/48-session-m4-gate.md) |
 
-**First coding task:** #86–#94 ✅. Next: M4 gate ([#95](https://github.com/Anna-Hax/JUNO/issues/95)).
+**First coding task:** #86–#95 ✅. M4 complete.
 
 ### M4 design constraints (do not violate)
 
@@ -168,6 +168,18 @@ Milestone: [M4: v1.3 Proactive & Mobile](https://github.com/Anna-Hax/JUNO/milest
 | Epic | Milestone | Scope |
 | ---- | --------- | ----- |
 | [#28](https://github.com/Anna-Hax/JUNO/issues/28) | M5 v2 polish | Flashcards, drafts, trust dial, Slack |
+
+---
+
+## M4 — **complete** (2026-09-04)
+
+Epic [#27](https://github.com/Anna-Hax/JUNO/issues/27) closed; milestone [M4: v1.3 Proactive & Mobile](https://github.com/Anna-Hax/JUNO/milestone/10) complete. Gate: [`docs/v1.3-release-gate.md`](v1.3-release-gate.md).
+
+---
+
+## Unlock M5 (planning) — not started
+
+Epic: [#28](https://github.com/Anna-Hax/JUNO/issues/28) — *Epic: M5 v2 polish*. Do not expand child issues until an explicit M5 kickoff.
 
 ---
 

--- a/docs/sessions/02-codebase-map.md
+++ b/docs/sessions/02-codebase-map.md
@@ -31,14 +31,14 @@ JUNO/
 | Config | `config.py` | pydantic-settings from `.env` |
 | CLI | `cli.py` | `juno serve` / `db-init` / `export` / `wipe` / `version` |
 | Runtime | `runtime.py` | Shared asyncio: uvicorn + PTB + inbox watcher + jobs scheduler lifespan |
-| Jobs | `jobs/scheduler.py`, `jobs/registry.py`, `jobs/resurface.py` | AsyncIOScheduler + named cron registry (ADR-07) |
+| Jobs | `jobs/scheduler.py`, `jobs/registry.py`, `jobs/handlers.py`, `jobs/health.py`, `jobs/resurface.py` | AsyncIOScheduler + named cron registry (ADR-07) |
 | API | `api/__init__.py` | FastAPI routes + token + loopback middleware |
 | Bot | `bot/handlers.py`, `bot/services.py`, `bot/review.py` | Telegram allowlist, query, capture, pause/digest/status ([#18](https://github.com/Anna-Hax/JUNO/issues/18) / [#19](https://github.com/Anna-Hax/JUNO/issues/19)); HITL `/review` ([#20](https://github.com/Anna-Hax/JUNO/issues/20)) |
 | Graph DB | `graph/db.py`, `graph/migrations.py`, `graph/ownership.py` | Engine, WAL, write queue, Alembic upgrade/stamp; export/wipe ([#23](https://github.com/Anna-Hax/JUNO/issues/23)) |
 | Vectors | `graph/vectors.py` | Persistent Chroma; one collection per embedding model ([ADR-04](../adr/004-chroma-collections.md)) |
 | Models | `models/__init__.py` | SQLAlchemy tables |
 | Alembic | `alembic/` + `alembic.ini` | Revision `0001` = current ORM ([ADR-03](../adr/003-alembic.md)) |
-| LLM | `llm/embedder.py`, `llm/chat.py` | MiniLM (optional extra) + stub embedder; Ollama / OpenAI-compat / offline chat; health probes |
+| LLM | `llm/embedder.py`, `llm/chat.py`, `llm/transcribe.py` | MiniLM (optional extra) + stub embedder; Ollama / OpenAI-compat / offline chat; opt-in voice STT (ADR-08) |
 | Ingest | `ingest/extractors.py`, `chunking.py`, `pipeline.py`, `watcher.py` | File/URL extract, chunk, persist, inbox watch ([#16](https://github.com/Anna-Hax/JUNO/issues/16)) |
 | RAG | `rag/engine.py` | Vector retrieve, join captures, sourced answer + confidence ([#17](https://github.com/Anna-Hax/JUNO/issues/17)); Telegram query uses this |
 | HITL | `hitl/queue.py` | Review queue; merges stay pending until Approve ([#20](https://github.com/Anna-Hax/JUNO/issues/20)) |
@@ -47,7 +47,7 @@ JUNO/
 
 - `uv run juno serve` → `runtime.main_sync()`
 - `uv run juno db-init` → `Database.migrate()` (Alembic `upgrade head`, or stamp legacy `create_all` DBs)
-- Tests: `test_foundation.py`, `test_migrations.py`, `test_ingest.py`, `test_vectors.py`, `test_embedder.py`, `test_chat.py`, `test_rag.py`, `test_bot.py`, `test_review.py`, `test_bot_review.py`, `test_api.py`, `test_write_queue.py`, `test_integration.py`, `test_export.py`, `test_jobs.py`
+- Tests: `test_foundation.py`, `test_migrations.py`, `test_ingest.py`, `test_vectors.py`, `test_embedder.py`, `test_chat.py`, `test_rag.py`, `test_bot.py`, `test_review.py`, `test_bot_review.py`, `test_api.py`, `test_write_queue.py`, `test_integration.py`, `test_export.py`, `test_jobs.py`, `test_transcribe.py`
 
 ### Dependencies
 

--- a/docs/sessions/48-session-m4-gate.md
+++ b/docs/sessions/48-session-m4-gate.md
@@ -1,0 +1,22 @@
+# Session 48 — M4 gate: jobs tests + v1.3 (#95)
+
+**Date:** 2026-09-04  
+**Issue:** [#95](https://github.com/Anna-Hax/JUNO/issues/95)  
+**Branch:** `feat/m4-gate-95`
+
+## What changed
+
+- [ADR-07](../adr/007-proactive-jobs-shared-loop.md) records landed M4 job behaviour (#86–#94).
+- [`docs/v1.3-release-gate.md`](../v1.3-release-gate.md) — M4 checklist; package **1.3.0**.
+- README + ADR-01 follow-ups point at completed proactive jobs, not a future spike.
+
+## Verify
+
+```powershell
+cd apps/core
+$env:EMBEDDING_BACKEND='stub'
+uv run pytest tests/test_jobs.py tests/test_transcribe.py tests/test_rag.py -q
+uv run juno version   # expect 1.3.0
+```
+
+CI must stay green with `JUNO_JOBS_SMOKE` off (no live Telegram).

--- a/docs/sessions/README.md
+++ b/docs/sessions/README.md
@@ -53,8 +53,10 @@ Living notes for what was implemented, how GitHub is set up, and what to do next
 | [45-session-mobile-hitl.md](45-session-mobile-hitl.md) | **#92** — Mobile HITL |
 | [46-session-serve-down.md](46-session-serve-down.md) | **#93** — PC-off / serve-down |
 | [47-session-jobs-health.md](47-session-jobs-health.md) | **#94** — Jobs module health |
+| [48-session-m4-gate.md](48-session-m4-gate.md) | **#95** — M4 gate + v1.3 |
 | [v1.0-release-gate.md](../v1.0-release-gate.md) | M1 checklist (all P0 closed) |
 | [v1.1-release-gate.md](../v1.1-release-gate.md) | M2 checklist (browser capture) |
 | [v1.2-release-gate.md](../v1.2-release-gate.md) | M3 checklist (IDE capture) |
+| [v1.3-release-gate.md](../v1.3-release-gate.md) | M4 checklist (proactive + mobile) |
 
 Architecture decisions live in [`../adr/`](../adr/). Product requirements: [`../../personal-knowledge-graph-prd.md](../../personal-knowledge-graph-prd.md).

--- a/docs/v1.3-release-gate.md
+++ b/docs/v1.3-release-gate.md
@@ -1,0 +1,65 @@
+# v1.3 release gate (M4: Proactive & Mobile)
+
+**Date:** 2026-09-04  
+**Milestone:** [M4: v1.3 Proactive & Mobile](https://github.com/Anna-Hax/JUNO/milestone/10)  
+**Package version:** `1.3.0` (`apps/core`)  
+**Epic:** [#27](https://github.com/Anna-Hax/JUNO/issues/27)
+
+This checklist closes issue **#95**. Acceptance: **all M4 child issues closed** and CI green without live Telegram pushes.
+
+---
+
+## M4 issues (#86–#95)
+
+| Issue | Capability | Status | PR |
+|-------|------------|--------|-----|
+| [#86](https://github.com/Anna-Hax/JUNO/issues/86) | Spike S4 — AsyncIOScheduler + Telegram smoke | ✅ Closed | [#96](https://github.com/Anna-Hax/JUNO/pull/96) |
+| [#87](https://github.com/Anna-Hax/JUNO/issues/87) | Scheduler scaffold + job registry | ✅ Closed | [#97](https://github.com/Anna-Hax/JUNO/pull/97) |
+| [#88](https://github.com/Anna-Hax/JUNO/issues/88) | Scheduled push digests (daily + weekly) | ✅ Closed | [#98](https://github.com/Anna-Hax/JUNO/pull/98) |
+| [#89](https://github.com/Anna-Hax/JUNO/issues/89) | Contextual resurfacing | ✅ Closed | [#99](https://github.com/Anna-Hax/JUNO/pull/99) |
+| [#90](https://github.com/Anna-Hax/JUNO/issues/90) | Temporal queries | ✅ Closed | [#100](https://github.com/Anna-Hax/JUNO/pull/100) |
+| [#91](https://github.com/Anna-Hax/JUNO/issues/91) | Voice memos | ✅ Closed | [#101](https://github.com/Anna-Hax/JUNO/pull/101) |
+| [#92](https://github.com/Anna-Hax/JUNO/issues/92) | Mobile depth + sensitive HITL | ✅ Closed | [#102](https://github.com/Anna-Hax/JUNO/pull/102) |
+| [#93](https://github.com/Anna-Hax/JUNO/issues/93) | PC-off / serve-down status | ✅ Closed | [#103](https://github.com/Anna-Hax/JUNO/pull/103) |
+| [#94](https://github.com/Anna-Hax/JUNO/issues/94) | Module health (`jobs`) + pause | ✅ Closed | [#104](https://github.com/Anna-Hax/JUNO/pull/104) |
+| [#95](https://github.com/Anna-Hax/JUNO/issues/95) | Jobs tests + this gate | ✅ Closed | (this doc + PR) |
+
+**M4:** 10 / 10 closed.
+
+---
+
+## CI / quality gate
+
+- [x] `uv run pytest` — **162** tests including scheduler, digest/resurface (mocked bot), temporal search, voice STT, mobile HITL, jobs module health
+- [x] `uv run ruff check` + format check
+- [x] No live Telegram required (`JUNO_JOBS_SMOKE` off; tests mock `send_message`)
+- [x] PR hygiene (`Closes #N`, conventional title)
+
+---
+
+## Manual smoke (operator)
+
+1. `uv run juno serve` with repo-root `.env`
+2. Optional: `JUNO_JOBS_SMOKE=true` once to prove an allowlisted push, then leave it off
+3. Telegram: `/jobs`, `/digest today`, `/status` shows `jobs` + `core` + `voice`; a voice note transcribes when STT is configured
+4. Temporal: ask “how has my understanding of X evolved”
+
+---
+
+## What v1.3 means
+
+Phase 4 proactive + mobile depth from the PRD:
+
+- APScheduler on the shared uvicorn/PTB loop ([ADR-07](adr/007-proactive-jobs-shared-loop.md))
+- Morning/weekly digest pushes; resurfacing with HITL fallback
+- Temporal retrieve mode; Telegram voice → text ingest ([ADR-08](adr/008-voice-transcription.md))
+- Phone forwards/docs/voice batches stay reviewable; URLs may auto-commit
+- Honest PC-off / serve-down copy; `module_health.jobs` freshness
+
+**Not in v1.3:** flashcards, drafts, trust dial, Slack (M5).
+
+---
+
+## Next milestone
+
+Epic [#28](https://github.com/Anna-Hax/JUNO/issues/28) — M5 v2 polish.


### PR DESCRIPTION
## Summary
- Operator checklist in `docs/v1.3-release-gate.md`; package **1.3.0**.
- ADR-07 records landed M4 jobs; README / ADR-01 point at completed proactive + mobile work.

## Linked issue
Closes #95
Closes #27

## Test plan
- [x] `uv run pytest` — 162 passed (apps/core, stub embedder)
- [x] `uv run ruff check src tests`
- [x] `uv run juno version` → 1.3.0
- [x] No live Telegram (`JUNO_JOBS_SMOKE` off)