### PR TITLE
feat(hitl): Spike S5 template draft through HITL

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -42,6 +42,11 @@ EMBEDDING_BACKEND=sentence_transformers
 # JUNO_JOBS_RESURFACING=true
 # JUNO_JOBS_RESURFACING_CRON=0 * * * *
 
+# M5 drafts (ADR-09) — template journal snippet through /review; never auto-publish
+# JUNO_DRAFTS_GENERATOR=template
+# Spike S5: enqueue one pending draft at serve start; leave off after proving
+# JUNO_DRAFTS_SMOKE=false
+
 # IDE adapter (apps/ide) — HTTP client only; empty path = platform Cursor default
 # JUNO_CURSOR_VSCDB=
 # JUNO_CURSOR_WORKSPACE_STORAGE=

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Personal knowledge-graph agent: passively (and manually) capture what you read, 
 - **Browser extension** (`apps/extension`): MV3 loopback client ([ADR-05](docs/adr/005-browser-extension-client.md)); Spike S2 captures tabs → `POST /ingest`
 - **IDE adapter** (`apps/ide`): read-only Cursor `state.vscdb` client ([ADR-06](docs/adr/006-ide-adapter-client.md)); poll/watch posts chats + terminal errors → `POST /ingest` (runbook in [`apps/ide/README.md`](apps/ide/README.md))
 - **Inbox** (`inbox/`): drop `.txt` / `.md` / `.pdf` / `.url` (or a one-line http(s) text file). `juno serve` watches the folder; good files move to `inbox/.processed/`, unreadable PDFs to `inbox/.failed/`.
-- **HITL** (`/review`): inline Approve / Reject / Skip for pending graph merges
+- **HITL** (`/review`): inline Approve / Reject / Skip for pending graph merges, sensitive batches, and auto-generated **drafts** (never auto-published; [ADR-09](docs/adr/009-draft-artifacts-hitl.md))
 
 ## Prerequisites
 

--- a/apps/core/src/juno/bot/handlers.py
+++ b/apps/core/src/juno/bot/handlers.py
@@ -37,7 +37,7 @@ HELP_TEXT = (
     "/pause — stop all ingest\n"
     "/resume — resume ingest (processes inbox backlog)\n"
     "/status — capture + module health\n"
-    "/review — HITL Approve/Reject/Skip (merges, IDE, mobile, resurfacing)\n"
+    "/review — HITL Approve/Reject/Skip (merges, IDE, mobile, resurfacing, drafts)\n"
     "Ask a question to search the graph.\n"
     "Forward a message, send a link, attach a doc, or send a voice note to capture."
 )

--- a/apps/core/src/juno/bot/review.py
+++ b/apps/core/src/juno/bot/review.py
@@ -120,6 +120,10 @@ async def review_callback(update: Update, context: ContextTypes.DEFAULT_TYPE) ->
             text += " Merge is now committed."
         elif result.card.kind == "merge" and decision == "reject":
             text += " Merge was not applied."
+        elif result.card.kind == "draft" and decision == "approve":
+            text += " Draft confirmed; it was not published."
+        elif result.card.kind == "draft" and decision == "reject":
+            text += " Draft discarded; it was not published."
         elif decision == "skip":
             text += " Left in the queue."
 

--- a/apps/core/src/juno/config.py
+++ b/apps/core/src/juno/config.py
@@ -82,6 +82,10 @@ class Settings(BaseSettings):
     juno_jobs_resurfacing: bool = True
     juno_jobs_resurfacing_cron: str = "0 * * * *"
 
+    # M5 drafts (ADR-09): template HITL artifacts; never auto-publish.
+    juno_drafts_smoke: bool = False
+    juno_drafts_generator: str = "template"  # template (llm deferred to #109)
+
     def allowed_user_id_set(self) -> set[int]:
         if not self.allowed_telegram_user_ids.strip():
             return set()

--- a/apps/core/src/juno/drafts/__init__.py
+++ b/apps/core/src/juno/drafts/__init__.py
@@ -1,0 +1,17 @@
+"""Auto-generated draft artifacts (M5). Stay HITL until approve; never auto-publish."""
+
+from juno.drafts.generate import (
+    DRAFT_KIND_JOURNAL,
+    GENERATOR_TEMPLATE,
+    enqueue_journal_draft,
+    format_journal_snippet,
+    maybe_enqueue_smoke_draft,
+)
+
+__all__ = [
+    "DRAFT_KIND_JOURNAL",
+    "GENERATOR_TEMPLATE",
+    "enqueue_journal_draft",
+    "format_journal_snippet",
+    "maybe_enqueue_smoke_draft",
+]

--- a/apps/core/src/juno/drafts/generate.py
+++ b/apps/core/src/juno/drafts/generate.py
@@ -1,0 +1,84 @@
+"""Template-generated journal drafts for Spike S5. Never auto-publish."""
+
+from __future__ import annotations
+
+import logging
+from datetime import UTC, datetime, timedelta
+from typing import Any
+
+from juno.bot.services import recent_captures
+from juno.graph.db import Database
+from juno.hitl.queue import ReviewCard, ReviewQueue
+from juno.models import Capture
+
+logger = logging.getLogger("juno.drafts")
+
+GENERATOR_TEMPLATE = "template"
+DRAFT_KIND_JOURNAL = "journal"
+SMOKE_LOOKBACK_HOURS = 72
+
+
+def format_journal_snippet(captures: list[Capture], *, now: datetime | None = None) -> str:
+    """One-paragraph journal from capture titles. Deterministic; no LLM."""
+    now = now or datetime.now(UTC)
+    day = now.strftime("%Y-%m-%d")
+    if not captures:
+        return (
+            f"Journal snippet for {day}. No recent captures yet — "
+            "this is a template draft for HITL review only."
+        )
+    bits: list[str] = []
+    for cap in captures[:5]:
+        title = (cap.title or cap.uri or cap.text or f"capture #{cap.id}").strip()
+        title = " ".join(title.split())[:80]
+        bits.append(f"{title} [{cap.source_type}]")
+    joined = "; ".join(bits)
+    return (
+        f"Journal snippet for {day}: recently captured {joined}. "
+        "This is a template draft, not a published journal."
+    )
+
+
+async def enqueue_journal_draft(
+    db: Database,
+    *,
+    captures: list[Capture] | None = None,
+    generator: str = GENERATOR_TEMPLATE,
+    lookback_hours: int = SMOKE_LOOKBACK_HOURS,
+    now: datetime | None = None,
+) -> ReviewCard:
+    """Queue a pending journal draft. Approve confirms; it still is not published."""
+    now = now or datetime.now(UTC)
+    if captures is None:
+        captures = await recent_captures(db, since=now - timedelta(hours=lookback_hours), limit=8)
+    body = format_journal_snippet(captures, now=now)
+    title = f"Journal snippet {now.strftime('%Y-%m-%d')}"
+    ids = [cap.id for cap in captures if cap.id is not None]
+    return await ReviewQueue(db).propose_draft(
+        draft_kind=DRAFT_KIND_JOURNAL,
+        title=title,
+        body=body,
+        source_capture_ids=ids,
+        generator=generator if generator == GENERATOR_TEMPLATE else GENERATOR_TEMPLATE,
+        reason=(
+            "Auto-generated journal snippet. Approve keeps it as a confirmed draft; "
+            "it is not published to the graph or Telegram."
+        ),
+    )
+
+
+async def maybe_enqueue_smoke_draft(app: Any) -> ReviewCard | None:
+    """Spike S5: one draft at serve start when JUNO_DRAFTS_SMOKE is on."""
+    settings = getattr(app.state, "settings", None)
+    if settings is None or not bool(getattr(settings, "juno_drafts_smoke", False)):
+        return None
+    if bool(getattr(app.state, "capture_paused", False)):
+        logger.info("drafts smoke skipped — capture paused")
+        return None
+    db: Database | None = getattr(app.state, "db", None)
+    if db is None:
+        return None
+    generator = getattr(settings, "juno_drafts_generator", GENERATOR_TEMPLATE)
+    card = await enqueue_journal_draft(db, generator=generator)
+    logger.info("drafts smoke queued review #%s (kind=%s)", card.id, card.kind)
+    return card

--- a/apps/core/src/juno/hitl/queue.py
+++ b/apps/core/src/juno/hitl/queue.py
@@ -19,6 +19,7 @@ KIND_ERROR_MATCH = "error_match"
 KIND_IDE_BATCH = "ide_batch"
 KIND_MOBILE_BATCH = "mobile_batch"
 KIND_RESURFACE = "resurface"
+KIND_DRAFT = "draft"
 STATUS_PENDING = "pending"
 STATUS_SKIPPED = "skipped"
 STATUS_DECIDED = "decided"
@@ -87,6 +88,17 @@ class ReviewCard:
             if reason:
                 lines.append(str(reason))
             lines.append("Approve if it is the same topic; Reject to ignore this suggestion.")
+        elif self.kind == KIND_DRAFT:
+            title = str(self.payload.get("title") or "draft")
+            draft_kind = str(self.payload.get("draft_kind") or "artifact")
+            lines.append(f"Draft {draft_kind}: {title}")
+            body = str(self.payload.get("body") or "").strip()
+            if body:
+                lines.append(body[:500])
+            reason = self.payload.get("reason")
+            if reason:
+                lines.append(str(reason))
+            lines.append("This draft is not published. Approve to keep it; Reject to discard.")
         else:
             preview = str(self.payload)[:500]
             if preview:
@@ -238,6 +250,34 @@ class ReviewQueue:
             },
         )
 
+    async def propose_draft(
+        self,
+        *,
+        draft_kind: str,
+        title: str,
+        body: str,
+        source_capture_ids: list[int] | None = None,
+        generator: str = "template",
+        confidence: float = 0.5,
+        reason: str | None = None,
+    ) -> ReviewCard:
+        """Queue an auto-generated artifact. Approve confirms; never publishes (#106)."""
+        return await self.enqueue(
+            kind=KIND_DRAFT,
+            confidence=confidence,
+            payload={
+                "draft_kind": draft_kind,
+                "title": title,
+                "body": body,
+                "source_capture_ids": list(source_capture_ids or []),
+                "generator": generator,
+                "reason": reason,
+                "confirmed": False,
+                "published": False,
+                "discarded": False,
+            },
+        )
+
     async def next_open(self) -> ReviewCard | None:
         async def load(session: AsyncSession) -> ReviewCard | None:
             row = await _next_row(session)
@@ -375,6 +415,13 @@ async def _apply(session: AsyncSession, row: ReviewItem) -> bool:
         payload["confirmed"] = True
         row.payload = payload
         return True
+    if row.kind == KIND_DRAFT:
+        payload = dict(row.payload or {})
+        payload["confirmed"] = True
+        payload["discarded"] = False
+        payload["published"] = False
+        row.payload = payload
+        return True
     if row.kind != KIND_MERGE:
         return False
     edge_id = (row.payload or {}).get("edge_id")
@@ -391,6 +438,13 @@ async def _reject(session: AsyncSession, row: ReviewItem) -> None:
     if row.kind in {KIND_ERROR_MATCH, KIND_IDE_BATCH}:
         payload = dict(row.payload or {})
         payload["confirmed"] = False
+        row.payload = payload
+        return
+    if row.kind == KIND_DRAFT:
+        payload = dict(row.payload or {})
+        payload["confirmed"] = False
+        payload["discarded"] = True
+        payload["published"] = False
         row.payload = payload
         return
     if row.kind != KIND_MERGE:

--- a/apps/core/src/juno/runtime.py
+++ b/apps/core/src/juno/runtime.py
@@ -32,6 +32,7 @@ from juno.bot.handlers import (
 from juno.bot.review import review_callback, review_cmd
 from juno.bot.services import BOT_DATA_KEY, BotServices, load_capture_paused
 from juno.config import Settings, get_settings, validate_serve_settings
+from juno.drafts import maybe_enqueue_smoke_draft
 from juno.graph.db import Database
 from juno.graph.vectors import VectorStore
 from juno.hitl.queue import ReviewQueue
@@ -191,6 +192,7 @@ def attach_lifespan(fastapi_app: FastAPI) -> FastAPI:
             await record_jobs_health(db, detail="scheduler started", ok=True)
         else:
             await record_jobs_health(db, detail="scheduler disabled", ok=True)
+        await maybe_enqueue_smoke_draft(app)
 
         yield
 

--- a/apps/core/tests/test_bot_review.py
+++ b/apps/core/tests/test_bot_review.py
@@ -99,6 +99,41 @@ async def test_review_cmd_shows_pending_merge(allowed_settings, queue):
 
 
 @pytest.mark.asyncio
+async def test_review_cmd_shows_pending_draft(allowed_settings, queue):
+    card = await queue.propose_draft(
+        draft_kind="journal",
+        title="Journal snippet 2026-09-05",
+        body="Recently captured HITL notes.",
+        generator="template",
+    )
+    update = _message_update(42)
+    await review_cmd(update, _context(allowed_settings, queue))
+    text = update.message.reply_text.await_args.args[0]
+    assert f"Review #{card.id}" in text
+    assert "Draft journal" in text
+    assert "not published" in text
+
+
+@pytest.mark.asyncio
+async def test_approve_callback_confirms_draft_without_publish(allowed_settings, queue):
+    card = await queue.propose_draft(
+        draft_kind="journal",
+        title="Journal snippet 2026-09-05",
+        body="Recently captured HITL notes.",
+        generator="template",
+    )
+    update = _callback_update(42, f"rev:{card.id}:approve")
+    await review_callback(update, _context(allowed_settings, queue))
+    edited = update.callback_query.edit_message_text.await_args.args[0]
+    assert "Approved" in edited
+    assert "not published" in edited
+    loaded = await queue.get(card.id)
+    assert loaded is not None
+    assert loaded.payload["confirmed"] is True
+    assert loaded.payload["published"] is False
+
+
+@pytest.mark.asyncio
 async def test_approve_callback_commits_merge(allowed_settings, queue):
     card = await queue.propose_merge(from_name="Src", to_name="Dst", confidence=0.7)
     edge_id = int(card.payload["edge_id"])

--- a/apps/core/tests/test_drafts.py
+++ b/apps/core/tests/test_drafts.py
@@ -1,0 +1,140 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from types import SimpleNamespace
+
+import pytest
+from sqlalchemy import func, select
+
+from juno.drafts import (
+    DRAFT_KIND_JOURNAL,
+    GENERATOR_TEMPLATE,
+    enqueue_journal_draft,
+    format_journal_snippet,
+    maybe_enqueue_smoke_draft,
+)
+from juno.graph.db import Database
+from juno.hitl.queue import KIND_DRAFT, ReviewQueue
+from juno.models import Capture
+
+
+@pytest.fixture
+async def db(settings):
+    database = Database(settings)
+    await database.migrate()
+    yield database
+    await database.dispose()
+
+
+async def _add_capture(db: Database, *, title: str, text: str = "body") -> Capture:
+    async def write(session):
+        row = Capture(
+            source_type="upload",
+            title=title,
+            text=text,
+            status="committed",
+        )
+        session.add(row)
+        await session.flush()
+        return row
+
+    return await db.write(write)
+
+
+async def _capture_count(db: Database) -> int:
+    async def load(session):
+        result = await session.execute(select(func.count()).select_from(Capture))
+        return int(result.scalar_one())
+
+    return await db.read(load)
+
+
+def test_format_journal_snippet_from_titles():
+    now = datetime(2026, 9, 5, tzinfo=UTC)
+    caps = [
+        Capture(id=1, source_type="browser", title="Rust ownership notes", text="a"),
+        Capture(id=2, source_type="upload", title="WAL busy", text="b"),
+    ]
+    text = format_journal_snippet(caps, now=now)
+    assert "2026-09-05" in text
+    assert "Rust ownership notes [browser]" in text
+    assert "WAL busy [upload]" in text
+    assert "not a published journal" in text
+
+
+def test_format_journal_snippet_empty():
+    text = format_journal_snippet([], now=datetime(2026, 9, 5, tzinfo=UTC))
+    assert "No recent captures" in text
+    assert "HITL review only" in text
+
+
+@pytest.mark.asyncio
+async def test_journal_draft_stays_unpublished_after_approve(db):
+    cap = await _add_capture(db, title="Cursor HITL notes")
+    before = await _capture_count(db)
+    card = await enqueue_journal_draft(db, captures=[cap])
+    assert card.kind == KIND_DRAFT
+    assert card.status == "pending"
+    assert card.payload["draft_kind"] == DRAFT_KIND_JOURNAL
+    assert card.payload["generator"] == GENERATOR_TEMPLATE
+    assert card.payload["published"] is False
+    assert card.payload["confirmed"] is False
+    assert cap.id in card.payload["source_capture_ids"]
+    assert "Cursor HITL notes" in card.payload["body"]
+    assert "not published" in card.summary()
+
+    result = await ReviewQueue(db).decide(card.id, "approve")
+    assert result.applied is True
+    assert result.card.payload["confirmed"] is True
+    assert result.card.payload["published"] is False
+    assert result.card.payload["discarded"] is False
+    assert await _capture_count(db) == before
+
+
+@pytest.mark.asyncio
+async def test_journal_draft_reject_discards_without_publish(db):
+    card = await enqueue_journal_draft(db, captures=[])
+    result = await ReviewQueue(db).decide(card.id, "reject")
+    assert result.applied is False
+    assert result.card.payload["confirmed"] is False
+    assert result.card.payload["discarded"] is True
+    assert result.card.payload["published"] is False
+    assert await _capture_count(db) == 0
+
+
+@pytest.mark.asyncio
+async def test_journal_draft_skip_stays_pending(db):
+    card = await enqueue_journal_draft(db, captures=[])
+    result = await ReviewQueue(db).decide(card.id, "skip")
+    assert result.card.status == "skipped"
+    assert result.card.payload["published"] is False
+    later = await ReviewQueue(db).decide(card.id, "approve")
+    assert later.applied is True
+    assert later.card.payload["published"] is False
+
+
+@pytest.mark.asyncio
+async def test_llm_generator_setting_still_uses_template(db):
+    card = await enqueue_journal_draft(db, captures=[], generator="llm")
+    assert card.payload["generator"] == GENERATOR_TEMPLATE
+
+
+@pytest.mark.asyncio
+async def test_smoke_enqueues_when_enabled(settings, db):
+    settings.juno_drafts_smoke = True
+    app = SimpleNamespace(state=SimpleNamespace(settings=settings, db=db, capture_paused=False))
+    card = await maybe_enqueue_smoke_draft(app)
+    assert card is not None
+    assert card.kind == KIND_DRAFT
+    assert card.status == "pending"
+
+
+@pytest.mark.asyncio
+async def test_smoke_skips_when_paused_or_off(settings, db):
+    settings.juno_drafts_smoke = True
+    paused = SimpleNamespace(state=SimpleNamespace(settings=settings, db=db, capture_paused=True))
+    assert await maybe_enqueue_smoke_draft(paused) is None
+
+    settings.juno_drafts_smoke = False
+    off = SimpleNamespace(state=SimpleNamespace(settings=settings, db=db, capture_paused=False))
+    assert await maybe_enqueue_smoke_draft(off) is None

--- a/apps/core/tests/test_review.py
+++ b/apps/core/tests/test_review.py
@@ -119,6 +119,24 @@ async def test_next_open_prefers_pending_then_skipped(queue):
 
 
 @pytest.mark.asyncio
+async def test_draft_approve_does_not_publish(queue):
+    card = await queue.propose_draft(
+        draft_kind="journal",
+        title="Journal snippet 2026-09-05",
+        body="Recently captured HITL notes.",
+        source_capture_ids=[1],
+        generator="template",
+        reason="spike",
+    )
+    assert card.kind == "draft"
+    assert "not published" in card.summary()
+    result = await queue.decide(card.id, "approve")
+    assert result.applied is True
+    assert result.card.payload["published"] is False
+    assert result.card.payload["confirmed"] is True
+
+
+@pytest.mark.asyncio
 async def test_decide_missing_item(queue):
     with pytest.raises(LookupError):
         await queue.decide(999, "approve")

--- a/docs/adr/001-shared-event-loop.md
+++ b/docs/adr/001-shared-event-loop.md
@@ -7,7 +7,7 @@ Accepted (v1)
 ## Date
 
 2026-08-20 (M0 scaffold)  
-**Last reviewed:** 2026-09-04 (M4 Spike S4 / ADR-07)
+**Last reviewed:** 2026-09-05 (M5 Spike S5 / ADR-09)
 
 ## Context
 
@@ -51,6 +51,7 @@ Concrete rules (implemented in `apps/core/src/juno/runtime.py`):
 5. **All background work** on this process must be asyncio tasks, lifespan-managed objects, or async-compatible schedulers on **this same loop** — not a second “main” loop in another thread. That includes:
    - The inbox watcher (`InboxWatcher`, landed in M1 / #16)
    - APScheduler proactive jobs on this loop ([ADR-07](007-proactive-jobs-shared-loop.md); Spike S4 / #86)
+   - Draft smoke enqueue on serve start ([ADR-09](009-draft-artifacts-hitl.md); Spike S5 / #106)
    - Chroma I/O via `VectorStore` async helpers ([ADR-04](004-chroma-collections.md))
 6. If `TELEGRAM_BOT_TOKEN` is empty, the API (and inbox watcher) still run and the bot is simply disabled — same process model either way.
 7. Before listen, `validate_serve_settings()` refuses a non-loopback bind and the example API token ([#21](https://github.com/Anna-Hax/JUNO/issues/21)).

--- a/docs/adr/009-draft-artifacts-hitl.md
+++ b/docs/adr/009-draft-artifacts-hitl.md
@@ -1,0 +1,44 @@
+# ADR-09: Auto-generated artifacts stay HITL drafts
+
+## Status
+
+Accepted (M5 / Spike S5)
+
+## Date
+
+2026-09-05
+
+## Context
+
+PRD §8 P1: auto-generated artifacts (dev journals, README drafts, flashcards) land in a **draft/review** state — the operator skims, edits, and approves rather than the agent auto-publishing. Epic [#28](https://github.com/Anna-Hax/JUNO/issues/28) / Spike [#106](https://github.com/Anna-Hax/JUNO/issues/106) needs one proven path before a fuller scaffold ([#107](https://github.com/Anna-Hax/JUNO/issues/107)).
+
+Options:
+
+| Option | Summary | Why not (for v2 spike) |
+|--------|---------|------------------------|
+| **A. LLM body on every serve** | Call Ollama/OpenAI to write the paragraph | CI and offline operators cannot prove HITL; flakes |
+| **B. Template snippet + HITL `draft` kind** | Deterministic text from recent capture titles; queue as `review_items` | **Chosen** |
+| **C. Write a markdown file under `inbox/` or a git repo** | Operator sees a file immediately | Auto-publish by another name; #109 forbids unattended repo writes |
+| **D. Push the draft to Telegram as canonical** | Looks like a digest | Treats generated text as committed knowledge |
+
+## Decision
+
+1. **Generation for Spike S5 is template-only** (`JUNO_DRAFTS_GENERATOR=template`). An LLM path may be added later for journal/README quality ([#109](https://github.com/Anna-Hax/JUNO/issues/109)); CI must still enqueue/decide without a live model.
+2. Drafts are **`review_items` rows** with `kind=draft`. They are pending until Approve / Reject / Skip via existing `/review` ([#20](https://github.com/Anna-Hax/JUNO/issues/20)).
+3. **Approve confirms; it does not publish.** Payload keeps `published=false`. No new `captures` row, no inbox file, no Telegram “canonical” post.
+4. **Reject discards** (`discarded=true`); still not published. Skip leaves the item in the queue.
+5. Writes go through `Database.write()` ([ADR-02](002-sqlite-write-queue.md)). Draft jobs, when scheduled, stay on the serve asyncio loop ([ADR-01](001-shared-event-loop.md), [ADR-07](007-proactive-jobs-shared-loop.md)).
+6. Config knobs:
+   - `JUNO_DRAFTS_SMOKE` (default `false`) — enqueue one journal snippet at serve start (Spike S5)
+   - `JUNO_DRAFTS_GENERATOR` (default `template`) — ignored values other than `template` still use the template in S5
+7. Global `/pause` skips smoke enqueue.
+
+## Consequences
+
+- Operators prove the HITL path with `JUNO_DRAFTS_SMOKE=true` then `/review` — no live LLM.
+- Later kinds (flashcard / doc) reuse the same `draft` kind + payload `draft_kind` discriminator ([#107](https://github.com/Anna-Hax/JUNO/issues/107)).
+- Publishing (file write, ingest, Telegram canonical) is a later, explicit confirm step — never a side effect of Approve in S5.
+
+## Spike S5 proof
+
+Issue [#106](https://github.com/Anna-Hax/JUNO/issues/106): template journal from recent captures (or a placeholder if none) lands pending; Approve/Reject/Skip work; `published` stays false (see [session 49](../sessions/49-session-spike-s5.md)).

--- a/docs/next-work.md
+++ b/docs/next-work.md
@@ -1,8 +1,8 @@
 # Next work
 
-**Last updated:** 2026-09-04  
+**Last updated:** 2026-09-05  
 **Track issues on:** [https://github.com/Anna-Hax/JUNO/issues](https://github.com/Anna-Hax/JUNO/issues)  
-**Package:** `1.3.0` (M4 complete — [`docs/v1.3-release-gate.md`](v1.3-release-gate.md))
+**Package:** `1.3.0` (M4 complete — M5 polish expanded; [`docs/v1.3-release-gate.md`](v1.3-release-gate.md))
 
 Prefer one open issue ≈ one PR (`Closes #N`). This file is kept as-is across branch merges (`merge=ours`).
 
@@ -177,9 +177,50 @@ Epic [#27](https://github.com/Anna-Hax/JUNO/issues/27) closed; milestone [M4: v1
 
 ---
 
-## Unlock M5 (planning) — not started
+## Before M5 — **complete** (2026-09-05)
 
-Epic: [#28](https://github.com/Anna-Hax/JUNO/issues/28) — *Epic: M5 v2 polish*. Do not expand child issues until an explicit M5 kickoff.
+No blocking prep tickets (unlike Before M2’s Spike S1 / board / protection). M4 milestone already closed; branch protection and the [JUNO Roadmap](https://github.com/users/Anna-Hax/projects/1) board remain in place. Closed leftover [M0: Project Setup & CI](https://github.com/Anna-Hax/JUNO/milestone/1) (0 open, 10 closed). ADRs current through M4 ([ADR-07](adr/007-proactive-jobs-shared-loop.md), [ADR-08](adr/008-voice-transcription.md)).
+
+---
+
+## Unlock M5 (planning)
+
+Epic: [#28](https://github.com/Anna-Hax/JUNO/issues/28) — *Epic: M5 v2.0 polish*.  
+Milestone: [M5: v2.0 Polish & Extensions](https://github.com/Anna-Hax/JUNO/milestone/11).
+
+**Child issues expanded 2026-09-05** (#106–#115). Prefer one issue ≈ one PR.
+
+| Order | Issue | Title |
+| ----- | ----- | ----- |
+| 1 | [#106](https://github.com/Anna-Hax/JUNO/issues/106) | Spike S5 — one auto-generated draft through HITL — ✅ [session 49](sessions/49-session-spike-s5.md) |
+| 2 | [#107](https://github.com/Anna-Hax/JUNO/issues/107) | Draft artifacts scaffold — draft kinds + never auto-publish |
+| 3 | [#108](https://github.com/Anna-Hax/JUNO/issues/108) | Flashcards / spaced repetition from highlights |
+| 4 | [#109](https://github.com/Anna-Hax/JUNO/issues/109) | Auto-drafted dev journal / README drafts |
+| 5 | [#110](https://github.com/Anna-Hax/JUNO/issues/110) | Skill-gap tracking |
+| 6 | [#111](https://github.com/Anna-Hax/JUNO/issues/111) | Trust dial — per-category auto-commit thresholds |
+| 7 | [#112](https://github.com/Anna-Hax/JUNO/issues/112) | Optional Slack forward into upload space |
+| 8 | [#113](https://github.com/Anna-Hax/JUNO/issues/113) | Prune-with-confirm — retention / destructive graph cleanup |
+| 9 | [#114](https://github.com/Anna-Hax/JUNO/issues/114) | Module health — polish jobs freshness + respect /pause |
+| 10 | [#115](https://github.com/Anna-Hax/JUNO/issues/115) | M5 gate — polish tests, ADR, README, v2.0 release gate |
+
+**First coding task:** #106 ✅. Next: draft artifacts scaffold ([#107](https://github.com/Anna-Hax/JUNO/issues/107)).
+
+### M5 design constraints (do not violate)
+
+1. One process, one loop ([ADR-01](adr/001-shared-event-loop.md)) — flashcard/SRS/draft jobs on the **same** asyncio loop; no second daemon.
+2. All DB writes through `Database.write()` ([ADR-02](adr/002-sqlite-write-queue.md)).
+3. Schema changes = new Alembic revision ([ADR-03](adr/003-alembic.md)).
+4. Vectors only via the serve-process `VectorStore` after ingest ([ADR-04](adr/004-chroma-collections.md)).
+5. Auto-generated artifacts stay HITL drafts until approve — never auto-publish ([#107](https://github.com/Anna-Hax/JUNO/issues/107), [#20](https://github.com/Anna-Hax/JUNO/issues/20) patterns).
+6. Destructive prune always requires confirm ([#113](https://github.com/Anna-Hax/JUNO/issues/113)). Slack is opt-in forward into the existing inbox — not a live workspace listener ([#112](https://github.com/Anna-Hax/JUNO/issues/112)).
+
+### Explicitly **not** M5 (keep deferred)
+
+| Item | Why |
+| ---- | --- |
+| Live Slack workspace bot / passive listener | PRD §6.3 non-goal; #112 is opt-in forward only |
+| Rabbit-hole session narrative (A→B→C) | PRD §6.1 P1 browser; not in epic #28 |
+| Write drafts into user git repos unattended | #109 requires confirm before any file write |
 
 ---
 

--- a/docs/sessions/02-codebase-map.md
+++ b/docs/sessions/02-codebase-map.md
@@ -1,6 +1,6 @@
 # Codebase map (as of M0 / early M1)
 
-**Last updated:** 2026-09-04
+**Last updated:** 2026-09-05
 
 ---
 
@@ -32,6 +32,7 @@ JUNO/
 | CLI | `cli.py` | `juno serve` / `db-init` / `export` / `wipe` / `version` |
 | Runtime | `runtime.py` | Shared asyncio: uvicorn + PTB + inbox watcher + jobs scheduler lifespan |
 | Jobs | `jobs/scheduler.py`, `jobs/registry.py`, `jobs/handlers.py`, `jobs/health.py`, `jobs/resurface.py` | AsyncIOScheduler + named cron registry (ADR-07) |
+| Drafts | `drafts/generate.py` | Template journal snippets queued as HITL `draft` (ADR-09 / Spike S5) |
 | API | `api/__init__.py` | FastAPI routes + token + loopback middleware |
 | Bot | `bot/handlers.py`, `bot/services.py`, `bot/review.py` | Telegram allowlist, query, capture, pause/digest/status ([#18](https://github.com/Anna-Hax/JUNO/issues/18) / [#19](https://github.com/Anna-Hax/JUNO/issues/19)); HITL `/review` ([#20](https://github.com/Anna-Hax/JUNO/issues/20)) |
 | Graph DB | `graph/db.py`, `graph/migrations.py`, `graph/ownership.py` | Engine, WAL, write queue, Alembic upgrade/stamp; export/wipe ([#23](https://github.com/Anna-Hax/JUNO/issues/23)) |
@@ -41,13 +42,13 @@ JUNO/
 | LLM | `llm/embedder.py`, `llm/chat.py`, `llm/transcribe.py` | MiniLM (optional extra) + stub embedder; Ollama / OpenAI-compat / offline chat; opt-in voice STT (ADR-08) |
 | Ingest | `ingest/extractors.py`, `chunking.py`, `pipeline.py`, `watcher.py` | File/URL extract, chunk, persist, inbox watch ([#16](https://github.com/Anna-Hax/JUNO/issues/16)) |
 | RAG | `rag/engine.py` | Vector retrieve, join captures, sourced answer + confidence ([#17](https://github.com/Anna-Hax/JUNO/issues/17)); Telegram query uses this |
-| HITL | `hitl/queue.py` | Review queue; merges stay pending until Approve ([#20](https://github.com/Anna-Hax/JUNO/issues/20)) |
+| HITL | `hitl/queue.py` | Review queue; merges stay pending until Approve ([#20](https://github.com/Anna-Hax/JUNO/issues/20)); drafts never auto-publish ([#106](https://github.com/Anna-Hax/JUNO/issues/106)) |
 
 ### Entry points
 
 - `uv run juno serve` → `runtime.main_sync()`
 - `uv run juno db-init` → `Database.migrate()` (Alembic `upgrade head`, or stamp legacy `create_all` DBs)
-- Tests: `test_foundation.py`, `test_migrations.py`, `test_ingest.py`, `test_vectors.py`, `test_embedder.py`, `test_chat.py`, `test_rag.py`, `test_bot.py`, `test_review.py`, `test_bot_review.py`, `test_api.py`, `test_write_queue.py`, `test_integration.py`, `test_export.py`, `test_jobs.py`, `test_transcribe.py`
+- Tests: `test_foundation.py`, `test_migrations.py`, `test_ingest.py`, `test_vectors.py`, `test_embedder.py`, `test_chat.py`, `test_rag.py`, `test_bot.py`, `test_review.py`, `test_bot_review.py`, `test_api.py`, `test_write_queue.py`, `test_integration.py`, `test_export.py`, `test_jobs.py`, `test_transcribe.py`, `test_drafts.py`
 
 ### Dependencies
 

--- a/docs/sessions/49-session-spike-s5.md
+++ b/docs/sessions/49-session-spike-s5.md
@@ -1,0 +1,40 @@
+# Session 49 — Spike S5 (#106)
+
+**Date:** 2026-09-05  
+**Issue:** [#106](https://github.com/Anna-Hax/JUNO/issues/106) — Spike S5: one auto-generated draft through HITL  
+**Epic:** [#28](https://github.com/Anna-Hax/JUNO/issues/28)  
+**Branch:** `feat/spike-s5-106`
+
+## Decision
+
+**Template journal snippet** queued as `review_items.kind=draft`. Approve confirms; **never auto-publishes** (no capture, no file, no canonical Telegram). LLM generation deferred. Recorded in [ADR-09](../adr/009-draft-artifacts-hitl.md).
+
+## What changed
+
+- `juno.drafts.generate` — deterministic paragraph from recent capture titles (placeholder if empty).
+- `ReviewQueue.propose_draft` + `/review` card copy for drafts.
+- Serve lifespan enqueues one draft when `JUNO_DRAFTS_SMOKE=true` (skipped under `/pause`).
+- Knobs: `JUNO_DRAFTS_SMOKE` (default off), `JUNO_DRAFTS_GENERATOR=template`.
+- Pytest covers enqueue / Approve / Reject / Skip without a live LLM or Telegram.
+
+## Smoke
+
+With repo-root `.env` and `JUNO_DRAFTS_SMOKE=true`:
+
+```powershell
+cd apps/core
+uv run juno serve
+```
+
+Telegram `/review` should show a pending **Draft journal** card. Approve keeps it confirmed with `published=false`. Turn `JUNO_DRAFTS_SMOKE` back off afterwards so serve restarts do not re-queue.
+
+## Deferred to #107+
+
+Draft kinds scaffold, flashcards/SRS, LLM journal/README, skill-gap, trust dial, Slack forward, prune-with-confirm, polish module health, M5 gate.
+
+## Links
+
+| Doc | Role |
+|-----|------|
+| [009-draft-artifacts-hitl.md](../adr/009-draft-artifacts-hitl.md) | ADR |
+| [next-work.md](../next-work.md) | M5 queue |

--- a/docs/sessions/README.md
+++ b/docs/sessions/README.md
@@ -54,6 +54,7 @@ Living notes for what was implemented, how GitHub is set up, and what to do next
 | [46-session-serve-down.md](46-session-serve-down.md) | **#93** — PC-off / serve-down |
 | [47-session-jobs-health.md](47-session-jobs-health.md) | **#94** — Jobs module health |
 | [48-session-m4-gate.md](48-session-m4-gate.md) | **#95** — M4 gate + v1.3 |
+| [49-session-spike-s5.md](49-session-spike-s5.md) | **#106** — Spike S5 draft through HITL |
 | [v1.0-release-gate.md](../v1.0-release-gate.md) | M1 checklist (all P0 closed) |
 | [v1.1-release-gate.md](../v1.1-release-gate.md) | M2 checklist (browser capture) |
 | [v1.2-release-gate.md](../v1.2-release-gate.md) | M3 checklist (IDE capture) |


### PR DESCRIPTION
## Summary
- Queue a template journal snippet as a pending `draft` review item; Approve/Reject/Skip via `/review`.
- Approve confirms the draft and never publishes (no capture, no file, no canonical Telegram). ADR-09 records template generation and knobs.
- `JUNO_DRAFTS_SMOKE` enqueues one draft at serve start (skipped under `/pause`). CI needs no live LLM or Telegram.

## Linked issue
Closes #106

## Test plan
- [x] `uv run pytest tests/test_drafts.py tests/test_review.py tests/test_bot_review.py`
- [x] `uv run pytest -q` (172 passed)
- [x] `uv run ruff check src tests` + format check
- [ ] Manual: `JUNO_DRAFTS_SMOKE=true` + `juno serve` then Telegram `/review` shows an unpublished journal draft