### PR TITLE
feat(hitl): persist journal, flashcard, and doc drafts without publishing

### DIFF
--- a/apps/core/alembic/versions/0002_draft_artifacts.py
+++ b/apps/core/alembic/versions/0002_draft_artifacts.py
@@ -1,0 +1,62 @@
+"""0002 draft_artifacts — HITL auto-generated artifacts (M5 / #107).
+
+Revision ID: 0002
+Revises: 0001
+Create Date: 2026-09-05
+"""
+
+from __future__ import annotations
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "0002"
+down_revision: Union[str, Sequence[str], None] = "0001"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "draft_artifacts",
+        sa.Column("id", sa.Integer(), autoincrement=True, nullable=False),
+        sa.Column("kind", sa.String(length=32), nullable=False),
+        sa.Column("title", sa.String(length=1024), nullable=False),
+        sa.Column("body", sa.Text(), nullable=False),
+        sa.Column("extra_json", sa.JSON(), nullable=True),
+        sa.Column("generator", sa.String(length=32), nullable=False),
+        sa.Column("status", sa.String(length=32), nullable=False),
+        sa.Column("published", sa.String(length=8), nullable=False),
+        sa.Column("review_item_id", sa.Integer(), nullable=True),
+        sa.Column("source_capture_ids", sa.JSON(), nullable=True),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("(CURRENT_TIMESTAMP)"),
+            nullable=False,
+        ),
+        sa.ForeignKeyConstraint(
+            ["review_item_id"],
+            ["review_items.id"],
+            name=op.f("fk_draft_artifacts_review_item_id_review_items"),
+        ),
+        sa.PrimaryKeyConstraint("id", name=op.f("pk_draft_artifacts")),
+    )
+    with op.batch_alter_table("draft_artifacts", schema=None) as batch_op:
+        batch_op.create_index(batch_op.f("ix_draft_artifacts_kind"), ["kind"], unique=False)
+        batch_op.create_index(batch_op.f("ix_draft_artifacts_status"), ["status"], unique=False)
+        batch_op.create_index(
+            batch_op.f("ix_draft_artifacts_review_item_id"),
+            ["review_item_id"],
+            unique=False,
+        )
+
+
+def downgrade() -> None:
+    with op.batch_alter_table("draft_artifacts", schema=None) as batch_op:
+        batch_op.drop_index(batch_op.f("ix_draft_artifacts_review_item_id"))
+        batch_op.drop_index(batch_op.f("ix_draft_artifacts_status"))
+        batch_op.drop_index(batch_op.f("ix_draft_artifacts_kind"))
+    op.drop_table("draft_artifacts")

--- a/apps/core/src/juno/drafts/__init__.py
+++ b/apps/core/src/juno/drafts/__init__.py
@@ -1,17 +1,33 @@
 """Auto-generated draft artifacts (M5). Stay HITL until approve; never auto-publish."""
 
 from juno.drafts.generate import (
-    DRAFT_KIND_JOURNAL,
-    GENERATOR_TEMPLATE,
+    enqueue_doc_draft,
+    enqueue_flashcard_draft,
     enqueue_journal_draft,
+    format_doc_stub,
+    format_flashcard,
     format_journal_snippet,
     maybe_enqueue_smoke_draft,
 )
+from juno.drafts.kinds import (
+    DRAFT_KIND_DOC,
+    DRAFT_KIND_FLASHCARD,
+    DRAFT_KIND_JOURNAL,
+    DRAFT_KINDS,
+    GENERATOR_TEMPLATE,
+)
 
 __all__ = [
+    "DRAFT_KIND_DOC",
+    "DRAFT_KIND_FLASHCARD",
     "DRAFT_KIND_JOURNAL",
+    "DRAFT_KINDS",
     "GENERATOR_TEMPLATE",
+    "enqueue_doc_draft",
+    "enqueue_flashcard_draft",
     "enqueue_journal_draft",
+    "format_doc_stub",
+    "format_flashcard",
     "format_journal_snippet",
     "maybe_enqueue_smoke_draft",
 ]

--- a/apps/core/src/juno/drafts/generate.py
+++ b/apps/core/src/juno/drafts/generate.py
@@ -1,4 +1,4 @@
-"""Template-generated journal drafts for Spike S5. Never auto-publish."""
+"""Template-generated draft artifacts. Never auto-publish (ADR-09)."""
 
 from __future__ import annotations
 
@@ -7,14 +7,18 @@ from datetime import UTC, datetime, timedelta
 from typing import Any
 
 from juno.bot.services import recent_captures
+from juno.drafts.kinds import (
+    DRAFT_KIND_DOC,
+    DRAFT_KIND_FLASHCARD,
+    DRAFT_KIND_JOURNAL,
+    GENERATOR_TEMPLATE,
+)
 from juno.graph.db import Database
 from juno.hitl.queue import ReviewCard, ReviewQueue
 from juno.models import Capture
 
 logger = logging.getLogger("juno.drafts")
 
-GENERATOR_TEMPLATE = "template"
-DRAFT_KIND_JOURNAL = "journal"
 SMOKE_LOOKBACK_HOURS = 72
 
 
@@ -39,6 +43,27 @@ def format_journal_snippet(captures: list[Capture], *, now: datetime | None = No
     )
 
 
+def format_flashcard(front: str, back: str) -> tuple[str, dict[str, str]]:
+    """Q/A card body plus structured extra. Generation stays template-only."""
+    q = " ".join((front or "What stood out?").split())[:240]
+    a = " ".join((back or "").split())[:500]
+    body = f"Q: {q}\nA: {a or '(empty)'}"
+    return body, {"front": q, "back": a}
+
+
+def format_doc_stub(captures: list[Capture], *, now: datetime | None = None) -> str:
+    now = now or datetime.now(UTC)
+    day = now.strftime("%Y-%m-%d")
+    lines = [f"# Draft README ({day})", "", "Template stub — not a published document."]
+    for cap in captures[:5]:
+        title = (cap.title or cap.uri or f"capture #{cap.id}").strip()
+        title = " ".join(title.split())[:80]
+        lines.append(f"- {title} [{cap.source_type}]")
+    if len(captures) == 0:
+        lines.append("- (no recent captures)")
+    return "\n".join(lines)
+
+
 async def enqueue_journal_draft(
     db: Database,
     *,
@@ -59,10 +84,60 @@ async def enqueue_journal_draft(
         title=title,
         body=body,
         source_capture_ids=ids,
-        generator=generator if generator == GENERATOR_TEMPLATE else GENERATOR_TEMPLATE,
+        generator=generator,
         reason=(
             "Auto-generated journal snippet. Approve keeps it as a confirmed draft; "
             "it is not published to the graph or Telegram."
+        ),
+    )
+
+
+async def enqueue_flashcard_draft(
+    db: Database,
+    *,
+    front: str,
+    back: str,
+    source_capture_ids: list[int] | None = None,
+    title: str | None = None,
+    generator: str = GENERATOR_TEMPLATE,
+) -> ReviewCard:
+    body, extra = format_flashcard(front, back)
+    return await ReviewQueue(db).propose_draft(
+        draft_kind=DRAFT_KIND_FLASHCARD,
+        title=title or extra["front"][:80] or "Flashcard",
+        body=body,
+        extra=extra,
+        source_capture_ids=source_capture_ids,
+        generator=generator,
+        reason=(
+            "Auto-generated flashcard. Approve keeps it as a confirmed draft; "
+            "it is not published and does not enter SRS until later review."
+        ),
+    )
+
+
+async def enqueue_doc_draft(
+    db: Database,
+    *,
+    captures: list[Capture] | None = None,
+    generator: str = GENERATOR_TEMPLATE,
+    lookback_hours: int = SMOKE_LOOKBACK_HOURS,
+    now: datetime | None = None,
+) -> ReviewCard:
+    now = now or datetime.now(UTC)
+    if captures is None:
+        captures = await recent_captures(db, since=now - timedelta(hours=lookback_hours), limit=8)
+    body = format_doc_stub(captures, now=now)
+    ids = [cap.id for cap in captures if cap.id is not None]
+    return await ReviewQueue(db).propose_draft(
+        draft_kind=DRAFT_KIND_DOC,
+        title=f"README draft {now.strftime('%Y-%m-%d')}",
+        body=body,
+        source_capture_ids=ids,
+        generator=generator,
+        reason=(
+            "Auto-generated doc draft. Approve keeps it as a confirmed draft; "
+            "it is not written to any git repo or published."
         ),
     )
 

--- a/apps/core/src/juno/drafts/kinds.py
+++ b/apps/core/src/juno/drafts/kinds.py
@@ -1,0 +1,23 @@
+"""Draft artifact kinds. Stay HITL until approve; never auto-publish (ADR-09)."""
+
+from __future__ import annotations
+
+DRAFT_KIND_JOURNAL = "journal"
+DRAFT_KIND_FLASHCARD = "flashcard"
+DRAFT_KIND_DOC = "doc"
+DRAFT_KINDS = frozenset({DRAFT_KIND_JOURNAL, DRAFT_KIND_FLASHCARD, DRAFT_KIND_DOC})
+
+GENERATOR_TEMPLATE = "template"
+
+STATUS_PENDING = "pending"
+STATUS_CONFIRMED = "confirmed"
+STATUS_DISCARDED = "discarded"
+PUBLISHED_NO = "false"
+
+
+def require_draft_kind(kind: str) -> str:
+    value = (kind or "").strip().lower()
+    if value not in DRAFT_KINDS:
+        allowed = ", ".join(sorted(DRAFT_KINDS))
+        raise ValueError(f"unknown draft kind {kind!r}; expected one of {allowed}")
+    return value

--- a/apps/core/src/juno/hitl/queue.py
+++ b/apps/core/src/juno/hitl/queue.py
@@ -10,7 +10,7 @@ from sqlalchemy import case, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from juno.graph.db import Database
-from juno.models import Edge, Node, ReviewItem
+from juno.models import DraftArtifact, Edge, Node, ReviewItem
 
 Decision = Literal["approve", "reject", "skip"]
 
@@ -258,25 +258,62 @@ class ReviewQueue:
         body: str,
         source_capture_ids: list[int] | None = None,
         generator: str = "template",
+        extra: dict[str, Any] | None = None,
         confidence: float = 0.5,
         reason: str | None = None,
     ) -> ReviewCard:
-        """Queue an auto-generated artifact. Approve confirms; never publishes (#106)."""
-        return await self.enqueue(
-            kind=KIND_DRAFT,
-            confidence=confidence,
-            payload={
-                "draft_kind": draft_kind,
-                "title": title,
-                "body": body,
-                "source_capture_ids": list(source_capture_ids or []),
-                "generator": generator,
-                "reason": reason,
-                "confirmed": False,
-                "published": False,
-                "discarded": False,
-            },
+        """Queue an auto-generated artifact. Approve confirms; never publishes (#106/#107)."""
+        from juno.drafts.kinds import (
+            GENERATOR_TEMPLATE,
+            PUBLISHED_NO,
+            STATUS_PENDING,
+            require_draft_kind,
         )
+
+        kind = require_draft_kind(draft_kind)
+        gen = generator if generator == GENERATOR_TEMPLATE else GENERATOR_TEMPLATE
+        ids = list(source_capture_ids or [])
+
+        async def write(session: AsyncSession) -> ReviewCard:
+            item = ReviewItem(
+                kind=KIND_DRAFT,
+                confidence=confidence,
+                payload={
+                    "draft_kind": kind,
+                    "title": title,
+                    "body": body,
+                    "source_capture_ids": ids,
+                    "generator": gen,
+                    "reason": reason,
+                    "confirmed": False,
+                    "published": False,
+                    "discarded": False,
+                    "extra": extra or {},
+                },
+                status=STATUS_PENDING,
+            )
+            session.add(item)
+            await session.flush()
+            artifact = DraftArtifact(
+                kind=kind,
+                title=title,
+                body=body,
+                extra_json=extra,
+                generator=gen,
+                status=STATUS_PENDING,
+                published=PUBLISHED_NO,
+                review_item_id=item.id,
+                source_capture_ids=ids,
+            )
+            session.add(artifact)
+            await session.flush()
+            payload = dict(item.payload or {})
+            payload["artifact_id"] = artifact.id
+            item.payload = payload
+            await session.flush()
+            return _card(item)
+
+        return await self.db.write(write)
 
     async def next_open(self) -> ReviewCard | None:
         async def load(session: AsyncSession) -> ReviewCard | None:
@@ -421,6 +458,7 @@ async def _apply(session: AsyncSession, row: ReviewItem) -> bool:
         payload["discarded"] = False
         payload["published"] = False
         row.payload = payload
+        await _set_draft_artifact(session, payload, confirmed=True)
         return True
     if row.kind != KIND_MERGE:
         return False
@@ -446,6 +484,7 @@ async def _reject(session: AsyncSession, row: ReviewItem) -> None:
         payload["discarded"] = True
         payload["published"] = False
         row.payload = payload
+        await _set_draft_artifact(session, payload, confirmed=False)
         return
     if row.kind != KIND_MERGE:
         return
@@ -455,3 +494,18 @@ async def _reject(session: AsyncSession, row: ReviewItem) -> None:
     edge = await session.get(Edge, int(edge_id))
     if edge is not None and edge.status != EDGE_COMMITTED:
         edge.status = EDGE_REJECTED
+
+
+async def _set_draft_artifact(
+    session: AsyncSession, payload: dict[str, Any], *, confirmed: bool
+) -> None:
+    from juno.drafts.kinds import PUBLISHED_NO, STATUS_CONFIRMED, STATUS_DISCARDED
+
+    artifact_id = payload.get("artifact_id")
+    if artifact_id is None:
+        return
+    artifact = await session.get(DraftArtifact, int(artifact_id))
+    if artifact is None:
+        return
+    artifact.status = STATUS_CONFIRMED if confirmed else STATUS_DISCARDED
+    artifact.published = PUBLISHED_NO

--- a/apps/core/src/juno/models/__init__.py
+++ b/apps/core/src/juno/models/__init__.py
@@ -91,6 +91,26 @@ class ReviewItem(Base):
     decided_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
 
 
+class DraftArtifact(Base):
+    """HITL auto-generated artifact. Confirm via /review; never auto-publish (ADR-09)."""
+
+    __tablename__ = "draft_artifacts"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    kind: Mapped[str] = mapped_column(String(32), index=True)
+    title: Mapped[str] = mapped_column(String(1024))
+    body: Mapped[str] = mapped_column(Text)
+    extra_json: Mapped[dict[str, Any] | None] = mapped_column(JSON, nullable=True)
+    generator: Mapped[str] = mapped_column(String(32), default="template")
+    status: Mapped[str] = mapped_column(String(32), default="pending", index=True)
+    published: Mapped[str] = mapped_column(String(8), default="false")
+    review_item_id: Mapped[int | None] = mapped_column(
+        ForeignKey("review_items.id"), nullable=True, index=True
+    )
+    source_capture_ids: Mapped[list[Any] | None] = mapped_column(JSON, nullable=True)
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now())
+
+
 class ModuleHealth(Base):
     __tablename__ = "module_health"
 

--- a/apps/core/tests/test_drafts.py
+++ b/apps/core/tests/test_drafts.py
@@ -7,15 +7,19 @@ import pytest
 from sqlalchemy import func, select
 
 from juno.drafts import (
+    DRAFT_KIND_DOC,
+    DRAFT_KIND_FLASHCARD,
     DRAFT_KIND_JOURNAL,
     GENERATOR_TEMPLATE,
+    enqueue_doc_draft,
+    enqueue_flashcard_draft,
     enqueue_journal_draft,
     format_journal_snippet,
     maybe_enqueue_smoke_draft,
 )
 from juno.graph.db import Database
 from juno.hitl.queue import KIND_DRAFT, ReviewQueue
-from juno.models import Capture
+from juno.models import Capture, DraftArtifact
 
 
 @pytest.fixture
@@ -45,6 +49,13 @@ async def _capture_count(db: Database) -> int:
     async def load(session):
         result = await session.execute(select(func.count()).select_from(Capture))
         return int(result.scalar_one())
+
+    return await db.read(load)
+
+
+async def _artifact(db: Database, artifact_id: int) -> DraftArtifact | None:
+    async def load(session):
+        return await session.get(DraftArtifact, artifact_id)
 
     return await db.read(load)
 
@@ -89,6 +100,11 @@ async def test_journal_draft_stays_unpublished_after_approve(db):
     assert result.card.payload["published"] is False
     assert result.card.payload["discarded"] is False
     assert await _capture_count(db) == before
+    art = await _artifact(db, int(card.payload["artifact_id"]))
+    assert art is not None
+    assert art.status == "confirmed"
+    assert art.published == "false"
+    assert art.kind == DRAFT_KIND_JOURNAL
 
 
 @pytest.mark.asyncio
@@ -100,6 +116,10 @@ async def test_journal_draft_reject_discards_without_publish(db):
     assert result.card.payload["discarded"] is True
     assert result.card.payload["published"] is False
     assert await _capture_count(db) == 0
+    art = await _artifact(db, int(card.payload["artifact_id"]))
+    assert art is not None
+    assert art.status == "discarded"
+    assert art.published == "false"
 
 
 @pytest.mark.asyncio
@@ -138,3 +158,42 @@ async def test_smoke_skips_when_paused_or_off(settings, db):
     settings.juno_drafts_smoke = False
     off = SimpleNamespace(state=SimpleNamespace(settings=settings, db=db, capture_paused=False))
     assert await maybe_enqueue_smoke_draft(off) is None
+
+
+@pytest.mark.asyncio
+async def test_flashcard_and_doc_kinds_never_publish(db):
+    cap = await _add_capture(db, title="Ownership notes", text="Rc vs Arc")
+    card = await enqueue_flashcard_draft(
+        db,
+        front=cap.title or "front",
+        back=cap.text or "back",
+        source_capture_ids=[cap.id],
+    )
+    assert card.payload["draft_kind"] == DRAFT_KIND_FLASHCARD
+    assert card.payload["extra"]["front"] == "Ownership notes"
+    assert "Q:" in card.payload["body"]
+    approved = await ReviewQueue(db).decide(card.id, "approve")
+    art = await _artifact(db, int(approved.card.payload["artifact_id"]))
+    assert art is not None
+    assert art.kind == DRAFT_KIND_FLASHCARD
+    assert art.status == "confirmed"
+    assert art.published == "false"
+
+    doc = await enqueue_doc_draft(db, captures=[cap])
+    assert doc.payload["draft_kind"] == DRAFT_KIND_DOC
+    assert "Draft README" in doc.payload["body"]
+    rejected = await ReviewQueue(db).decide(doc.id, "reject")
+    discarded = await _artifact(db, int(rejected.card.payload["artifact_id"]))
+    assert discarded is not None
+    assert discarded.status == "discarded"
+    assert discarded.published == "false"
+
+
+@pytest.mark.asyncio
+async def test_unknown_draft_kind_rejected(db):
+    with pytest.raises(ValueError, match="unknown draft kind"):
+        await ReviewQueue(db).propose_draft(
+            draft_kind="tweet",
+            title="nope",
+            body="nope",
+        )

--- a/apps/core/tests/test_migrations.py
+++ b/apps/core/tests/test_migrations.py
@@ -24,6 +24,7 @@ GRAPH_TABLES = {
     "review_items",
     "module_health",
     "settings",
+    "draft_artifacts",
 }
 
 

--- a/docs/adr/003-alembic.md
+++ b/docs/adr/003-alembic.md
@@ -7,7 +7,7 @@ Accepted (v1)
 ## Date
 
 2026-08-20 (M0 scaffold)  
-**Last reviewed:** 2026-08-26 (after M1 / issue #11; schema still at revision `0001`)
+**Last reviewed:** 2026-09-05 (M5 / #107; schema head is revision `0002`)
 
 ## Context
 
@@ -16,6 +16,7 @@ The knowledge-graph schema lives in SQLAlchemy models under `apps/core/src/juno/
 - `captures`, `chunks`, `nodes`, `edges`
 - `review_items` (HITL)
 - `module_health`, `settings`
+- `draft_artifacts` (M5 HITL drafts; [ADR-09](009-draft-artifacts-hitl.md))
 
 That schema will keep evolving past v1.0 (browser metadata in M2, IDE fields in M3, prune / trust dials in M5, and so on). Shipping only `Base.metadata.create_all` at first boot works for empty databases, but it **cannot** safely alter an existing user’s `data/juno.db` when columns or tables change.
 
@@ -38,7 +39,7 @@ Use **Alembic** for all schema evolution, starting with the first revision.
 
 Concrete rules:
 
-1. Migrations live under `apps/core/alembic/` with `alembic.ini` in `apps/core/`. Current head: revision **`0001`** (`0001_initial_schema.py`) matching the ORM tables above.
+1. Migrations live under `apps/core/alembic/` with `alembic.ini` in `apps/core/`. Current head: revision **`0002`** (`0002_draft_artifacts.py`) following **`0001`** (`0001_initial_schema.py`).
 2. **`juno db-init`** and **`juno serve`** (via `Database.migrate()`) apply `alembic upgrade head`.
 3. The upgrade runs on a **sync** SQLite URL (`sqlite:///…`) inside **`asyncio.to_thread`**, so the asyncio loop is never nested (ADR-01). After upgrade, the async engine re-asserts `PRAGMA journal_mode=WAL` ([ADR-02](002-sqlite-write-queue.md)).
 4. Databases that were created with the pre-Alembic `create_all` path (tables already match `0001`) are **stamped** at head rather than re-created — see `juno.graph.migrations`.
@@ -58,7 +59,7 @@ Concrete rules:
 
 - Contributors must remember: model change ⇒ new Alembic revision in the same PR.
 - Autogenerate can miss renames / data migrations; always read the generated script.
-- Until a second revision exists, “stamp vs upgrade” only matters for people who still have pre-Alembic files — new installs just upgrade to `0001`.
+- **`0002`** adds `draft_artifacts` for HITL drafts ([ADR-09](009-draft-artifacts-hitl.md) / #107). Existing `0001` databases **upgrade**; they are not stamped over `0002`.
 
 ### Follow-ups
 

--- a/docs/adr/009-draft-artifacts-hitl.md
+++ b/docs/adr/009-draft-artifacts-hitl.md
@@ -36,9 +36,13 @@ Options:
 ## Consequences
 
 - Operators prove the HITL path with `JUNO_DRAFTS_SMOKE=true` then `/review` — no live LLM.
-- Later kinds (flashcard / doc) reuse the same `draft` kind + payload `draft_kind` discriminator ([#107](https://github.com/Anna-Hax/JUNO/issues/107)).
+- Later kinds (flashcard / doc) reuse the same `draft` kind + payload `draft_kind` discriminator ([#107](https://github.com/Anna-Hax/JUNO/issues/107)). Confirmed rows live in `draft_artifacts`; they are still not published.
 - Publishing (file write, ingest, Telegram canonical) is a later, explicit confirm step — never a side effect of Approve in S5.
 
 ## Spike S5 proof
 
 Issue [#106](https://github.com/Anna-Hax/JUNO/issues/106): template journal from recent captures (or a placeholder if none) lands pending; Approve/Reject/Skip work; `published` stays false (see [session 49](../sessions/49-session-spike-s5.md)).
+
+## Scaffold (#107)
+
+Issue [#107](https://github.com/Anna-Hax/JUNO/issues/107): kinds `journal` / `flashcard` / `doc` persist as `draft_artifacts` (Alembic **`0002`**) plus a `review_items` row. Approve sets artifact `status=confirmed` and **still** `published=false`. Reject sets `discarded`. CI enqueues all three kinds without an LLM (see [session 50](../sessions/50-session-draft-scaffold.md)).

--- a/docs/next-work.md
+++ b/docs/next-work.md
@@ -193,7 +193,7 @@ Milestone: [M5: v2.0 Polish & Extensions](https://github.com/Anna-Hax/JUNO/miles
 | Order | Issue | Title |
 | ----- | ----- | ----- |
 | 1 | [#106](https://github.com/Anna-Hax/JUNO/issues/106) | Spike S5 — one auto-generated draft through HITL — ✅ [session 49](sessions/49-session-spike-s5.md) |
-| 2 | [#107](https://github.com/Anna-Hax/JUNO/issues/107) | Draft artifacts scaffold — draft kinds + never auto-publish |
+| 2 | [#107](https://github.com/Anna-Hax/JUNO/issues/107) | Draft artifacts scaffold — draft kinds + never auto-publish — ✅ [session 50](sessions/50-session-draft-scaffold.md) |
 | 3 | [#108](https://github.com/Anna-Hax/JUNO/issues/108) | Flashcards / spaced repetition from highlights |
 | 4 | [#109](https://github.com/Anna-Hax/JUNO/issues/109) | Auto-drafted dev journal / README drafts |
 | 5 | [#110](https://github.com/Anna-Hax/JUNO/issues/110) | Skill-gap tracking |
@@ -203,7 +203,7 @@ Milestone: [M5: v2.0 Polish & Extensions](https://github.com/Anna-Hax/JUNO/miles
 | 9 | [#114](https://github.com/Anna-Hax/JUNO/issues/114) | Module health — polish jobs freshness + respect /pause |
 | 10 | [#115](https://github.com/Anna-Hax/JUNO/issues/115) | M5 gate — polish tests, ADR, README, v2.0 release gate |
 
-**First coding task:** #106 ✅. Next: draft artifacts scaffold ([#107](https://github.com/Anna-Hax/JUNO/issues/107)).
+**First coding task:** #106–#107 ✅. Next: flashcards / SRS ([#108](https://github.com/Anna-Hax/JUNO/issues/108)).
 
 ### M5 design constraints (do not violate)
 

--- a/docs/sessions/02-codebase-map.md
+++ b/docs/sessions/02-codebase-map.md
@@ -32,13 +32,13 @@ JUNO/
 | CLI | `cli.py` | `juno serve` / `db-init` / `export` / `wipe` / `version` |
 | Runtime | `runtime.py` | Shared asyncio: uvicorn + PTB + inbox watcher + jobs scheduler lifespan |
 | Jobs | `jobs/scheduler.py`, `jobs/registry.py`, `jobs/handlers.py`, `jobs/health.py`, `jobs/resurface.py` | AsyncIOScheduler + named cron registry (ADR-07) |
-| Drafts | `drafts/generate.py` | Template journal snippets queued as HITL `draft` (ADR-09 / Spike S5) |
+| Drafts | `drafts/generate.py`, `drafts/kinds.py` | Template journal/flashcard/doc queued as HITL `draft` + `draft_artifacts` (ADR-09 / #107) |
 | API | `api/__init__.py` | FastAPI routes + token + loopback middleware |
 | Bot | `bot/handlers.py`, `bot/services.py`, `bot/review.py` | Telegram allowlist, query, capture, pause/digest/status ([#18](https://github.com/Anna-Hax/JUNO/issues/18) / [#19](https://github.com/Anna-Hax/JUNO/issues/19)); HITL `/review` ([#20](https://github.com/Anna-Hax/JUNO/issues/20)) |
 | Graph DB | `graph/db.py`, `graph/migrations.py`, `graph/ownership.py` | Engine, WAL, write queue, Alembic upgrade/stamp; export/wipe ([#23](https://github.com/Anna-Hax/JUNO/issues/23)) |
 | Vectors | `graph/vectors.py` | Persistent Chroma; one collection per embedding model ([ADR-04](../adr/004-chroma-collections.md)) |
-| Models | `models/__init__.py` | SQLAlchemy tables |
-| Alembic | `alembic/` + `alembic.ini` | Revision `0001` = current ORM ([ADR-03](../adr/003-alembic.md)) |
+| Models | `models/__init__.py` | SQLAlchemy tables including `draft_artifacts` |
+| Alembic | `alembic/` + `alembic.ini` | Head `0002` (`draft_artifacts`) after `0001` ([ADR-03](../adr/003-alembic.md)) |
 | LLM | `llm/embedder.py`, `llm/chat.py`, `llm/transcribe.py` | MiniLM (optional extra) + stub embedder; Ollama / OpenAI-compat / offline chat; opt-in voice STT (ADR-08) |
 | Ingest | `ingest/extractors.py`, `chunking.py`, `pipeline.py`, `watcher.py` | File/URL extract, chunk, persist, inbox watch ([#16](https://github.com/Anna-Hax/JUNO/issues/16)) |
 | RAG | `rag/engine.py` | Vector retrieve, join captures, sourced answer + confidence ([#17](https://github.com/Anna-Hax/JUNO/issues/17)); Telegram query uses this |

--- a/docs/sessions/50-session-draft-scaffold.md
+++ b/docs/sessions/50-session-draft-scaffold.md
@@ -1,0 +1,33 @@
+# Session 50 — Draft artifacts scaffold (#107)
+
+**Date:** 2026-09-05  
+**Issue:** [#107](https://github.com/Anna-Hax/JUNO/issues/107) — Draft artifacts scaffold: draft kinds + never auto-publish  
+**Epic:** [#28](https://github.com/Anna-Hax/JUNO/issues/28)  
+**Branch:** `feat/draft-scaffold-107`
+
+## What changed
+
+- Kinds `journal` / `flashcard` / `doc` (`juno.drafts.kinds`); unknown kinds raise.
+- `draft_artifacts` table via Alembic **0002**; approve confirms, reject discards, `published` stays `false`.
+- Template enqueue helpers for flashcard + doc (no LLM). Journal smoke path unchanged.
+- ADR-09 scaffold note; ADR-03 head is `0002`.
+
+## Verify
+
+```powershell
+cd apps/core
+$env:EMBEDDING_BACKEND='stub'
+uv run pytest tests/test_drafts.py tests/test_migrations.py -q
+```
+
+## Deferred
+
+Flashcard SRS (#108), LLM journal/README (#109), skill-gap, trust dial, Slack, prune, polish health, M5 gate.
+
+## Links
+
+| Doc | Role |
+|-----|------|
+| [009-draft-artifacts-hitl.md](../adr/009-draft-artifacts-hitl.md) | ADR |
+| [003-alembic.md](../adr/003-alembic.md) | Schema head 0002 |
+| [next-work.md](../next-work.md) | M5 queue |

--- a/docs/sessions/README.md
+++ b/docs/sessions/README.md
@@ -55,6 +55,7 @@ Living notes for what was implemented, how GitHub is set up, and what to do next
 | [47-session-jobs-health.md](47-session-jobs-health.md) | **#94** — Jobs module health |
 | [48-session-m4-gate.md](48-session-m4-gate.md) | **#95** — M4 gate + v1.3 |
 | [49-session-spike-s5.md](49-session-spike-s5.md) | **#106** — Spike S5 draft through HITL |
+| [50-session-draft-scaffold.md](50-session-draft-scaffold.md) | **#107** — Draft kinds + never auto-publish |
 | [v1.0-release-gate.md](../v1.0-release-gate.md) | M1 checklist (all P0 closed) |
 | [v1.1-release-gate.md](../v1.1-release-gate.md) | M2 checklist (browser capture) |
 | [v1.2-release-gate.md](../v1.2-release-gate.md) | M3 checklist (IDE capture) |


### PR DESCRIPTION
## Summary
- Formalize HITL draft kinds `journal` / `flashcard` / `doc` and persist them in `draft_artifacts` (Alembic 0002).
- Approve confirms and reject discards; `published` stays false — never auto-publish to the graph, Telegram, or a git repo.
- Template enqueue helpers work without a live LLM. ADR-09 scaffold + ADR-03 head `0002`.

## Linked issue
Closes #107

## Test plan
- [x] `uv run pytest tests/test_drafts.py tests/test_migrations.py tests/test_review.py`
- [x] `uv run pytest -q` (175 passed)
- [x] `uv run ruff check src tests`
- [ ] Manual: enqueue a flashcard/doc draft and `/review` Approve — row stays unpublished