### PR TITLE
feat(bot): generate highlight flashcards and review them with SRS

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ uv run juno wipe --confirm wipe-all-data
 - API: `http://127.0.0.1:8787/health` (no token). `/status` `/ingest` `/search` need `Authorization: Bearer <JUNO_API_TOKEN>`. Serve refuses the example `change-me` token and any non-loopback `JUNO_API_HOST`.
 - Token-gated `GET /status` reports the live embedder (model / backend / dimensions) and LLM health (`llm_healthy`, `llm_provider`, `llm_model`). If Ollama is down, `llm_healthy` is false and answers stay retrieve-only.
 - Token-gated `GET /search?q=` returns citations + confidence (sourced answer when the LLM is healthy).
-- Bot runs only while this process (and PC) is on. Telegram queues updates ~24h; longer downtime can drop messages. Commands: `/start` `/help` `/digest today|week` `/jobs` `/pause` `/resume` `/status` `/review`. Forward a message, send a link, attach a doc, or send a **voice note** to capture; other text queries the graph. Voice STT is opt-in ([ADR-08](docs/adr/008-voice-transcription.md)).
+- Bot runs only while this process (and PC) is on. Telegram queues updates ~24h; longer downtime can drop messages. Commands: `/start` `/help` `/digest today|week` `/jobs` `/pause` `/resume` `/status` `/review` `/cards`. Forward a message, send a link, attach a doc, or send a **voice note** to capture; other text queries the graph. Voice STT is opt-in ([ADR-08](docs/adr/008-voice-transcription.md)). New flashcards stay HITL drafts until Approve.
 
 ### Tests
 

--- a/apps/core/alembic/versions/0003_flashcards.py
+++ b/apps/core/alembic/versions/0003_flashcards.py
@@ -1,0 +1,65 @@
+"""0003 flashcards — SRS rows after HITL flashcard drafts (#108).
+
+Revision ID: 0003
+Revises: 0002
+Create Date: 2026-09-05
+"""
+
+from __future__ import annotations
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "0003"
+down_revision: Union[str, Sequence[str], None] = "0002"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "flashcards",
+        sa.Column("id", sa.Integer(), autoincrement=True, nullable=False),
+        sa.Column("artifact_id", sa.Integer(), nullable=False),
+        sa.Column("front", sa.Text(), nullable=False),
+        sa.Column("back", sa.Text(), nullable=False),
+        sa.Column("fingerprint", sa.String(length=128), nullable=False),
+        sa.Column("capture_id", sa.Integer(), nullable=True),
+        sa.Column("due_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("ease", sa.Float(), nullable=False),
+        sa.Column("interval_days", sa.Integer(), nullable=False),
+        sa.Column("reps", sa.Integer(), nullable=False),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("(CURRENT_TIMESTAMP)"),
+            nullable=False,
+        ),
+        sa.ForeignKeyConstraint(
+            ["artifact_id"],
+            ["draft_artifacts.id"],
+            name=op.f("fk_flashcards_artifact_id_draft_artifacts"),
+        ),
+        sa.ForeignKeyConstraint(
+            ["capture_id"],
+            ["captures.id"],
+            name=op.f("fk_flashcards_capture_id_captures"),
+        ),
+        sa.PrimaryKeyConstraint("id", name=op.f("pk_flashcards")),
+    )
+    with op.batch_alter_table("flashcards", schema=None) as batch_op:
+        batch_op.create_index(batch_op.f("ix_flashcards_artifact_id"), ["artifact_id"], unique=True)
+        batch_op.create_index(batch_op.f("ix_flashcards_fingerprint"), ["fingerprint"], unique=True)
+        batch_op.create_index(batch_op.f("ix_flashcards_capture_id"), ["capture_id"], unique=False)
+        batch_op.create_index(batch_op.f("ix_flashcards_due_at"), ["due_at"], unique=False)
+
+
+def downgrade() -> None:
+    with op.batch_alter_table("flashcards", schema=None) as batch_op:
+        batch_op.drop_index(batch_op.f("ix_flashcards_due_at"))
+        batch_op.drop_index(batch_op.f("ix_flashcards_capture_id"))
+        batch_op.drop_index(batch_op.f("ix_flashcards_fingerprint"))
+        batch_op.drop_index(batch_op.f("ix_flashcards_artifact_id"))
+    op.drop_table("flashcards")

--- a/apps/core/src/juno/bot/cards.py
+++ b/apps/core/src/juno/bot/cards.py
@@ -1,0 +1,132 @@
+"""Telegram /cards — due SRS prompts. Generation of new cards stays HITL."""
+
+from __future__ import annotations
+
+from telegram import InlineKeyboardButton, InlineKeyboardMarkup, Update
+from telegram.ext import ContextTypes
+
+from juno.bot.services import BOT_DATA_KEY, BotServices, user_allowed
+from juno.config import Settings, get_settings
+from juno.drafts.flashcards import (
+    format_card_prompt,
+    format_card_reveal,
+    next_due_card,
+    queue_highlight_flashcards,
+    review_card,
+)
+from juno.models import Flashcard
+
+_GRADES = {"again": "Again", "good": "Good"}
+
+
+def _services(context: ContextTypes.DEFAULT_TYPE) -> BotServices | None:
+    raw = context.application.bot_data.get(BOT_DATA_KEY)
+    return raw if isinstance(raw, BotServices) else None
+
+
+def _settings(context: ContextTypes.DEFAULT_TYPE) -> Settings:
+    stored = context.application.bot_data.get("settings")
+    if stored is not None:
+        return stored
+    svc = _services(context)
+    return svc.settings if svc is not None else get_settings()
+
+
+def _allowed(user_id: int | None, context: ContextTypes.DEFAULT_TYPE) -> bool:
+    return user_allowed(user_id, _settings(context))
+
+
+def cards_keyboard(card_id: int) -> InlineKeyboardMarkup:
+    return InlineKeyboardMarkup(
+        [
+            [
+                InlineKeyboardButton("Again", callback_data=f"srs:{card_id}:again"),
+                InlineKeyboardButton("Good", callback_data=f"srs:{card_id}:good"),
+            ]
+        ]
+    )
+
+
+def parse_srs_callback(data: str) -> tuple[int, str] | None:
+    parts = data.split(":")
+    if len(parts) != 3 or parts[0] != "srs":
+        return None
+    try:
+        card_id = int(parts[1])
+    except ValueError:
+        return None
+    grade = parts[2]
+    if grade not in _GRADES:
+        return None
+    return card_id, grade
+
+
+def _paused(context: ContextTypes.DEFAULT_TYPE) -> bool:
+    svc = _services(context)
+    app = svc.app if svc is not None else None
+    if app is None:
+        return False
+    return bool(getattr(app.state, "capture_paused", False))
+
+
+def _card_text(card: Flashcard) -> str:
+    return f"{format_card_prompt(card)}\n\n{format_card_reveal(card)}"
+
+
+async def cards_cmd(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+    if not update.effective_user or not _allowed(update.effective_user.id, context):
+        return
+    if update.message is None:
+        return
+    svc = _services(context)
+    if svc is None or svc.db is None:
+        await update.message.reply_text("Cards unavailable (database not attached).")
+        return
+    queued = await queue_highlight_flashcards(svc.db, paused=_paused(context))
+    due = await next_due_card(svc.db)
+    prefix = f"Queued {len(queued)} flashcard draft(s) for /review.\n\n" if queued else ""
+    if due is None:
+        msg = prefix + "No flashcards due."
+        if _paused(context):
+            msg += " Capture is paused, so no new drafts were generated."
+        await update.message.reply_text(msg)
+        return
+    await update.message.reply_text(
+        prefix + _card_text(due),
+        reply_markup=cards_keyboard(due.id),
+    )
+
+
+async def cards_callback(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+    query = update.callback_query
+    if query is None:
+        return
+    if not update.effective_user or not _allowed(update.effective_user.id, context):
+        await query.answer()
+        return
+    parsed = parse_srs_callback(query.data or "")
+    if parsed is None:
+        await query.answer("Unknown button")
+        return
+    card_id, grade = parsed
+    svc = _services(context)
+    if svc is None or svc.db is None:
+        await query.answer("Cards unavailable.")
+        return
+    try:
+        graded = await review_card(svc.db, card_id, grade)
+    except LookupError:
+        await query.answer("That card is gone.")
+        await query.edit_message_text("Flashcard not found.")
+        return
+    await query.answer()
+    nxt = await next_due_card(svc.db)
+    verb = _GRADES[grade]
+    text = f"{verb} on flashcard #{graded.id}."
+    if nxt is None:
+        await query.edit_message_text(text + "\n\nNo more cards due.")
+        return
+    await query.edit_message_text(
+        text + f"\n\nNext:\n{_card_text(nxt)}",
+        reply_markup=cards_keyboard(nxt.id),
+    )

--- a/apps/core/src/juno/bot/handlers.py
+++ b/apps/core/src/juno/bot/handlers.py
@@ -38,6 +38,7 @@ HELP_TEXT = (
     "/resume — resume ingest (processes inbox backlog)\n"
     "/status — capture + module health\n"
     "/review — HITL Approve/Reject/Skip (merges, IDE, mobile, resurfacing, drafts)\n"
+    "/cards — flashcards due (Again/Good); new cards stay drafts until /review\n"
     "Ask a question to search the graph.\n"
     "Forward a message, send a link, attach a doc, or send a voice note to capture."
 )

--- a/apps/core/src/juno/drafts/__init__.py
+++ b/apps/core/src/juno/drafts/__init__.py
@@ -1,5 +1,6 @@
 """Auto-generated draft artifacts (M5). Stay HITL until approve; never auto-publish."""
 
+from juno.drafts.flashcards import queue_highlight_flashcards, review_card
 from juno.drafts.generate import (
     enqueue_doc_draft,
     enqueue_flashcard_draft,
@@ -30,4 +31,6 @@ __all__ = [
     "format_flashcard",
     "format_journal_snippet",
     "maybe_enqueue_smoke_draft",
+    "queue_highlight_flashcards",
+    "review_card",
 ]

--- a/apps/core/src/juno/drafts/flashcards.py
+++ b/apps/core/src/juno/drafts/flashcards.py
@@ -1,0 +1,217 @@
+"""Flashcards from highlights + SM-2-lite SRS. Drafts stay HITL until approve."""
+
+from __future__ import annotations
+
+import hashlib
+import logging
+from dataclasses import dataclass
+from datetime import UTC, datetime, timedelta
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from juno.drafts.generate import enqueue_flashcard_draft
+from juno.drafts.kinds import DRAFT_KIND_FLASHCARD, STATUS_CONFIRMED, STATUS_PENDING
+from juno.graph.db import Database
+from juno.hitl.queue import ReviewCard
+from juno.models import Capture, DraftArtifact, Flashcard
+
+logger = logging.getLogger("juno.drafts")
+
+AGAIN_DELAY = timedelta(minutes=10)
+MIN_HIGHLIGHT_LEN = 8
+
+
+@dataclass(frozen=True)
+class Highlight:
+    capture_id: int
+    text: str
+    back: str
+    fingerprint: str
+
+
+def highlight_fingerprint(capture_id: int, text: str) -> str:
+    norm = " ".join((text or "").lower().split())
+    digest = hashlib.sha256(f"{capture_id}:{norm}".encode()).hexdigest()[:20]
+    return f"hl.{capture_id}.{digest}"
+
+
+def extract_highlights(capture: Capture) -> list[Highlight]:
+    raw = capture.raw_json if isinstance(capture.raw_json, dict) else {}
+    items = raw.get("highlights") if isinstance(raw.get("highlights"), list) else []
+    back = (capture.title or capture.uri or capture.source_type or "").strip()
+    found: list[Highlight] = []
+    seen: set[str] = set()
+    for item in items:
+        if isinstance(item, str):
+            text = item.strip()
+        elif isinstance(item, dict):
+            text = str(item.get("text") or "").strip()
+        else:
+            continue
+        text = " ".join(text.split())
+        if len(text) < MIN_HIGHLIGHT_LEN:
+            continue
+        fp = highlight_fingerprint(capture.id, text)
+        if fp in seen:
+            continue
+        seen.add(fp)
+        found.append(Highlight(capture_id=capture.id, text=text, back=back, fingerprint=fp))
+    return found
+
+
+async def queue_highlight_flashcards(
+    db: Database,
+    *,
+    paused: bool = False,
+) -> list[ReviewCard]:
+    """Enqueue HITL flashcard drafts from capture highlights. No-op when paused."""
+    if paused:
+        logger.info("flashcard generation skipped — capture paused")
+        return []
+    captures = await _captures_with_raw(db)
+    known = await _known_fingerprints(db)
+    queued: list[ReviewCard] = []
+    for cap in captures:
+        for hl in extract_highlights(cap):
+            if hl.fingerprint in known:
+                continue
+            card = await enqueue_flashcard_draft(
+                db,
+                front=hl.text,
+                back=hl.back,
+                source_capture_ids=[hl.capture_id],
+                title=hl.text[:80],
+                extra={"fingerprint": hl.fingerprint, "capture_id": hl.capture_id},
+            )
+            known.add(hl.fingerprint)
+            queued.append(card)
+    return queued
+
+
+async def next_due_card(db: Database, *, now: datetime | None = None) -> Flashcard | None:
+    now = now or datetime.now(UTC)
+
+    async def load(session: AsyncSession) -> Flashcard | None:
+        stmt = (
+            select(Flashcard)
+            .where(Flashcard.due_at <= now)
+            .order_by(Flashcard.due_at, Flashcard.id)
+            .limit(1)
+        )
+        result = await session.execute(stmt)
+        return result.scalar_one_or_none()
+
+    return await db.read(load)
+
+
+def apply_again(card: Flashcard, *, now: datetime | None = None) -> None:
+    now = now or datetime.now(UTC)
+    card.reps = 0
+    card.interval_days = 0
+    card.ease = max(1.3, float(card.ease) - 0.2)
+    card.due_at = now + AGAIN_DELAY
+
+
+def apply_good(card: Flashcard, *, now: datetime | None = None) -> None:
+    now = now or datetime.now(UTC)
+    card.reps = int(card.reps) + 1
+    if card.reps == 1:
+        card.interval_days = 1
+    elif card.reps == 2:
+        card.interval_days = 6
+    else:
+        card.interval_days = max(1, round(float(card.interval_days) * float(card.ease)))
+    card.ease = min(2.8, float(card.ease) + 0.05)
+    card.due_at = now + timedelta(days=card.interval_days)
+
+
+async def review_card(db: Database, card_id: int, grade: str) -> Flashcard:
+    if grade not in {"again", "good"}:
+        raise ValueError(f"unknown grade: {grade}")
+
+    async def write(session: AsyncSession) -> Flashcard:
+        row = await session.get(Flashcard, card_id)
+        if row is None:
+            raise LookupError(f"flashcard {card_id} not found")
+        now = datetime.now(UTC)
+        if grade == "again":
+            apply_again(row, now=now)
+        else:
+            apply_good(row, now=now)
+        return row
+
+    return await db.write(write)
+
+
+async def activate_approved_flashcard(
+    session: AsyncSession, artifact: DraftArtifact
+) -> Flashcard | None:
+    """Create an SRS row after HITL approve. Never called for unpublished drafts."""
+    if artifact.kind != DRAFT_KIND_FLASHCARD:
+        return None
+    extra = artifact.extra_json if isinstance(artifact.extra_json, dict) else {}
+    front = str(extra.get("front") or artifact.title or "").strip()
+    back = str(extra.get("back") or "").strip()
+    fingerprint = str(extra.get("fingerprint") or highlight_fingerprint(0, front))
+    capture_id = extra.get("capture_id")
+    existing = await session.execute(select(Flashcard).where(Flashcard.artifact_id == artifact.id))
+    row = existing.scalar_one_or_none()
+    if row is not None:
+        return row
+    by_fp = await session.execute(select(Flashcard).where(Flashcard.fingerprint == fingerprint))
+    if by_fp.scalar_one_or_none() is not None:
+        return None
+    card = Flashcard(
+        artifact_id=artifact.id,
+        front=front or artifact.body,
+        back=back,
+        fingerprint=fingerprint,
+        capture_id=int(capture_id) if capture_id is not None else None,
+        due_at=datetime.now(UTC),
+        ease=2.5,
+        interval_days=0,
+        reps=0,
+    )
+    session.add(card)
+    await session.flush()
+    return card
+
+
+def format_card_prompt(card: Flashcard) -> str:
+    return f"Flashcard #{card.id}\n\nQ: {card.front}"
+
+
+def format_card_reveal(card: Flashcard) -> str:
+    return f"A: {card.back or '(empty)'}"
+
+
+async def _captures_with_raw(db: Database) -> list[Capture]:
+    async def load(session: AsyncSession) -> list[Capture]:
+        result = await session.execute(
+            select(Capture).where(Capture.raw_json.is_not(None)).order_by(Capture.id)
+        )
+        return list(result.scalars())
+
+    return await db.read(load)
+
+
+async def _known_fingerprints(db: Database) -> set[str]:
+    async def load(session: AsyncSession) -> set[str]:
+        known: set[str] = set()
+        cards = await session.execute(select(Flashcard.fingerprint))
+        known.update(str(x) for x in cards.scalars())
+        arts = await session.execute(
+            select(DraftArtifact).where(
+                DraftArtifact.kind == DRAFT_KIND_FLASHCARD,
+                DraftArtifact.status.in_((STATUS_PENDING, STATUS_CONFIRMED)),
+            )
+        )
+        for art in arts.scalars():
+            extra = art.extra_json if isinstance(art.extra_json, dict) else {}
+            fp = extra.get("fingerprint")
+            if fp:
+                known.add(str(fp))
+        return known
+
+    return await db.read(load)

--- a/apps/core/src/juno/drafts/generate.py
+++ b/apps/core/src/juno/drafts/generate.py
@@ -99,19 +99,21 @@ async def enqueue_flashcard_draft(
     back: str,
     source_capture_ids: list[int] | None = None,
     title: str | None = None,
+    extra: dict[str, Any] | None = None,
     generator: str = GENERATOR_TEMPLATE,
 ) -> ReviewCard:
-    body, extra = format_flashcard(front, back)
+    body, structured = format_flashcard(front, back)
+    payload_extra = {**structured, **(extra or {})}
     return await ReviewQueue(db).propose_draft(
         draft_kind=DRAFT_KIND_FLASHCARD,
-        title=title or extra["front"][:80] or "Flashcard",
+        title=title or structured["front"][:80] or "Flashcard",
         body=body,
-        extra=extra,
+        extra=payload_extra,
         source_capture_ids=source_capture_ids,
         generator=generator,
         reason=(
-            "Auto-generated flashcard. Approve keeps it as a confirmed draft; "
-            "it is not published and does not enter SRS until later review."
+            "Auto-generated flashcard. Approve confirms it into SRS practice; "
+            "it is not published to the graph or Telegram as canonical."
         ),
     )
 

--- a/apps/core/src/juno/hitl/queue.py
+++ b/apps/core/src/juno/hitl/queue.py
@@ -509,3 +509,7 @@ async def _set_draft_artifact(
         return
     artifact.status = STATUS_CONFIRMED if confirmed else STATUS_DISCARDED
     artifact.published = PUBLISHED_NO
+    if confirmed:
+        from juno.drafts.flashcards import activate_approved_flashcard
+
+        await activate_approved_flashcard(session, artifact)

--- a/apps/core/src/juno/models/__init__.py
+++ b/apps/core/src/juno/models/__init__.py
@@ -111,6 +111,28 @@ class DraftArtifact(Base):
     created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now())
 
 
+class Flashcard(Base):
+    """SRS card created only after a flashcard draft is approved (ADR-09)."""
+
+    __tablename__ = "flashcards"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    artifact_id: Mapped[int] = mapped_column(
+        ForeignKey("draft_artifacts.id"), unique=True, index=True
+    )
+    front: Mapped[str] = mapped_column(Text)
+    back: Mapped[str] = mapped_column(Text)
+    fingerprint: Mapped[str] = mapped_column(String(128), unique=True, index=True)
+    capture_id: Mapped[int | None] = mapped_column(
+        ForeignKey("captures.id"), nullable=True, index=True
+    )
+    due_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), index=True)
+    ease: Mapped[float] = mapped_column(Float, default=2.5)
+    interval_days: Mapped[int] = mapped_column(Integer, default=0)
+    reps: Mapped[int] = mapped_column(Integer, default=0)
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now())
+
+
 class ModuleHealth(Base):
     __tablename__ = "module_health"
 

--- a/apps/core/src/juno/runtime.py
+++ b/apps/core/src/juno/runtime.py
@@ -17,6 +17,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from telegram.ext import Application, CallbackQueryHandler, CommandHandler, MessageHandler, filters
 
 from juno.api import create_app
+from juno.bot.cards import cards_callback, cards_cmd
 from juno.bot.handlers import (
     digest_cmd,
     document_msg,
@@ -63,7 +64,9 @@ def build_telegram_application(settings: Settings) -> Application | None:
     app.add_handler(CommandHandler("resume", resume_cmd))
     app.add_handler(CommandHandler("status", status_cmd))
     app.add_handler(CommandHandler("review", review_cmd))
+    app.add_handler(CommandHandler("cards", cards_cmd))
     app.add_handler(CallbackQueryHandler(review_callback, pattern=r"^rev:"))
+    app.add_handler(CallbackQueryHandler(cards_callback, pattern=r"^srs:"))
     app.add_handler(MessageHandler(filters.VOICE, voice_msg))
     app.add_handler(MessageHandler(filters.Document.ALL, document_msg))
     app.add_handler(MessageHandler(filters.TEXT & ~filters.COMMAND, text_msg))

--- a/apps/core/tests/test_bot.py
+++ b/apps/core/tests/test_bot.py
@@ -247,7 +247,7 @@ def test_build_telegram_application_registers_commands(allowed_settings):
     for group in app.handlers.values():
         for handler in group:
             commands.update(getattr(handler, "commands", set()))
-    assert commands >= {"start", "help", "digest", "pause", "resume", "status", "review"}
+    assert commands >= {"start", "help", "digest", "pause", "resume", "status", "review", "cards"}
 
 
 @pytest.mark.asyncio
@@ -280,6 +280,7 @@ async def test_start_and_help_reply_for_allowlisted_user(allowed_settings):
     assert "/digest" in body
     assert "/jobs" in body
     assert "/review" in body
+    assert "/cards" in body
     assert "Approve" in body
 
 

--- a/apps/core/tests/test_flashcards.py
+++ b/apps/core/tests/test_flashcards.py
@@ -1,0 +1,139 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from sqlalchemy import select
+
+from juno.bot.cards import cards_cmd, cards_keyboard, parse_srs_callback
+from juno.bot.services import BOT_DATA_KEY, BotServices
+from juno.drafts.flashcards import (
+    extract_highlights,
+    next_due_card,
+    queue_highlight_flashcards,
+    review_card,
+)
+from juno.graph.db import Database
+from juno.hitl.queue import ReviewQueue
+from juno.models import Capture, Flashcard
+
+
+@pytest.fixture
+async def db(settings):
+    database = Database(settings)
+    await database.migrate()
+    yield database
+    await database.dispose()
+
+
+async def _add_highlighted(db: Database, *, title: str, quote: str) -> Capture:
+    async def write(session):
+        row = Capture(
+            source_type="browser",
+            title=title,
+            text=quote,
+            raw_json={"highlights": [{"text": quote}]},
+            status="committed",
+        )
+        session.add(row)
+        await session.flush()
+        return row
+
+    return await db.write(write)
+
+
+def test_extract_highlights_skips_short():
+    cap = Capture(
+        id=1,
+        source_type="browser",
+        title="Page",
+        raw_json={"highlights": [{"text": "ab"}, {"text": "A useful quote here"}]},
+    )
+    found = extract_highlights(cap)
+    assert len(found) == 1
+    assert found[0].text == "A useful quote here"
+    assert found[0].back == "Page"
+
+
+@pytest.mark.asyncio
+async def test_highlights_queue_as_unpublished_drafts(db):
+    await _add_highlighted(db, title="Rust book", quote="Ownership moves values")
+    queued = await queue_highlight_flashcards(db, paused=False)
+    assert len(queued) == 1
+    card = queued[0]
+    assert card.payload["draft_kind"] == "flashcard"
+    assert card.payload["published"] is False
+    assert "Ownership moves values" in card.payload["body"]
+
+    again = await queue_highlight_flashcards(db, paused=False)
+    assert again == []
+
+    paused = await queue_highlight_flashcards(db, paused=True)
+    assert paused == []
+
+    async def count_cards(session):
+        result = await session.execute(select(Flashcard))
+        return list(result.scalars())
+
+    assert await db.read(count_cards) == []
+
+    approved = await ReviewQueue(db).decide(card.id, "approve")
+    assert approved.card.payload["published"] is False
+    rows = await db.read(count_cards)
+    assert len(rows) == 1
+    assert rows[0].front == "Ownership moves values"
+    assert rows[0].back == "Rust book"
+    assert rows[0].artifact_id == int(approved.card.payload["artifact_id"])
+
+
+@pytest.mark.asyncio
+async def test_srs_again_and_good(db):
+    await _add_highlighted(db, title="Topic", quote="Intervals compound with ease")
+    queued = await queue_highlight_flashcards(db)
+    await ReviewQueue(db).decide(queued[0].id, "approve")
+    due = await next_due_card(db)
+    assert due is not None
+    now = datetime.now(UTC)
+    graded = await review_card(db, due.id, "good")
+    assert graded.reps == 1
+    assert graded.interval_days == 1
+    assert graded.due_at > now + timedelta(hours=12)
+
+    later = await review_card(db, graded.id, "again")
+    assert later.reps == 0
+    assert later.interval_days == 0
+    assert later.due_at <= datetime.now(UTC) + timedelta(minutes=11)
+
+
+def test_parse_srs_callback():
+    assert parse_srs_callback("srs:4:again") == (4, "again")
+    assert parse_srs_callback("srs:4:good") == (4, "good")
+    assert parse_srs_callback("rev:4:approve") is None
+    labels = [btn.text for row in cards_keyboard(4).inline_keyboard for btn in row]
+    assert labels == ["Again", "Good"]
+
+
+@pytest.mark.asyncio
+async def test_cards_cmd_queues_drafts_and_skips_when_paused(settings, db):
+    await _add_highlighted(db, title="Page", quote="Spaced repetition works")
+    settings.allowed_telegram_user_ids = "42"
+    app = MagicMock()
+    app.state.capture_paused = False
+    svc = BotServices(settings=settings, db=db, app=app)
+    ctx = MagicMock()
+    ctx.application.bot_data = {BOT_DATA_KEY: svc, "settings": settings}
+    update = MagicMock()
+    update.effective_user.id = 42
+    update.message.reply_text = AsyncMock()
+    await cards_cmd(update, ctx)
+    text = update.message.reply_text.await_args.args[0]
+    assert "Queued 1 flashcard draft" in text
+    assert "No flashcards due" in text
+
+    app.state.capture_paused = True
+    update.message.reply_text = AsyncMock()
+    await cards_cmd(update, ctx)
+    paused_text = update.message.reply_text.await_args.args[0]
+    assert "paused" in paused_text.lower()
+    assert "Queued" not in paused_text

--- a/apps/core/tests/test_migrations.py
+++ b/apps/core/tests/test_migrations.py
@@ -25,6 +25,7 @@ GRAPH_TABLES = {
     "module_health",
     "settings",
     "draft_artifacts",
+    "flashcards",
 }
 
 

--- a/docs/adr/003-alembic.md
+++ b/docs/adr/003-alembic.md
@@ -7,7 +7,7 @@ Accepted (v1)
 ## Date
 
 2026-08-20 (M0 scaffold)  
-**Last reviewed:** 2026-09-05 (M5 / #107; schema head is revision `0002`)
+**Last reviewed:** 2026-09-05 (M5 / #108; schema head is revision `0003`)
 
 ## Context
 
@@ -39,7 +39,7 @@ Use **Alembic** for all schema evolution, starting with the first revision.
 
 Concrete rules:
 
-1. Migrations live under `apps/core/alembic/` with `alembic.ini` in `apps/core/`. Current head: revision **`0002`** (`0002_draft_artifacts.py`) following **`0001`** (`0001_initial_schema.py`).
+1. Migrations live under `apps/core/alembic/` with `alembic.ini` in `apps/core/`. Current head: revision **`0003`** (`0003_flashcards.py`) after **`0002`** / **`0001`**.
 2. **`juno db-init`** and **`juno serve`** (via `Database.migrate()`) apply `alembic upgrade head`.
 3. The upgrade runs on a **sync** SQLite URL (`sqlite:///…`) inside **`asyncio.to_thread`**, so the asyncio loop is never nested (ADR-01). After upgrade, the async engine re-asserts `PRAGMA journal_mode=WAL` ([ADR-02](002-sqlite-write-queue.md)).
 4. Databases that were created with the pre-Alembic `create_all` path (tables already match `0001`) are **stamped** at head rather than re-created — see `juno.graph.migrations`.
@@ -60,6 +60,7 @@ Concrete rules:
 - Contributors must remember: model change ⇒ new Alembic revision in the same PR.
 - Autogenerate can miss renames / data migrations; always read the generated script.
 - **`0002`** adds `draft_artifacts` for HITL drafts ([ADR-09](009-draft-artifacts-hitl.md) / #107). Existing `0001` databases **upgrade**; they are not stamped over `0002`.
+- **`0003`** adds `flashcards` SRS rows created only after a flashcard draft is approved (#108).
 
 ### Follow-ups
 

--- a/docs/adr/009-draft-artifacts-hitl.md
+++ b/docs/adr/009-draft-artifacts-hitl.md
@@ -46,3 +46,7 @@ Issue [#106](https://github.com/Anna-Hax/JUNO/issues/106): template journal from
 ## Scaffold (#107)
 
 Issue [#107](https://github.com/Anna-Hax/JUNO/issues/107): kinds `journal` / `flashcard` / `doc` persist as `draft_artifacts` (Alembic **`0002`**) plus a `review_items` row. Approve sets artifact `status=confirmed` and **still** `published=false`. Reject sets `discarded`. CI enqueues all three kinds without an LLM (see [session 50](../sessions/50-session-draft-scaffold.md)).
+
+## Flashcards / SRS (#108)
+
+Highlights on captures (`raw_json.highlights`) become **flashcard drafts**. Approve creates a `flashcards` row (Alembic **`0003`**) that is due for Telegram `/cards` Again/Good (SM-2-lite). Generation is skipped under `/pause`. Cards are never auto-published (see [session 51](../sessions/51-session-flashcards.md)).

--- a/docs/next-work.md
+++ b/docs/next-work.md
@@ -194,7 +194,7 @@ Milestone: [M5: v2.0 Polish & Extensions](https://github.com/Anna-Hax/JUNO/miles
 | ----- | ----- | ----- |
 | 1 | [#106](https://github.com/Anna-Hax/JUNO/issues/106) | Spike S5 — one auto-generated draft through HITL — ✅ [session 49](sessions/49-session-spike-s5.md) |
 | 2 | [#107](https://github.com/Anna-Hax/JUNO/issues/107) | Draft artifacts scaffold — draft kinds + never auto-publish — ✅ [session 50](sessions/50-session-draft-scaffold.md) |
-| 3 | [#108](https://github.com/Anna-Hax/JUNO/issues/108) | Flashcards / spaced repetition from highlights |
+| 3 | [#108](https://github.com/Anna-Hax/JUNO/issues/108) | Flashcards / spaced repetition from highlights — ✅ [session 51](sessions/51-session-flashcards.md) |
 | 4 | [#109](https://github.com/Anna-Hax/JUNO/issues/109) | Auto-drafted dev journal / README drafts |
 | 5 | [#110](https://github.com/Anna-Hax/JUNO/issues/110) | Skill-gap tracking |
 | 6 | [#111](https://github.com/Anna-Hax/JUNO/issues/111) | Trust dial — per-category auto-commit thresholds |
@@ -203,7 +203,7 @@ Milestone: [M5: v2.0 Polish & Extensions](https://github.com/Anna-Hax/JUNO/miles
 | 9 | [#114](https://github.com/Anna-Hax/JUNO/issues/114) | Module health — polish jobs freshness + respect /pause |
 | 10 | [#115](https://github.com/Anna-Hax/JUNO/issues/115) | M5 gate — polish tests, ADR, README, v2.0 release gate |
 
-**First coding task:** #106–#107 ✅. Next: flashcards / SRS ([#108](https://github.com/Anna-Hax/JUNO/issues/108)).
+**First coding task:** #106–#108 ✅. Next: auto-drafted journal / README ([#109](https://github.com/Anna-Hax/JUNO/issues/109)).
 
 ### M5 design constraints (do not violate)
 

--- a/docs/sessions/02-codebase-map.md
+++ b/docs/sessions/02-codebase-map.md
@@ -32,13 +32,13 @@ JUNO/
 | CLI | `cli.py` | `juno serve` / `db-init` / `export` / `wipe` / `version` |
 | Runtime | `runtime.py` | Shared asyncio: uvicorn + PTB + inbox watcher + jobs scheduler lifespan |
 | Jobs | `jobs/scheduler.py`, `jobs/registry.py`, `jobs/handlers.py`, `jobs/health.py`, `jobs/resurface.py` | AsyncIOScheduler + named cron registry (ADR-07) |
-| Drafts | `drafts/generate.py`, `drafts/kinds.py` | Template journal/flashcard/doc queued as HITL `draft` + `draft_artifacts` (ADR-09 / #107) |
+| Drafts | `drafts/generate.py`, `drafts/kinds.py`, `drafts/flashcards.py` | Template journal/flashcard/doc HITL drafts; SRS after flashcard approve (ADR-09) |
 | API | `api/__init__.py` | FastAPI routes + token + loopback middleware |
 | Bot | `bot/handlers.py`, `bot/services.py`, `bot/review.py` | Telegram allowlist, query, capture, pause/digest/status ([#18](https://github.com/Anna-Hax/JUNO/issues/18) / [#19](https://github.com/Anna-Hax/JUNO/issues/19)); HITL `/review` ([#20](https://github.com/Anna-Hax/JUNO/issues/20)) |
 | Graph DB | `graph/db.py`, `graph/migrations.py`, `graph/ownership.py` | Engine, WAL, write queue, Alembic upgrade/stamp; export/wipe ([#23](https://github.com/Anna-Hax/JUNO/issues/23)) |
 | Vectors | `graph/vectors.py` | Persistent Chroma; one collection per embedding model ([ADR-04](../adr/004-chroma-collections.md)) |
 | Models | `models/__init__.py` | SQLAlchemy tables including `draft_artifacts` |
-| Alembic | `alembic/` + `alembic.ini` | Head `0002` (`draft_artifacts`) after `0001` ([ADR-03](../adr/003-alembic.md)) |
+| Alembic | `alembic/` + `alembic.ini` | Head `0003` (`flashcards`) after `0002` / `0001` ([ADR-03](../adr/003-alembic.md)) |
 | LLM | `llm/embedder.py`, `llm/chat.py`, `llm/transcribe.py` | MiniLM (optional extra) + stub embedder; Ollama / OpenAI-compat / offline chat; opt-in voice STT (ADR-08) |
 | Ingest | `ingest/extractors.py`, `chunking.py`, `pipeline.py`, `watcher.py` | File/URL extract, chunk, persist, inbox watch ([#16](https://github.com/Anna-Hax/JUNO/issues/16)) |
 | RAG | `rag/engine.py` | Vector retrieve, join captures, sourced answer + confidence ([#17](https://github.com/Anna-Hax/JUNO/issues/17)); Telegram query uses this |
@@ -48,7 +48,7 @@ JUNO/
 
 - `uv run juno serve` → `runtime.main_sync()`
 - `uv run juno db-init` → `Database.migrate()` (Alembic `upgrade head`, or stamp legacy `create_all` DBs)
-- Tests: `test_foundation.py`, `test_migrations.py`, `test_ingest.py`, `test_vectors.py`, `test_embedder.py`, `test_chat.py`, `test_rag.py`, `test_bot.py`, `test_review.py`, `test_bot_review.py`, `test_api.py`, `test_write_queue.py`, `test_integration.py`, `test_export.py`, `test_jobs.py`, `test_transcribe.py`, `test_drafts.py`
+- Tests: `test_foundation.py`, `test_migrations.py`, `test_ingest.py`, `test_vectors.py`, `test_embedder.py`, `test_chat.py`, `test_rag.py`, `test_bot.py`, `test_review.py`, `test_bot_review.py`, `test_api.py`, `test_write_queue.py`, `test_integration.py`, `test_export.py`, `test_jobs.py`, `test_transcribe.py`, `test_drafts.py`, `test_flashcards.py`
 
 ### Dependencies
 

--- a/docs/sessions/51-session-flashcards.md
+++ b/docs/sessions/51-session-flashcards.md
@@ -1,0 +1,32 @@
+# Session 51 — Flashcards / SRS (#108)
+
+**Date:** 2026-09-05  
+**Issue:** [#108](https://github.com/Anna-Hax/JUNO/issues/108) — Flashcards / spaced repetition from highlights  
+**Epic:** [#28](https://github.com/Anna-Hax/JUNO/issues/28)  
+**Branch:** `feat/flashcards-108`
+
+## What changed
+
+- Scan `raw_json.highlights` → HITL `flashcard` drafts (deduped by fingerprint).
+- Approve creates an SRS `flashcards` row (Alembic **0003**); reject does not.
+- Telegram `/cards` with Again / Good (SM-2-lite). `/pause` skips generation, not practice of existing due cards.
+- Never auto-publish.
+
+## Verify
+
+```powershell
+cd apps/core
+$env:EMBEDDING_BACKEND='stub'
+uv run pytest tests/test_flashcards.py tests/test_migrations.py -q
+```
+
+## Deferred
+
+LLM journal/README (#109), skill-gap, trust dial, Slack, prune, polish module health, M5 gate.
+
+## Links
+
+| Doc | Role |
+|-----|------|
+| [009-draft-artifacts-hitl.md](../adr/009-draft-artifacts-hitl.md) | ADR |
+| [next-work.md](../next-work.md) | M5 queue |

--- a/docs/sessions/README.md
+++ b/docs/sessions/README.md
@@ -56,6 +56,7 @@ Living notes for what was implemented, how GitHub is set up, and what to do next
 | [48-session-m4-gate.md](48-session-m4-gate.md) | **#95** — M4 gate + v1.3 |
 | [49-session-spike-s5.md](49-session-spike-s5.md) | **#106** — Spike S5 draft through HITL |
 | [50-session-draft-scaffold.md](50-session-draft-scaffold.md) | **#107** — Draft kinds + never auto-publish |
+| [51-session-flashcards.md](51-session-flashcards.md) | **#108** — Flashcards / SRS from highlights |
 | [v1.0-release-gate.md](../v1.0-release-gate.md) | M1 checklist (all P0 closed) |
 | [v1.1-release-gate.md](../v1.1-release-gate.md) | M2 checklist (browser capture) |
 | [v1.2-release-gate.md](../v1.2-release-gate.md) | M3 checklist (IDE capture) |


### PR DESCRIPTION
## Summary
- Turn capture `raw_json.highlights` into HITL flashcard drafts (deduped); `/pause` skips generation.
- Approve creates an SRS `flashcards` row (Alembic 0003). Reject does not. Never auto-publish.
- Telegram `/cards` Again/Good uses a small SM-2-lite schedule.

## Linked issue
Closes #108

## Test plan
- [x] `uv run pytest tests/test_flashcards.py tests/test_migrations.py`
- [x] `uv run pytest -q` (180 passed)
- [x] `uv run ruff check src tests`
- [ ] Manual: ingest a highlighted page, `/cards` queues a draft, `/review` Approve, then `/cards` Again/Good