### PR TITLE
feat(bot): draft IDE journals and READMEs without writing files

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ uv run juno wipe --confirm wipe-all-data
 - API: `http://127.0.0.1:8787/health` (no token). `/status` `/ingest` `/search` need `Authorization: Bearer <JUNO_API_TOKEN>`. Serve refuses the example `change-me` token and any non-loopback `JUNO_API_HOST`.
 - Token-gated `GET /status` reports the live embedder (model / backend / dimensions) and LLM health (`llm_healthy`, `llm_provider`, `llm_model`). If Ollama is down, `llm_healthy` is false and answers stay retrieve-only.
 - Token-gated `GET /search?q=` returns citations + confidence (sourced answer when the LLM is healthy).
-- Bot runs only while this process (and PC) is on. Telegram queues updates ~24h; longer downtime can drop messages. Commands: `/start` `/help` `/digest today|week` `/jobs` `/pause` `/resume` `/status` `/review` `/cards`. Forward a message, send a link, attach a doc, or send a **voice note** to capture; other text queries the graph. Voice STT is opt-in ([ADR-08](docs/adr/008-voice-transcription.md)). New flashcards stay HITL drafts until Approve.
+- Bot runs only while this process (and PC) is on. Telegram queues updates ~24h; longer downtime can drop messages. Commands: `/start` `/help` `/digest today|week` `/jobs` `/pause` `/resume` `/status` `/review` `/cards` `/drafts journal|readme`. Forward a message, send a link, attach a doc, or send a **voice note** to capture; other text queries the graph. Voice STT is opt-in ([ADR-08](docs/adr/008-voice-transcription.md)). New flashcards and journal/README drafts stay HITL until Approve; `/drafts` never writes git files unattended.
 
 ### Tests
 

--- a/apps/core/src/juno/bot/handlers.py
+++ b/apps/core/src/juno/bot/handlers.py
@@ -39,6 +39,7 @@ HELP_TEXT = (
     "/status — capture + module health\n"
     "/review — HITL Approve/Reject/Skip (merges, IDE, mobile, resurfacing, drafts)\n"
     "/cards — flashcards due (Again/Good); new cards stay drafts until /review\n"
+    "/drafts journal|readme — queue an IDE journal or README draft (never writes files)\n"
     "Ask a question to search the graph.\n"
     "Forward a message, send a link, attach a doc, or send a voice note to capture."
 )
@@ -111,6 +112,36 @@ async def jobs_cmd(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
     job_id = TOGGLEABLE_JOBS[args[0]]
     msg = await set_cron_job_enabled(svc.app, job_id, enabled=args[1] == "on")
     await update.message.reply_text(msg)
+
+
+async def drafts_cmd(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+    if not update.message or not _authorized(update, context):
+        return
+    args = [a.lower() for a in (context.args or [])]
+    kind = args[0] if args else "journal"
+    if kind not in {"journal", "readme", "doc"}:
+        await update.message.reply_text("Usage: /drafts journal|readme")
+        return
+    svc = _services(context)
+    if svc is None or svc.db is None:
+        await update.message.reply_text("Drafts unavailable (database not attached).")
+        return
+    from juno.drafts.journal import queue_ide_journal_draft, queue_ide_readme_draft
+
+    paused = False
+    if svc.app is not None:
+        paused = bool(getattr(svc.app.state, "capture_paused", False))
+    if kind == "journal":
+        card = await queue_ide_journal_draft(svc.db, paused=paused)
+    else:
+        card = await queue_ide_readme_draft(svc.db, paused=paused)
+    if card is None:
+        await update.message.reply_text("Draft generation skipped (capture paused).")
+        return
+    await update.message.reply_text(
+        f"Queued {card.payload.get('draft_kind')} draft #{card.id} for /review. "
+        "Approve confirms the draft; Juno does not write files to your repos."
+    )
 
 
 async def pause_cmd(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:

--- a/apps/core/src/juno/drafts/__init__.py
+++ b/apps/core/src/juno/drafts/__init__.py
@@ -1,6 +1,5 @@
 """Auto-generated draft artifacts (M5). Stay HITL until approve; never auto-publish."""
 
-from juno.drafts.flashcards import queue_highlight_flashcards, review_card
 from juno.drafts.generate import (
     enqueue_doc_draft,
     enqueue_flashcard_draft,
@@ -10,6 +9,7 @@ from juno.drafts.generate import (
     format_journal_snippet,
     maybe_enqueue_smoke_draft,
 )
+from juno.drafts.journal import queue_ide_journal_draft, queue_ide_readme_draft
 from juno.drafts.kinds import (
     DRAFT_KIND_DOC,
     DRAFT_KIND_FLASHCARD,
@@ -32,5 +32,7 @@ __all__ = [
     "format_journal_snippet",
     "maybe_enqueue_smoke_draft",
     "queue_highlight_flashcards",
+    "queue_ide_journal_draft",
+    "queue_ide_readme_draft",
     "review_card",
 ]

--- a/apps/core/src/juno/drafts/journal.py
+++ b/apps/core/src/juno/drafts/journal.py
@@ -1,0 +1,54 @@
+"""Weekly journal / README drafts from IDE captures. Never write user repos."""
+
+from __future__ import annotations
+
+import logging
+from datetime import UTC, datetime, timedelta
+
+from juno.bot.services import recent_captures
+from juno.drafts.generate import enqueue_doc_draft, enqueue_journal_draft
+from juno.graph.db import Database
+from juno.hitl.queue import ReviewCard
+from juno.models import Capture
+
+logger = logging.getLogger("juno.drafts")
+
+IDE_LOOKBACK_DAYS = 7
+
+
+async def recent_ide_captures(
+    db: Database,
+    *,
+    now: datetime | None = None,
+    days: int = IDE_LOOKBACK_DAYS,
+    limit: int = 20,
+) -> list[Capture]:
+    now = now or datetime.now(UTC)
+    rows = await recent_captures(db, since=now - timedelta(days=days), limit=limit)
+    return [row for row in rows if row.source_type == "ide"]
+
+
+async def queue_ide_journal_draft(
+    db: Database,
+    *,
+    paused: bool = False,
+    now: datetime | None = None,
+) -> ReviewCard | None:
+    if paused:
+        logger.info("journal draft skipped — capture paused")
+        return None
+    captures = await recent_ide_captures(db, now=now)
+    return await enqueue_journal_draft(db, captures=captures, now=now)
+
+
+async def queue_ide_readme_draft(
+    db: Database,
+    *,
+    paused: bool = False,
+    now: datetime | None = None,
+) -> ReviewCard | None:
+    if paused:
+        logger.info("readme draft skipped — capture paused")
+        return None
+    captures = await recent_ide_captures(db, now=now)
+    return await enqueue_doc_draft(db, captures=captures, now=now)

--- a/apps/core/src/juno/runtime.py
+++ b/apps/core/src/juno/runtime.py
@@ -21,6 +21,7 @@ from juno.bot.cards import cards_callback, cards_cmd
 from juno.bot.handlers import (
     digest_cmd,
     document_msg,
+    drafts_cmd,
     help_cmd,
     jobs_cmd,
     pause_cmd,
@@ -65,6 +66,7 @@ def build_telegram_application(settings: Settings) -> Application | None:
     app.add_handler(CommandHandler("status", status_cmd))
     app.add_handler(CommandHandler("review", review_cmd))
     app.add_handler(CommandHandler("cards", cards_cmd))
+    app.add_handler(CommandHandler("drafts", drafts_cmd))
     app.add_handler(CallbackQueryHandler(review_callback, pattern=r"^rev:"))
     app.add_handler(CallbackQueryHandler(cards_callback, pattern=r"^srs:"))
     app.add_handler(MessageHandler(filters.VOICE, voice_msg))

--- a/apps/core/tests/test_bot.py
+++ b/apps/core/tests/test_bot.py
@@ -247,7 +247,17 @@ def test_build_telegram_application_registers_commands(allowed_settings):
     for group in app.handlers.values():
         for handler in group:
             commands.update(getattr(handler, "commands", set()))
-    assert commands >= {"start", "help", "digest", "pause", "resume", "status", "review", "cards"}
+    assert commands >= {
+        "start",
+        "help",
+        "digest",
+        "pause",
+        "resume",
+        "status",
+        "review",
+        "cards",
+        "drafts",
+    }
 
 
 @pytest.mark.asyncio
@@ -281,6 +291,7 @@ async def test_start_and_help_reply_for_allowlisted_user(allowed_settings):
     assert "/jobs" in body
     assert "/review" in body
     assert "/cards" in body
+    assert "/drafts" in body
     assert "Approve" in body
 
 

--- a/apps/core/tests/test_journal.py
+++ b/apps/core/tests/test_journal.py
@@ -1,0 +1,89 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from juno.bot.handlers import drafts_cmd
+from juno.bot.services import BOT_DATA_KEY, BotServices
+from juno.drafts.journal import queue_ide_journal_draft, queue_ide_readme_draft
+from juno.graph.db import Database
+from juno.hitl.queue import ReviewQueue
+from juno.models import Capture, DraftArtifact
+
+
+@pytest.fixture
+async def db(settings):
+    database = Database(settings)
+    await database.migrate()
+    yield database
+    await database.dispose()
+
+
+async def _add(db: Database, *, source: str, title: str, text: str = "body") -> Capture:
+    async def write(session):
+        row = Capture(source_type=source, title=title, text=text, status="committed")
+        session.add(row)
+        await session.flush()
+        return row
+
+    return await db.write(write)
+
+
+@pytest.mark.asyncio
+async def test_ide_journal_ignores_browser_and_never_writes_files(db, tmp_path):
+    await _add(db, source="browser", title="a webpage")
+    await _add(db, source="ide", title="Cursor chat about WAL")
+    marker = tmp_path / "README.md"
+    card = await queue_ide_journal_draft(db, paused=False, now=datetime.now(UTC))
+    assert card is not None
+    assert card.payload["draft_kind"] == "journal"
+    assert "WAL" in card.payload["body"]
+    assert "webpage" not in card.payload["body"]
+    assert card.payload["published"] is False
+    assert not marker.exists()
+
+    approved = await ReviewQueue(db).decide(card.id, "approve")
+    assert approved.card.payload["published"] is False
+    assert not marker.exists()
+    assert not (tmp_path / "README.md").exists()
+
+
+@pytest.mark.asyncio
+async def test_ide_readme_draft_and_pause(db):
+    await _add(db, source="ide", title="terminal error: locked")
+    paused = await queue_ide_readme_draft(db, paused=True)
+    assert paused is None
+    card = await queue_ide_readme_draft(db, paused=False)
+    assert card is not None
+    assert card.payload["draft_kind"] == "doc"
+    assert "Draft README" in card.payload["body"]
+    assert "locked" in card.payload["body"]
+    assert card.payload["published"] is False
+
+    async def load(session):
+        return await session.get(DraftArtifact, int(card.payload["artifact_id"]))
+
+    art = await db.read(load)
+    assert art is not None
+    assert art.published == "false"
+
+
+@pytest.mark.asyncio
+async def test_drafts_cmd_queues_journal(settings, db):
+    await _add(db, source="ide", title="composer session")
+    settings.allowed_telegram_user_ids = "42"
+    app = MagicMock()
+    app.state.capture_paused = False
+    svc = BotServices(settings=settings, db=db, app=app)
+    ctx = MagicMock()
+    ctx.bot_data = {BOT_DATA_KEY: svc}
+    ctx.args = ["journal"]
+    update = MagicMock()
+    update.effective_user.id = 42
+    update.message.reply_text = AsyncMock()
+    await drafts_cmd(update, ctx)
+    text = update.message.reply_text.await_args.args[0]
+    assert "journal draft" in text
+    assert "does not write files" in text

--- a/docs/adr/009-draft-artifacts-hitl.md
+++ b/docs/adr/009-draft-artifacts-hitl.md
@@ -50,3 +50,7 @@ Issue [#107](https://github.com/Anna-Hax/JUNO/issues/107): kinds `journal` / `fl
 ## Flashcards / SRS (#108)
 
 Highlights on captures (`raw_json.highlights`) become **flashcard drafts**. Approve creates a `flashcards` row (Alembic **`0003`**) that is due for Telegram `/cards` Again/Good (SM-2-lite). Generation is skipped under `/pause`. Cards are never auto-published (see [session 51](../sessions/51-session-flashcards.md)).
+
+## Journal / README drafts (#109)
+
+`/drafts journal|readme` builds a template from recent **IDE** chats/errors (browser captures are ignored). The result is a HITL draft only — **no file is written** into user git repos. See [session 52](../sessions/52-session-journal-drafts.md).

--- a/docs/next-work.md
+++ b/docs/next-work.md
@@ -195,7 +195,7 @@ Milestone: [M5: v2.0 Polish & Extensions](https://github.com/Anna-Hax/JUNO/miles
 | 1 | [#106](https://github.com/Anna-Hax/JUNO/issues/106) | Spike S5 — one auto-generated draft through HITL — ✅ [session 49](sessions/49-session-spike-s5.md) |
 | 2 | [#107](https://github.com/Anna-Hax/JUNO/issues/107) | Draft artifacts scaffold — draft kinds + never auto-publish — ✅ [session 50](sessions/50-session-draft-scaffold.md) |
 | 3 | [#108](https://github.com/Anna-Hax/JUNO/issues/108) | Flashcards / spaced repetition from highlights — ✅ [session 51](sessions/51-session-flashcards.md) |
-| 4 | [#109](https://github.com/Anna-Hax/JUNO/issues/109) | Auto-drafted dev journal / README drafts |
+| 4 | [#109](https://github.com/Anna-Hax/JUNO/issues/109) | Auto-drafted dev journal / README drafts — ✅ [session 52](sessions/52-session-journal-drafts.md) |
 | 5 | [#110](https://github.com/Anna-Hax/JUNO/issues/110) | Skill-gap tracking |
 | 6 | [#111](https://github.com/Anna-Hax/JUNO/issues/111) | Trust dial — per-category auto-commit thresholds |
 | 7 | [#112](https://github.com/Anna-Hax/JUNO/issues/112) | Optional Slack forward into upload space |
@@ -203,7 +203,7 @@ Milestone: [M5: v2.0 Polish & Extensions](https://github.com/Anna-Hax/JUNO/miles
 | 9 | [#114](https://github.com/Anna-Hax/JUNO/issues/114) | Module health — polish jobs freshness + respect /pause |
 | 10 | [#115](https://github.com/Anna-Hax/JUNO/issues/115) | M5 gate — polish tests, ADR, README, v2.0 release gate |
 
-**First coding task:** #106–#108 ✅. Next: auto-drafted journal / README ([#109](https://github.com/Anna-Hax/JUNO/issues/109)).
+**First coding task:** #106–#109 ✅. Next: skill-gap tracking ([#110](https://github.com/Anna-Hax/JUNO/issues/110)).
 
 ### M5 design constraints (do not violate)
 

--- a/docs/sessions/02-codebase-map.md
+++ b/docs/sessions/02-codebase-map.md
@@ -32,7 +32,7 @@ JUNO/
 | CLI | `cli.py` | `juno serve` / `db-init` / `export` / `wipe` / `version` |
 | Runtime | `runtime.py` | Shared asyncio: uvicorn + PTB + inbox watcher + jobs scheduler lifespan |
 | Jobs | `jobs/scheduler.py`, `jobs/registry.py`, `jobs/handlers.py`, `jobs/health.py`, `jobs/resurface.py` | AsyncIOScheduler + named cron registry (ADR-07) |
-| Drafts | `drafts/generate.py`, `drafts/kinds.py`, `drafts/flashcards.py` | Template journal/flashcard/doc HITL drafts; SRS after flashcard approve (ADR-09) |
+| Drafts | `drafts/generate.py`, `drafts/kinds.py`, `drafts/flashcards.py`, `drafts/journal.py` | HITL journal/flashcard/doc; SRS after flashcard approve; IDE journal/README via `/drafts` (ADR-09) |
 | API | `api/__init__.py` | FastAPI routes + token + loopback middleware |
 | Bot | `bot/handlers.py`, `bot/services.py`, `bot/review.py` | Telegram allowlist, query, capture, pause/digest/status ([#18](https://github.com/Anna-Hax/JUNO/issues/18) / [#19](https://github.com/Anna-Hax/JUNO/issues/19)); HITL `/review` ([#20](https://github.com/Anna-Hax/JUNO/issues/20)) |
 | Graph DB | `graph/db.py`, `graph/migrations.py`, `graph/ownership.py` | Engine, WAL, write queue, Alembic upgrade/stamp; export/wipe ([#23](https://github.com/Anna-Hax/JUNO/issues/23)) |
@@ -48,7 +48,7 @@ JUNO/
 
 - `uv run juno serve` → `runtime.main_sync()`
 - `uv run juno db-init` → `Database.migrate()` (Alembic `upgrade head`, or stamp legacy `create_all` DBs)
-- Tests: `test_foundation.py`, `test_migrations.py`, `test_ingest.py`, `test_vectors.py`, `test_embedder.py`, `test_chat.py`, `test_rag.py`, `test_bot.py`, `test_review.py`, `test_bot_review.py`, `test_api.py`, `test_write_queue.py`, `test_integration.py`, `test_export.py`, `test_jobs.py`, `test_transcribe.py`, `test_drafts.py`, `test_flashcards.py`
+- Tests: `test_foundation.py`, `test_migrations.py`, `test_ingest.py`, `test_vectors.py`, `test_embedder.py`, `test_chat.py`, `test_rag.py`, `test_bot.py`, `test_review.py`, `test_bot_review.py`, `test_api.py`, `test_write_queue.py`, `test_integration.py`, `test_export.py`, `test_jobs.py`, `test_transcribe.py`, `test_drafts.py`, `test_flashcards.py`, `test_journal.py`
 
 ### Dependencies
 

--- a/docs/sessions/52-session-journal-drafts.md
+++ b/docs/sessions/52-session-journal-drafts.md
@@ -1,0 +1,26 @@
+# Session 52 — Auto-drafted journal / README (#109)
+
+**Date:** 2026-09-05  
+**Issue:** [#109](https://github.com/Anna-Hax/JUNO/issues/109)  
+**Branch:** `feat/journal-drafts-109`
+
+## What changed
+
+- `/drafts journal|readme` templates a weekly-style journal or README from recent **IDE** captures.
+- Always HITL; approve does not write files into user repos.
+- `/pause` skips generation.
+
+## Verify
+
+```powershell
+cd apps/core
+$env:EMBEDDING_BACKEND='stub'
+uv run pytest tests/test_journal.py -q
+```
+
+## Links
+
+| Doc | Role |
+|-----|------|
+| [009-draft-artifacts-hitl.md](../adr/009-draft-artifacts-hitl.md) | ADR |
+| [next-work.md](../next-work.md) | M5 queue |

--- a/docs/sessions/README.md
+++ b/docs/sessions/README.md
@@ -57,6 +57,7 @@ Living notes for what was implemented, how GitHub is set up, and what to do next
 | [49-session-spike-s5.md](49-session-spike-s5.md) | **#106** — Spike S5 draft through HITL |
 | [50-session-draft-scaffold.md](50-session-draft-scaffold.md) | **#107** — Draft kinds + never auto-publish |
 | [51-session-flashcards.md](51-session-flashcards.md) | **#108** — Flashcards / SRS from highlights |
+| [52-session-journal-drafts.md](52-session-journal-drafts.md) | **#109** — IDE journal / README drafts |
 | [v1.0-release-gate.md](../v1.0-release-gate.md) | M1 checklist (all P0 closed) |
 | [v1.1-release-gate.md](../v1.1-release-gate.md) | M2 checklist (browser capture) |
 | [v1.2-release-gate.md](../v1.2-release-gate.md) | M3 checklist (IDE capture) |


### PR DESCRIPTION
## Summary
- `/drafts journal|readme` templates a weekly journal or README from recent IDE chats/errors (browser captures ignored).
- Always HITL; approve does not write files into user repos. `/pause` skips generation.

## Linked issue
Closes #109

## Test plan
- [x] `uv run pytest tests/test_journal.py tests/test_bot.py`
- [x] `uv run pytest -q` (183 passed)
- [x] `uv run ruff check src tests`
- [ ] Manual: sync an IDE chat, `/drafts journal`, `/review` Approve — no README file appears on disk