### PR TITLE
feat(rag): flag repeat IDE errors and unfinished reads

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ uv run juno wipe --confirm wipe-all-data
 - API: `http://127.0.0.1:8787/health` (no token). `/status` `/ingest` `/search` need `Authorization: Bearer <JUNO_API_TOKEN>`. Serve refuses the example `change-me` token and any non-loopback `JUNO_API_HOST`.
 - Token-gated `GET /status` reports the live embedder (model / backend / dimensions) and LLM health (`llm_healthy`, `llm_provider`, `llm_model`). If Ollama is down, `llm_healthy` is false and answers stay retrieve-only.
 - Token-gated `GET /search?q=` returns citations + confidence (sourced answer when the LLM is healthy).
-- Bot runs only while this process (and PC) is on. Telegram queues updates ~24h; longer downtime can drop messages. Commands: `/start` `/help` `/digest today|week` `/jobs` `/pause` `/resume` `/status` `/review` `/cards` `/drafts journal|readme`. Forward a message, send a link, attach a doc, or send a **voice note** to capture; other text queries the graph. Voice STT is opt-in ([ADR-08](docs/adr/008-voice-transcription.md)). New flashcards and journal/README drafts stay HITL until Approve; `/drafts` never writes git files unattended.
+- Bot runs only while this process (and PC) is on. Telegram queues updates ~24h; longer downtime can drop messages. Commands: `/start` `/help` `/digest today|week` `/jobs` `/pause` `/resume` `/status` `/review` `/cards` `/drafts journal|readme` `/gaps`. Forward a message, send a link, attach a doc, or send a **voice note** to capture; other text queries the graph. Voice STT is opt-in ([ADR-08](docs/adr/008-voice-transcription.md)). New flashcards and journal/README drafts stay HITL until Approve; `/drafts` never writes git files unattended.
 
 ### Tests
 

--- a/apps/core/src/juno/bot/handlers.py
+++ b/apps/core/src/juno/bot/handlers.py
@@ -40,6 +40,7 @@ HELP_TEXT = (
     "/review — HITL Approve/Reject/Skip (merges, IDE, mobile, resurfacing, drafts)\n"
     "/cards — flashcards due (Again/Good); new cards stay drafts until /review\n"
     "/drafts journal|readme — queue an IDE journal or README draft (never writes files)\n"
+    "/gaps — repeat IDE errors / unfinished reads (low-confidence stays in /review)\n"
     "Ask a question to search the graph.\n"
     "Forward a message, send a link, attach a doc, or send a voice note to capture."
 )
@@ -142,6 +143,29 @@ async def drafts_cmd(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None
         f"Queued {card.payload.get('draft_kind')} draft #{card.id} for /review. "
         "Approve confirms the draft; Juno does not write files to your repos."
     )
+
+
+async def gaps_cmd(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+    if not update.message or not _authorized(update, context):
+        return
+    svc = _services(context)
+    if svc is None or svc.db is None:
+        await update.message.reply_text("Gaps unavailable (database not attached).")
+        return
+    from juno.rag.gaps import apply_skill_gaps, find_skill_gaps, format_gaps
+
+    paused = False
+    if svc.app is not None:
+        paused = bool(getattr(svc.app.state, "capture_paused", False))
+    gaps = await find_skill_gaps(svc.db)
+    result = await apply_skill_gaps(svc.db, gaps, paused=paused)
+    if paused:
+        await update.message.reply_text("Skill-gap scan skipped (capture paused).")
+        return
+    extra = ""
+    if result.queued:
+        extra = f"\nQueued {result.queued} low-confidence flag(s) for /review."
+    await update.message.reply_text(format_gaps(list(result.fresh)) + extra)
 
 
 async def pause_cmd(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:

--- a/apps/core/src/juno/hitl/queue.py
+++ b/apps/core/src/juno/hitl/queue.py
@@ -20,6 +20,7 @@ KIND_IDE_BATCH = "ide_batch"
 KIND_MOBILE_BATCH = "mobile_batch"
 KIND_RESURFACE = "resurface"
 KIND_DRAFT = "draft"
+KIND_SKILL_GAP = "skill_gap"
 STATUS_PENDING = "pending"
 STATUS_SKIPPED = "skipped"
 STATUS_DECIDED = "decided"
@@ -99,6 +100,20 @@ class ReviewCard:
             if reason:
                 lines.append(str(reason))
             lines.append("This draft is not published. Approve to keep it; Reject to discard.")
+        elif self.kind == KIND_SKILL_GAP:
+            topic = str(self.payload.get("topic") or "topic")
+            gap_kind = str(self.payload.get("gap_kind") or "gap")
+            count = self.payload.get("count") or "?"
+            lines.append(f"Skill gap ({gap_kind}): {topic} ({count}x)")
+            related = self.payload.get("related") or []
+            if related:
+                lines.append("Related: " + ", ".join(str(x) for x in related[:3]))
+            reason = self.payload.get("reason")
+            if reason:
+                lines.append(str(reason))
+            lines.append(
+                "Approve if this is a real struggle; Reject to ignore (Juno will not nag)."
+            )
         else:
             preview = str(self.payload)[:500]
             if preview:
@@ -447,7 +462,7 @@ async def _pending_edge(
 
 
 async def _apply(session: AsyncSession, row: ReviewItem) -> bool:
-    if row.kind in {KIND_ERROR_MATCH, KIND_IDE_BATCH}:
+    if row.kind in {KIND_ERROR_MATCH, KIND_IDE_BATCH, KIND_SKILL_GAP}:
         payload = dict(row.payload or {})
         payload["confirmed"] = True
         row.payload = payload
@@ -473,7 +488,7 @@ async def _apply(session: AsyncSession, row: ReviewItem) -> bool:
 
 
 async def _reject(session: AsyncSession, row: ReviewItem) -> None:
-    if row.kind in {KIND_ERROR_MATCH, KIND_IDE_BATCH}:
+    if row.kind in {KIND_ERROR_MATCH, KIND_IDE_BATCH, KIND_SKILL_GAP}:
         payload = dict(row.payload or {})
         payload["confirmed"] = False
         row.payload = payload

--- a/apps/core/src/juno/rag/gaps.py
+++ b/apps/core/src/juno/rag/gaps.py
@@ -1,0 +1,223 @@
+"""Skill-gap flags: repeat IDE errors and unfinished reads. Do not nag."""
+
+from __future__ import annotations
+
+import logging
+import re
+from collections import defaultdict
+from dataclasses import dataclass
+from datetime import UTC, datetime, timedelta
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from juno.graph.db import Database
+from juno.hitl.queue import KIND_SKILL_GAP, ReviewQueue
+from juno.models import AppSetting, Capture
+
+logger = logging.getLogger("juno.gaps")
+
+HIGH_CONFIDENCE = 0.7
+MIN_REPEAT = 2
+UNFINISHED_DAYS = 3
+SEEN_PREFIX = "gaps.seen."
+
+
+@dataclass(frozen=True)
+class SkillGap:
+    key: str
+    topic: str
+    kind: str  # repeat_error | unfinished_read
+    count: int
+    capture_ids: list[int]
+    related: list[str]
+    confidence: float
+
+    def seen_key(self) -> str:
+        return f"{SEEN_PREFIX}{self.key}"
+
+
+def topic_key(title: str) -> str:
+    words = re.findall(r"[a-z0-9]+", (title or "").lower())
+    return " ".join(words[:4]) or "untitled"
+
+
+def format_gaps(gaps: list[SkillGap]) -> str:
+    if not gaps:
+        return "No skill-gap flags right now."
+    lines = ["Possible skill gaps:"]
+    for gap in gaps:
+        related = f" Related: {', '.join(gap.related[:3])}." if gap.related else ""
+        lines.append(f"• {gap.topic} ({gap.kind}, {gap.count}x, {gap.confidence:.0%}).{related}")
+    lines.append("Low-confidence flags go to /review. Juno will not nag about the same gap.")
+    return "\n".join(lines)
+
+
+async def find_skill_gaps(db: Database, *, now: datetime | None = None) -> list[SkillGap]:
+    now = now or datetime.now(UTC)
+    captures = await _all_captures(db)
+    gaps: list[SkillGap] = []
+    gaps.extend(_repeat_ide_errors(captures))
+    gaps.extend(_unfinished_reads(captures, now=now))
+    gaps.sort(key=lambda g: (g.confidence, g.count), reverse=True)
+    return gaps[:8]
+
+
+@dataclass(frozen=True)
+class GapApplyResult:
+    queued: int
+    listed: int
+    fresh: tuple[SkillGap, ...]
+
+
+async def apply_skill_gaps(
+    db: Database,
+    gaps: list[SkillGap],
+    *,
+    paused: bool = False,
+) -> GapApplyResult:
+    """Report high-confidence gaps; queue low-confidence HITL. Skip seen keys (no nag)."""
+    queued = 0
+    listed = 0
+    fresh: list[SkillGap] = []
+    if paused:
+        logger.info("skill-gap scan skipped — capture paused")
+        return GapApplyResult(queued=0, listed=0, fresh=())
+    review = ReviewQueue(db)
+    for gap in gaps:
+        if await _already_seen(db, gap.seen_key()):
+            continue
+        fresh.append(gap)
+        if gap.confidence < HIGH_CONFIDENCE:
+            await review.enqueue(
+                kind=KIND_SKILL_GAP,
+                confidence=gap.confidence,
+                payload={
+                    "topic": gap.topic,
+                    "gap_kind": gap.kind,
+                    "count": gap.count,
+                    "capture_ids": gap.capture_ids,
+                    "related": gap.related,
+                    "reason": "Low-confidence skill-gap; confirm it is a real struggle, not noise.",
+                    "confirmed": False,
+                },
+            )
+            queued += 1
+        else:
+            listed += 1
+        await _mark_seen(db, gap.seen_key())
+    return GapApplyResult(queued=queued, listed=listed, fresh=tuple(fresh))
+
+
+def _repeat_ide_errors(captures: list[Capture]) -> list[SkillGap]:
+    buckets: dict[str, list[Capture]] = defaultdict(list)
+    for cap in captures:
+        if cap.source_type != "ide":
+            continue
+        raw = cap.raw_json if isinstance(cap.raw_json, dict) else {}
+        kind = str(raw.get("kind") or "")
+        title = cap.title or cap.text or ""
+        if kind != "cursor_error" and "error" not in title.lower():
+            continue
+        key = topic_key(title)
+        if len(key) < 6:
+            continue
+        buckets[key].append(cap)
+    gaps: list[SkillGap] = []
+    for key, rows in buckets.items():
+        if len(rows) < MIN_REPEAT:
+            continue
+        related = _related_titles(captures, key, exclude={r.id for r in rows})
+        conf = 0.55 if len(rows) == 2 else 0.8
+        gaps.append(
+            SkillGap(
+                key=f"err.{key}",
+                topic=key,
+                kind="repeat_error",
+                count=len(rows),
+                capture_ids=[r.id for r in rows],
+                related=related,
+                confidence=conf,
+            )
+        )
+    return gaps
+
+
+def _unfinished_reads(captures: list[Capture], *, now: datetime) -> list[SkillGap]:
+    cutoff = now - timedelta(days=UNFINISHED_DAYS)
+    by_uri: dict[str, list[Capture]] = defaultdict(list)
+    for cap in captures:
+        if cap.source_type != "browser" or not cap.uri:
+            continue
+        by_uri[cap.uri].append(cap)
+    gaps: list[SkillGap] = []
+    for uri, rows in by_uri.items():
+        if len(rows) != 1:
+            continue
+        cap = rows[0]
+        raw = cap.raw_json if isinstance(cap.raw_json, dict) else {}
+        highlights = raw.get("highlights") if isinstance(raw.get("highlights"), list) else []
+        if highlights:
+            continue
+        when = cap.captured_at
+        if when is None:
+            continue
+        if when.tzinfo is None:
+            when = when.replace(tzinfo=UTC)
+        if when > cutoff:
+            continue
+        title = cap.title or uri
+        key = topic_key(title)
+        related = _related_titles(captures, key, exclude={cap.id})
+        gaps.append(
+            SkillGap(
+                key=f"read.{cap.id}",
+                topic=title[:80],
+                kind="unfinished_read",
+                count=1,
+                capture_ids=[cap.id],
+                related=related,
+                confidence=0.45,
+            )
+        )
+    return gaps
+
+
+def _related_titles(captures: list[Capture], key: str, *, exclude: set[int]) -> list[str]:
+    tokens = set(key.split())
+    found: list[str] = []
+    for cap in captures:
+        if cap.id in exclude:
+            continue
+        title = (cap.title or cap.text or "")[:80]
+        words = set(re.findall(r"[a-z0-9]+", title.lower()))
+        if tokens & words:
+            found.append(title or f"capture #{cap.id}")
+        if len(found) >= 3:
+            break
+    return found
+
+
+async def _all_captures(db: Database) -> list[Capture]:
+    async def load(session: AsyncSession) -> list[Capture]:
+        result = await session.execute(select(Capture).order_by(Capture.id))
+        return list(result.scalars())
+
+    return await db.read(load)
+
+
+async def _already_seen(db: Database, key: str) -> bool:
+    async def fn(session: AsyncSession) -> bool:
+        row = await session.get(AppSetting, key)
+        return row is not None
+
+    return await db.read(fn)
+
+
+async def _mark_seen(db: Database, key: str) -> None:
+    async def fn(session: AsyncSession) -> None:
+        row = await session.get(AppSetting, key)
+        if row is None:
+            session.add(AppSetting(key=key, value="true"))
+
+    await db.write(fn)

--- a/apps/core/src/juno/runtime.py
+++ b/apps/core/src/juno/runtime.py
@@ -22,6 +22,7 @@ from juno.bot.handlers import (
     digest_cmd,
     document_msg,
     drafts_cmd,
+    gaps_cmd,
     help_cmd,
     jobs_cmd,
     pause_cmd,
@@ -67,6 +68,7 @@ def build_telegram_application(settings: Settings) -> Application | None:
     app.add_handler(CommandHandler("review", review_cmd))
     app.add_handler(CommandHandler("cards", cards_cmd))
     app.add_handler(CommandHandler("drafts", drafts_cmd))
+    app.add_handler(CommandHandler("gaps", gaps_cmd))
     app.add_handler(CallbackQueryHandler(review_callback, pattern=r"^rev:"))
     app.add_handler(CallbackQueryHandler(cards_callback, pattern=r"^srs:"))
     app.add_handler(MessageHandler(filters.VOICE, voice_msg))

--- a/apps/core/tests/test_bot.py
+++ b/apps/core/tests/test_bot.py
@@ -257,6 +257,7 @@ def test_build_telegram_application_registers_commands(allowed_settings):
         "review",
         "cards",
         "drafts",
+        "gaps",
     }
 
 
@@ -292,6 +293,7 @@ async def test_start_and_help_reply_for_allowlisted_user(allowed_settings):
     assert "/review" in body
     assert "/cards" in body
     assert "/drafts" in body
+    assert "/gaps" in body
     assert "Approve" in body
 
 

--- a/apps/core/tests/test_gaps.py
+++ b/apps/core/tests/test_gaps.py
@@ -1,0 +1,92 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+
+import pytest
+
+from juno.graph.db import Database
+from juno.hitl.queue import KIND_SKILL_GAP, ReviewQueue
+from juno.models import Capture
+from juno.rag.gaps import apply_skill_gaps, find_skill_gaps, format_gaps
+
+
+@pytest.fixture
+async def db(settings):
+    database = Database(settings)
+    await database.migrate()
+    yield database
+    await database.dispose()
+
+
+async def _add(
+    db: Database,
+    *,
+    source: str,
+    title: str,
+    kind: str | None = None,
+    uri: str | None = None,
+    captured_at: datetime | None = None,
+) -> Capture:
+    async def write(session):
+        raw = {"kind": kind} if kind else {}
+        row = Capture(
+            source_type=source,
+            title=title,
+            text=title,
+            uri=uri,
+            raw_json=raw or None,
+            status="committed",
+            captured_at=captured_at or datetime.now(UTC),
+        )
+        session.add(row)
+        await session.flush()
+        return row
+
+    return await db.write(write)
+
+
+@pytest.mark.asyncio
+async def test_repeat_ide_error_is_high_confidence_gap(db):
+    await _add(db, source="ide", title="sqlite database is locked today", kind="cursor_error")
+    await _add(db, source="ide", title="sqlite database is locked tonight", kind="cursor_error")
+    await _add(db, source="ide", title="sqlite database is locked still", kind="cursor_error")
+    await _add(db, source="upload", title="notes on sqlite locks")
+    gaps = await find_skill_gaps(db)
+    assert any(g.kind == "repeat_error" and g.confidence >= 0.7 for g in gaps)
+    text = format_gaps(gaps)
+    assert "sqlite" in text
+    assert "notes on sqlite" in text.lower() or "Related" in text
+
+
+@pytest.mark.asyncio
+async def test_unfinished_read_queues_hitl_once(db):
+    old = datetime.now(UTC) - timedelta(days=5)
+    await _add(
+        db,
+        source="browser",
+        title="Deep dive into ownership",
+        uri="https://example.test/own",
+        captured_at=old,
+    )
+    gaps = await find_skill_gaps(db, now=datetime.now(UTC))
+    unfinished = [g for g in gaps if g.kind == "unfinished_read"]
+    assert unfinished
+    first = await apply_skill_gaps(db, gaps, paused=False)
+    assert first.queued >= 1
+    nxt = await ReviewQueue(db).next_open()
+    assert nxt is not None
+    assert nxt.kind == KIND_SKILL_GAP
+    assert "will not nag" in nxt.summary()
+    second = await apply_skill_gaps(db, gaps, paused=False)
+    assert second.queued == 0
+    assert second.listed == 0
+
+
+@pytest.mark.asyncio
+async def test_pause_skips_gap_apply(db):
+    await _add(db, source="ide", title="boom error traceback a", kind="cursor_error")
+    await _add(db, source="ide", title="boom error traceback b", kind="cursor_error")
+    gaps = await find_skill_gaps(db)
+    skipped = await apply_skill_gaps(db, gaps, paused=True)
+    assert skipped.queued == 0
+    assert await ReviewQueue(db).next_open() is None

--- a/docs/next-work.md
+++ b/docs/next-work.md
@@ -196,14 +196,14 @@ Milestone: [M5: v2.0 Polish & Extensions](https://github.com/Anna-Hax/JUNO/miles
 | 2 | [#107](https://github.com/Anna-Hax/JUNO/issues/107) | Draft artifacts scaffold — draft kinds + never auto-publish — ✅ [session 50](sessions/50-session-draft-scaffold.md) |
 | 3 | [#108](https://github.com/Anna-Hax/JUNO/issues/108) | Flashcards / spaced repetition from highlights — ✅ [session 51](sessions/51-session-flashcards.md) |
 | 4 | [#109](https://github.com/Anna-Hax/JUNO/issues/109) | Auto-drafted dev journal / README drafts — ✅ [session 52](sessions/52-session-journal-drafts.md) |
-| 5 | [#110](https://github.com/Anna-Hax/JUNO/issues/110) | Skill-gap tracking |
+| 5 | [#110](https://github.com/Anna-Hax/JUNO/issues/110) | Skill-gap tracking — ✅ [session 53](sessions/53-session-skill-gaps.md) |
 | 6 | [#111](https://github.com/Anna-Hax/JUNO/issues/111) | Trust dial — per-category auto-commit thresholds |
 | 7 | [#112](https://github.com/Anna-Hax/JUNO/issues/112) | Optional Slack forward into upload space |
 | 8 | [#113](https://github.com/Anna-Hax/JUNO/issues/113) | Prune-with-confirm — retention / destructive graph cleanup |
 | 9 | [#114](https://github.com/Anna-Hax/JUNO/issues/114) | Module health — polish jobs freshness + respect /pause |
 | 10 | [#115](https://github.com/Anna-Hax/JUNO/issues/115) | M5 gate — polish tests, ADR, README, v2.0 release gate |
 
-**First coding task:** #106–#109 ✅. Next: skill-gap tracking ([#110](https://github.com/Anna-Hax/JUNO/issues/110)).
+**First coding task:** #106–#110 ✅. Next: trust dial ([#111](https://github.com/Anna-Hax/JUNO/issues/111)).
 
 ### M5 design constraints (do not violate)
 

--- a/docs/sessions/02-codebase-map.md
+++ b/docs/sessions/02-codebase-map.md
@@ -41,14 +41,14 @@ JUNO/
 | Alembic | `alembic/` + `alembic.ini` | Head `0003` (`flashcards`) after `0002` / `0001` ([ADR-03](../adr/003-alembic.md)) |
 | LLM | `llm/embedder.py`, `llm/chat.py`, `llm/transcribe.py` | MiniLM (optional extra) + stub embedder; Ollama / OpenAI-compat / offline chat; opt-in voice STT (ADR-08) |
 | Ingest | `ingest/extractors.py`, `chunking.py`, `pipeline.py`, `watcher.py` | File/URL extract, chunk, persist, inbox watch ([#16](https://github.com/Anna-Hax/JUNO/issues/16)) |
-| RAG | `rag/engine.py` | Vector retrieve, join captures, sourced answer + confidence ([#17](https://github.com/Anna-Hax/JUNO/issues/17)); Telegram query uses this |
+| RAG | `rag/engine.py`, `rag/gaps.py` | Vector retrieve, sourced answers ([#17](https://github.com/Anna-Hax/JUNO/issues/17)); skill-gap flags ([#110](https://github.com/Anna-Hax/JUNO/issues/110)) |
 | HITL | `hitl/queue.py` | Review queue; merges stay pending until Approve ([#20](https://github.com/Anna-Hax/JUNO/issues/20)); drafts never auto-publish ([#106](https://github.com/Anna-Hax/JUNO/issues/106)) |
 
 ### Entry points
 
 - `uv run juno serve` → `runtime.main_sync()`
 - `uv run juno db-init` → `Database.migrate()` (Alembic `upgrade head`, or stamp legacy `create_all` DBs)
-- Tests: `test_foundation.py`, `test_migrations.py`, `test_ingest.py`, `test_vectors.py`, `test_embedder.py`, `test_chat.py`, `test_rag.py`, `test_bot.py`, `test_review.py`, `test_bot_review.py`, `test_api.py`, `test_write_queue.py`, `test_integration.py`, `test_export.py`, `test_jobs.py`, `test_transcribe.py`, `test_drafts.py`, `test_flashcards.py`, `test_journal.py`
+- Tests: `test_foundation.py`, `test_migrations.py`, `test_ingest.py`, `test_vectors.py`, `test_embedder.py`, `test_chat.py`, `test_rag.py`, `test_bot.py`, `test_review.py`, `test_bot_review.py`, `test_api.py`, `test_write_queue.py`, `test_integration.py`, `test_export.py`, `test_jobs.py`, `test_transcribe.py`, `test_drafts.py`, `test_flashcards.py`, `test_journal.py`, `test_gaps.py`
 
 ### Dependencies
 

--- a/docs/sessions/53-session-skill-gaps.md
+++ b/docs/sessions/53-session-skill-gaps.md
@@ -1,0 +1,19 @@
+# Session 53 — Skill-gap tracking (#110)
+
+**Date:** 2026-09-05  
+**Issue:** [#110](https://github.com/Anna-Hax/JUNO/issues/110)  
+**Branch:** `feat/skill-gaps-110`
+
+## What changed
+
+- `/gaps` finds repeat IDE errors and unfinished browser reads (no highlights, stale URI).
+- High-confidence repeats are listed; low-confidence flags go to `/review` (`skill_gap`).
+- Seen keys persist so Juno does not nag. `/pause` skips the scan.
+
+## Verify
+
+```powershell
+cd apps/core
+$env:EMBEDDING_BACKEND='stub'
+uv run pytest tests/test_gaps.py -q
+```

--- a/docs/sessions/README.md
+++ b/docs/sessions/README.md
@@ -58,6 +58,7 @@ Living notes for what was implemented, how GitHub is set up, and what to do next
 | [50-session-draft-scaffold.md](50-session-draft-scaffold.md) | **#107** — Draft kinds + never auto-publish |
 | [51-session-flashcards.md](51-session-flashcards.md) | **#108** — Flashcards / SRS from highlights |
 | [52-session-journal-drafts.md](52-session-journal-drafts.md) | **#109** — IDE journal / README drafts |
+| [53-session-skill-gaps.md](53-session-skill-gaps.md) | **#110** — Skill-gap tracking |
 | [v1.0-release-gate.md](../v1.0-release-gate.md) | M1 checklist (all P0 closed) |
 | [v1.1-release-gate.md](../v1.1-release-gate.md) | M2 checklist (browser capture) |
 | [v1.2-release-gate.md](../v1.2-release-gate.md) | M3 checklist (IDE capture) |


### PR DESCRIPTION
## Summary
- `/gaps` finds repeat IDE errors and unfinished browser reads, with related capture titles.
- Low-confidence flags go to HITL `skill_gap`; seen keys prevent nagging. `/pause` skips the scan.

## Linked issue
Closes #110

## Test plan
- [x] `uv run pytest tests/test_gaps.py`
- [x] `uv run pytest -q` (186 passed)
- [x] `uv run ruff check src tests`
- [ ] Manual: ingest two similar IDE errors, `/gaps`, then `/review` for the low-confidence flag