### PR TITLE
feat(hitl): add per-category trust dials with locked mobile and drafts

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ uv run juno wipe --confirm wipe-all-data
 - API: `http://127.0.0.1:8787/health` (no token). `/status` `/ingest` `/search` need `Authorization: Bearer <JUNO_API_TOKEN>`. Serve refuses the example `change-me` token and any non-loopback `JUNO_API_HOST`.
 - Token-gated `GET /status` reports the live embedder (model / backend / dimensions) and LLM health (`llm_healthy`, `llm_provider`, `llm_model`). If Ollama is down, `llm_healthy` is false and answers stay retrieve-only.
 - Token-gated `GET /search?q=` returns citations + confidence (sourced answer when the LLM is healthy).
-- Bot runs only while this process (and PC) is on. Telegram queues updates ~24h; longer downtime can drop messages. Commands: `/start` `/help` `/digest today|week` `/jobs` `/pause` `/resume` `/status` `/review` `/cards` `/drafts journal|readme` `/gaps`. Forward a message, send a link, attach a doc, or send a **voice note** to capture; other text queries the graph. Voice STT is opt-in ([ADR-08](docs/adr/008-voice-transcription.md)). New flashcards and journal/README drafts stay HITL until Approve; `/drafts` never writes git files unattended.
+- Bot runs only while this process (and PC) is on. Telegram queues updates ~24h; longer downtime can drop messages. Commands: `/start` `/help` `/digest today|week` `/jobs` `/pause` `/resume` `/status` `/review` `/cards` `/drafts journal|readme` `/gaps` `/trust`. Forward a message, send a link, attach a doc, or send a **voice note** to capture; other text queries the graph. Voice STT is opt-in ([ADR-08](docs/adr/008-voice-transcription.md)). New flashcards and journal/README drafts stay HITL until Approve; `/drafts` never writes git files unattended.
 
 ### Tests
 

--- a/apps/core/src/juno/bot/handlers.py
+++ b/apps/core/src/juno/bot/handlers.py
@@ -41,6 +41,7 @@ HELP_TEXT = (
     "/cards — flashcards due (Again/Good); new cards stay drafts until /review\n"
     "/drafts journal|readme — queue an IDE journal or README draft (never writes files)\n"
     "/gaps — repeat IDE errors / unfinished reads (low-confidence stays in /review)\n"
+    "/trust — per-category auto-commit dials (mobile/drafts stay gated)\n"
     "Ask a question to search the graph.\n"
     "Forward a message, send a link, attach a doc, or send a voice note to capture."
 )
@@ -168,6 +169,33 @@ async def gaps_cmd(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
     await update.message.reply_text(format_gaps(list(result.fresh)) + extra)
 
 
+async def trust_cmd(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+    if not update.message or not _authorized(update, context):
+        return
+    svc = _services(context)
+    if svc is None or svc.db is None:
+        await update.message.reply_text("Trust dials unavailable (database not attached).")
+        return
+    from juno.hitl.trust import CATEGORIES, format_trust, list_dials, set_auto
+
+    args = [a.lower() for a in (context.args or [])]
+    if not args:
+        dials = await list_dials(svc.db)
+        await update.message.reply_text(format_trust(dials))
+        return
+    if len(args) != 2 or args[0] not in CATEGORIES or args[1] not in {"on", "off"}:
+        await update.message.reply_text(
+            "Usage: /trust   or   /trust merge|browser|ide_error on|off"
+        )
+        return
+    try:
+        dial = await set_auto(svc.db, args[0], enabled=args[1] == "on")
+    except ValueError as exc:
+        await update.message.reply_text(str(exc))
+        return
+    await update.message.reply_text(dial.summary())
+
+
 async def pause_cmd(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
     if not update.message or not _authorized(update, context):
         return
@@ -218,21 +246,25 @@ async def status_cmd(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None
     health: list = []
     if svc.db is not None:
         health = await all_module_health(svc.db)
-    await update.message.reply_text(
-        format_status(
-            paused=svc.is_paused(),
-            llm_healthy=llm_healthy,
-            llm_provider=getattr(chat, "name", None) or settings.llm_provider,
-            llm_model=getattr(chat, "model", None) or settings.llm_model,
-            embedding_model=getattr(embedder, "model_id", settings.embedding_model),
-            embedding_backend=getattr(embedder, "backend", settings.embedding_backend),
-            chroma_collection=chroma_collection,
-            chroma_count=chroma_count,
-            health=health,
-            api_host=settings.juno_api_host,
-            api_port=settings.juno_api_port,
-        )
+    body = format_status(
+        paused=svc.is_paused(),
+        llm_healthy=llm_healthy,
+        llm_provider=getattr(chat, "name", None) or settings.llm_provider,
+        llm_model=getattr(chat, "model", None) or settings.llm_model,
+        embedding_model=getattr(embedder, "model_id", settings.embedding_model),
+        embedding_backend=getattr(embedder, "backend", settings.embedding_backend),
+        chroma_collection=chroma_collection,
+        chroma_count=chroma_count,
+        health=health,
+        api_host=settings.juno_api_host,
+        api_port=settings.juno_api_port,
     )
+    if svc.db is not None:
+        from juno.hitl.trust import list_dials
+
+        dials = await list_dials(svc.db)
+        body = body + "\nTrust: " + "; ".join(d.summary() for d in dials)
+    await update.message.reply_text(body)
 
 
 async def text_msg(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:

--- a/apps/core/src/juno/hitl/queue.py
+++ b/apps/core/src/juno/hitl/queue.py
@@ -168,8 +168,12 @@ class ReviewQueue:
     ) -> ReviewCard:
         """Create nodes (if needed) plus a *pending* edge and a review item.
 
-        The edge is not committed here — that requires ``decide(..., "approve")``.
+        The edge is not committed here — that requires ``decide(..., "approve")``,
+        unless the merge trust dial is on and confidence is high.
         """
+        from juno.hitl.trust import should_auto_commit
+
+        auto = await should_auto_commit(self.db, "merge", confidence)
 
         async def write(session: AsyncSession) -> ReviewCard:
             src = await _get_or_create_node(session, from_name.strip(), from_kind)
@@ -192,11 +196,16 @@ class ReviewQueue:
                     "edge_id": edge.id,
                     "relation": relation,
                     "reason": reason,
+                    "auto_committed": auto,
                 },
-                status=STATUS_PENDING,
+                status=STATUS_DECIDED if auto else STATUS_PENDING,
+                decision="approve" if auto else None,
+                decided_at=datetime.now(UTC) if auto else None,
             )
             session.add(item)
             await session.flush()
+            if auto:
+                edge.status = EDGE_COMMITTED
             return _card(item)
 
         return await self.db.write(write)
@@ -384,7 +393,17 @@ class ReviewQueue:
                 next_card=next_card,
             )
 
-        return await self.db.write(write)
+        result = await self.db.write(write)
+        if not result.already_decided and result.card.decision == "approve" and result.applied:
+            from juno.hitl.trust import record_success
+
+            category = {
+                KIND_MERGE: "merge",
+                KIND_ERROR_MATCH: "ide_error",
+            }.get(result.card.kind)
+            if category:
+                await record_success(self.db, category)
+        return result
 
 
 def _card(row: ReviewItem) -> ReviewCard:

--- a/apps/core/src/juno/hitl/trust.py
+++ b/apps/core/src/juno/hitl/trust.py
@@ -1,0 +1,142 @@
+"""Per-category trust dials (PRD §8 P2). Mobile and drafts stay gated."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from juno.graph.db import Database
+from juno.models import AppSetting
+
+CATEGORIES = ("merge", "browser", "ide_error", "mobile", "drafts")
+LOCKED = frozenset({"mobile", "drafts"})
+DEFAULT_THRESHOLD = 5
+HIGH_CONFIDENCE = 0.8
+
+
+@dataclass(frozen=True)
+class TrustDial:
+    category: str
+    successes: int
+    threshold: int
+    auto: bool
+    locked: bool
+
+    def summary(self) -> str:
+        if self.locked:
+            return f"{self.category}: gated (always HITL)"
+        mode = "auto-commit on" if self.auto else "HITL"
+        return f"{self.category}: {mode} ({self.successes}/{self.threshold} approved)"
+
+
+def _success_key(category: str) -> str:
+    return f"trust.{category}.successes"
+
+
+def _auto_key(category: str) -> str:
+    return f"trust.{category}.auto"
+
+
+def _threshold_key(category: str) -> str:
+    return f"trust.{category}.threshold"
+
+
+async def get_dial(db: Database, category: str) -> TrustDial:
+    if category not in CATEGORIES:
+        raise ValueError(f"unknown trust category {category!r}")
+
+    async def load(session: AsyncSession) -> TrustDial:
+        return await _dial_from_session(session, category)
+
+    return await db.read(load)
+
+
+async def list_dials(db: Database) -> list[TrustDial]:
+    async def load(session: AsyncSession) -> list[TrustDial]:
+        return [await _dial_from_session(session, cat) for cat in CATEGORIES]
+
+    return await db.read(load)
+
+
+async def record_success(db: Database, category: str) -> TrustDial:
+    if category not in CATEGORIES:
+        raise ValueError(f"unknown trust category {category!r}")
+
+    async def write(session: AsyncSession) -> TrustDial:
+        dial = await _dial_from_session(session, category)
+        successes = dial.successes + 1
+        await _put(session, _success_key(category), str(successes))
+        auto = dial.auto
+        if not dial.locked and successes >= dial.threshold:
+            auto = True
+            await _put(session, _auto_key(category), "true")
+        return TrustDial(
+            category=category,
+            successes=successes,
+            threshold=dial.threshold,
+            auto=auto,
+            locked=dial.locked,
+        )
+
+    return await db.write(write)
+
+
+async def set_auto(db: Database, category: str, enabled: bool) -> TrustDial:
+    if category not in CATEGORIES:
+        raise ValueError(f"unknown trust category {category!r}")
+    if category in LOCKED and enabled:
+        raise ValueError(f"{category} stays gated")
+
+    async def write(session: AsyncSession) -> TrustDial:
+        await _put(session, _auto_key(category), "true" if enabled else "false")
+        return await _dial_from_session(session, category)
+
+    return await db.write(write)
+
+
+async def should_auto_commit(
+    db: Database,
+    category: str,
+    confidence: float,
+) -> bool:
+    if category in LOCKED:
+        return False
+    dial = await get_dial(db, category)
+    return dial.auto and confidence >= HIGH_CONFIDENCE
+
+
+def format_trust(dials: list[TrustDial]) -> str:
+    lines = ["Trust dials (per category, not a global switch):"]
+    lines.extend(f"• {d.summary()}" for d in dials)
+    lines.append("Toggle: /trust merge|browser|ide_error on|off")
+    lines.append("mobile and drafts stay gated.")
+    return "\n".join(lines)
+
+
+async def _dial_from_session(session: AsyncSession, category: str) -> TrustDial:
+    successes = int(await _get(session, _success_key(category), "0"))
+    threshold = int(await _get(session, _threshold_key(category), str(DEFAULT_THRESHOLD)))
+    auto_raw = await _get(session, _auto_key(category), "false")
+    locked = category in LOCKED
+    auto = (not locked) and auto_raw.strip().lower() in {"1", "true", "yes", "on"}
+    return TrustDial(
+        category=category,
+        successes=successes,
+        threshold=threshold,
+        auto=auto,
+        locked=locked,
+    )
+
+
+async def _get(session: AsyncSession, key: str, default: str) -> str:
+    row = await session.get(AppSetting, key)
+    return default if row is None else row.value
+
+
+async def _put(session: AsyncSession, key: str, value: str) -> None:
+    row = await session.get(AppSetting, key)
+    if row is None:
+        session.add(AppSetting(key=key, value=value))
+    else:
+        row.value = value

--- a/apps/core/src/juno/runtime.py
+++ b/apps/core/src/juno/runtime.py
@@ -30,6 +30,7 @@ from juno.bot.handlers import (
     start_cmd,
     status_cmd,
     text_msg,
+    trust_cmd,
     voice_msg,
 )
 from juno.bot.review import review_callback, review_cmd
@@ -69,6 +70,7 @@ def build_telegram_application(settings: Settings) -> Application | None:
     app.add_handler(CommandHandler("cards", cards_cmd))
     app.add_handler(CommandHandler("drafts", drafts_cmd))
     app.add_handler(CommandHandler("gaps", gaps_cmd))
+    app.add_handler(CommandHandler("trust", trust_cmd))
     app.add_handler(CallbackQueryHandler(review_callback, pattern=r"^rev:"))
     app.add_handler(CallbackQueryHandler(cards_callback, pattern=r"^srs:"))
     app.add_handler(MessageHandler(filters.VOICE, voice_msg))

--- a/apps/core/tests/test_bot.py
+++ b/apps/core/tests/test_bot.py
@@ -258,6 +258,7 @@ def test_build_telegram_application_registers_commands(allowed_settings):
         "cards",
         "drafts",
         "gaps",
+        "trust",
     }
 
 
@@ -294,6 +295,7 @@ async def test_start_and_help_reply_for_allowlisted_user(allowed_settings):
     assert "/cards" in body
     assert "/drafts" in body
     assert "/gaps" in body
+    assert "/trust" in body
     assert "Approve" in body
 
 

--- a/apps/core/tests/test_trust.py
+++ b/apps/core/tests/test_trust.py
@@ -1,0 +1,69 @@
+from __future__ import annotations
+
+import pytest
+
+from juno.graph.db import Database
+from juno.hitl.queue import EDGE_COMMITTED, EDGE_PENDING, ReviewQueue
+from juno.hitl.trust import get_dial, set_auto, should_auto_commit
+from juno.models import Edge
+
+
+@pytest.fixture
+async def db(settings):
+    database = Database(settings)
+    await database.migrate()
+    yield database
+    await database.dispose()
+
+
+@pytest.mark.asyncio
+async def test_mobile_and_drafts_stay_gated(db):
+    with pytest.raises(ValueError, match="gated"):
+        await set_auto(db, "mobile", True)
+    with pytest.raises(ValueError, match="gated"):
+        await set_auto(db, "drafts", True)
+    assert await should_auto_commit(db, "mobile", 0.99) is False
+    assert await should_auto_commit(db, "drafts", 0.99) is False
+
+
+@pytest.mark.asyncio
+async def test_merge_auto_commit_after_enough_approvals(db):
+    queue = ReviewQueue(db)
+    assert await should_auto_commit(db, "merge", 0.95) is False
+    for i in range(5):
+        card = await queue.propose_merge(from_name=f"A{i}", to_name=f"B{i}", confidence=0.4)
+        await queue.decide(card.id, "approve")
+    dial = await get_dial(db, "merge")
+    assert dial.successes == 5
+    assert dial.auto is True
+    assert await should_auto_commit(db, "merge", 0.95) is True
+    assert await should_auto_commit(db, "merge", 0.5) is False
+
+    auto = await queue.propose_merge(from_name="Rust", to_name="Ownership", confidence=0.9)
+    assert auto.status == "decided"
+    assert auto.payload.get("auto_committed") is True
+    edge_id = int(auto.payload["edge_id"])
+
+    async def load(session):
+        edge = await session.get(Edge, edge_id)
+        return edge.status if edge else None
+
+    assert await db.read(load) == EDGE_COMMITTED
+
+
+@pytest.mark.asyncio
+async def test_operator_can_turn_merge_auto_off(db):
+    queue = ReviewQueue(db)
+    for i in range(5):
+        card = await queue.propose_merge(from_name=f"x{i}", to_name=f"y{i}", confidence=0.4)
+        await queue.decide(card.id, "approve")
+    await set_auto(db, "merge", False)
+    card = await queue.propose_merge(from_name="Keep", to_name="Pending", confidence=0.99)
+    assert card.status == "pending"
+    edge_id = int(card.payload["edge_id"])
+
+    async def load(session):
+        edge = await session.get(Edge, edge_id)
+        return edge.status if edge else None
+
+    assert await db.read(load) == EDGE_PENDING

--- a/docs/adr/010-trust-dials.md
+++ b/docs/adr/010-trust-dials.md
@@ -1,0 +1,26 @@
+# ADR-10: Per-category trust dials
+
+## Status
+
+Accepted (M5 / #111)
+
+## Date
+
+2026-09-05
+
+## Context
+
+PRD §8 P2: as the agent earns confidence in a category, that category's gate can loosen while tighter categories (mobile, drafts) stay gated. This must be an **explicit per-category setting**, not a global switch.
+
+## Decision
+
+1. Store dials in `settings` (`trust.{category}.successes` / `.auto` / `.threshold`). No extra table.
+2. Categories: `merge`, `browser`, `ide_error`, `mobile`, `drafts`.
+3. **`mobile` and `drafts` are locked** — `/trust mobile on` is rejected; `should_auto_commit` is always false.
+4. Five successful Approve taps on `merge` or `ide_error` turns auto-commit **on** for that category. High-confidence (`>= 0.8`) merges then commit without a pending `/review` card (audit row still stored as decided).
+5. Operator can `/trust merge|browser|ide_error on|off`. `/status` lists current dials.
+
+## Consequences
+
+- Early graphs stay HITL-heavy; a month of good merge reviews can loosen only merges.
+- Draft auto-publish remains forbidden ([ADR-09](009-draft-artifacts-hitl.md)).

--- a/docs/next-work.md
+++ b/docs/next-work.md
@@ -197,13 +197,13 @@ Milestone: [M5: v2.0 Polish & Extensions](https://github.com/Anna-Hax/JUNO/miles
 | 3 | [#108](https://github.com/Anna-Hax/JUNO/issues/108) | Flashcards / spaced repetition from highlights — ✅ [session 51](sessions/51-session-flashcards.md) |
 | 4 | [#109](https://github.com/Anna-Hax/JUNO/issues/109) | Auto-drafted dev journal / README drafts — ✅ [session 52](sessions/52-session-journal-drafts.md) |
 | 5 | [#110](https://github.com/Anna-Hax/JUNO/issues/110) | Skill-gap tracking — ✅ [session 53](sessions/53-session-skill-gaps.md) |
-| 6 | [#111](https://github.com/Anna-Hax/JUNO/issues/111) | Trust dial — per-category auto-commit thresholds |
+| 6 | [#111](https://github.com/Anna-Hax/JUNO/issues/111) | Trust dial — per-category auto-commit thresholds — ✅ [session 54](sessions/54-session-trust-dial.md) |
 | 7 | [#112](https://github.com/Anna-Hax/JUNO/issues/112) | Optional Slack forward into upload space |
 | 8 | [#113](https://github.com/Anna-Hax/JUNO/issues/113) | Prune-with-confirm — retention / destructive graph cleanup |
 | 9 | [#114](https://github.com/Anna-Hax/JUNO/issues/114) | Module health — polish jobs freshness + respect /pause |
 | 10 | [#115](https://github.com/Anna-Hax/JUNO/issues/115) | M5 gate — polish tests, ADR, README, v2.0 release gate |
 
-**First coding task:** #106–#110 ✅. Next: trust dial ([#111](https://github.com/Anna-Hax/JUNO/issues/111)).
+**First coding task:** #106–#111 ✅. Next: optional Slack forward ([#112](https://github.com/Anna-Hax/JUNO/issues/112)).
 
 ### M5 design constraints (do not violate)
 

--- a/docs/sessions/02-codebase-map.md
+++ b/docs/sessions/02-codebase-map.md
@@ -42,7 +42,7 @@ JUNO/
 | LLM | `llm/embedder.py`, `llm/chat.py`, `llm/transcribe.py` | MiniLM (optional extra) + stub embedder; Ollama / OpenAI-compat / offline chat; opt-in voice STT (ADR-08) |
 | Ingest | `ingest/extractors.py`, `chunking.py`, `pipeline.py`, `watcher.py` | File/URL extract, chunk, persist, inbox watch ([#16](https://github.com/Anna-Hax/JUNO/issues/16)) |
 | RAG | `rag/engine.py`, `rag/gaps.py` | Vector retrieve, sourced answers ([#17](https://github.com/Anna-Hax/JUNO/issues/17)); skill-gap flags ([#110](https://github.com/Anna-Hax/JUNO/issues/110)) |
-| HITL | `hitl/queue.py` | Review queue; merges stay pending until Approve ([#20](https://github.com/Anna-Hax/JUNO/issues/20)); drafts never auto-publish ([#106](https://github.com/Anna-Hax/JUNO/issues/106)) |
+| HITL | `hitl/queue.py`, `hitl/trust.py` | Review queue; per-category trust dials (ADR-10) |
 
 ### Entry points
 

--- a/docs/sessions/54-session-trust-dial.md
+++ b/docs/sessions/54-session-trust-dial.md
@@ -1,0 +1,19 @@
+# Session 54 — Trust dial (#111)
+
+**Date:** 2026-09-05  
+**Issue:** [#111](https://github.com/Anna-Hax/JUNO/issues/111)  
+**Branch:** `feat/trust-dial-111`
+
+## What changed
+
+- Per-category dials in `settings`; `/trust` and `/status` show them.
+- Five approved merges turn merge auto-commit on for high-confidence proposes.
+- `mobile` and `drafts` stay gated. [ADR-10](../adr/010-trust-dials.md).
+
+## Verify
+
+```powershell
+cd apps/core
+$env:EMBEDDING_BACKEND='stub'
+uv run pytest tests/test_trust.py -q
+```

--- a/docs/sessions/README.md
+++ b/docs/sessions/README.md
@@ -59,6 +59,7 @@ Living notes for what was implemented, how GitHub is set up, and what to do next
 | [51-session-flashcards.md](51-session-flashcards.md) | **#108** — Flashcards / SRS from highlights |
 | [52-session-journal-drafts.md](52-session-journal-drafts.md) | **#109** — IDE journal / README drafts |
 | [53-session-skill-gaps.md](53-session-skill-gaps.md) | **#110** — Skill-gap tracking |
+| [54-session-trust-dial.md](54-session-trust-dial.md) | **#111** — Trust dial |
 | [v1.0-release-gate.md](../v1.0-release-gate.md) | M1 checklist (all P0 closed) |
 | [v1.1-release-gate.md](../v1.1-release-gate.md) | M2 checklist (browser capture) |
 | [v1.2-release-gate.md](../v1.2-release-gate.md) | M3 checklist (IDE capture) |


### PR DESCRIPTION
## Summary
- Per-category trust dials in `settings`; `/trust` and `/status` show them (ADR-10).
- Five successful merge approvals turn merge auto-commit on for high-confidence proposes. `mobile` and `drafts` cannot be loosened.

## Linked issue
Closes #111

## Test plan
- [x] `uv run pytest tests/test_trust.py tests/test_review.py`
- [x] `uv run pytest -q` (189 passed)
- [x] `uv run ruff check src tests`
- [ ] Manual: `/trust`, approve five merges, then a high-confidence merge auto-commits