### PR TITLE
feat(ingest): opt-in Slack.com link forward through HITL

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -47,6 +47,9 @@ EMBEDDING_BACKEND=sentence_transformers
 # Spike S5: enqueue one pending draft at serve start; leave off after proving
 # JUNO_DRAFTS_SMOKE=false
 
+# M5 Slack — opt-in slack.com link ingest into the upload space (not a workspace bot)
+# JUNO_SLACK_FORWARD=false
+
 # IDE adapter (apps/ide) — HTTP client only; empty path = platform Cursor default
 # JUNO_CURSOR_VSCDB=
 # JUNO_CURSOR_WORKSPACE_STORAGE=

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Personal knowledge-graph agent: passively (and manually) capture what you read, 
 - **Chroma** for vectors — persistent client, one collection per embedding model ([ADR-04](docs/adr/004-chroma-collections.md)); **stub embedder** in CI
 - **Browser extension** (`apps/extension`): MV3 loopback client ([ADR-05](docs/adr/005-browser-extension-client.md)); Spike S2 captures tabs → `POST /ingest`
 - **IDE adapter** (`apps/ide`): read-only Cursor `state.vscdb` client ([ADR-06](docs/adr/006-ide-adapter-client.md)); poll/watch posts chats + terminal errors → `POST /ingest` (runbook in [`apps/ide/README.md`](apps/ide/README.md))
-- **Inbox** (`inbox/`): drop `.txt` / `.md` / `.pdf` / `.url` (or a one-line http(s) text file). `juno serve` watches the folder; good files move to `inbox/.processed/`, unreadable PDFs to `inbox/.failed/`.
+- **Inbox** (`inbox/`): drop `.txt` / `.md` / `.pdf` / `.url` (or a one-line http(s) text file). `juno serve` watches the folder; good files move to `inbox/.processed/`, unreadable PDFs to `inbox/.failed/`. Optional Slack.com links via Telegram when `JUNO_SLACK_FORWARD=true` (not a workspace bot; [ADR-11](docs/adr/011-slack-forward.md)).
 - **HITL** (`/review`): inline Approve / Reject / Skip for pending graph merges, sensitive batches, and auto-generated **drafts** (never auto-published; [ADR-09](docs/adr/009-draft-artifacts-hitl.md))
 
 ## Prerequisites

--- a/apps/core/src/juno/bot/handlers.py
+++ b/apps/core/src/juno/bot/handlers.py
@@ -20,6 +20,7 @@ from juno.bot.services import (
     format_digest,
     format_status,
     is_forwarded,
+    is_slack_url,
     recent_captures,
     single_http_url,
     user_allowed,
@@ -43,7 +44,8 @@ HELP_TEXT = (
     "/gaps — repeat IDE errors / unfinished reads (low-confidence stays in /review)\n"
     "/trust — per-category auto-commit dials (mobile/drafts stay gated)\n"
     "Ask a question to search the graph.\n"
-    "Forward a message, send a link, attach a doc, or send a voice note to capture."
+    "Forward a message, send a link, attach a doc, or send a voice note to capture.\n"
+    "Slack.com links ingest only when JUNO_SLACK_FORWARD=true (not a workspace bot)."
 )
 
 
@@ -364,6 +366,22 @@ async def _capture_text(update: Update, context: ContextTypes.DEFAULT_TYPE, text
     url = single_http_url(text)
     title = None
     try:
+        if url and is_slack_url(url):
+            if not svc.settings.juno_slack_forward:
+                await update.message.reply_text(
+                    "Slack forward is off. Set JUNO_SLACK_FORWARD=true to ingest slack.com "
+                    "links into the upload space (not a live workspace listener)."
+                )
+                return
+            result = await svc.pipeline.ingest_url(url, source_type="slack")
+            extra = await _queue_mobile_review(
+                svc,
+                result,
+                title="Slack forward",
+                reason="Opt-in Slack link — confirm this batch belongs in the graph.",
+            )
+            await update.message.reply_text(format_capture_ack(result) + extra)
+            return
         if url:
             result = await svc.pipeline.ingest_url(url, source_type="telegram")
         else:

--- a/apps/core/src/juno/bot/services.py
+++ b/apps/core/src/juno/bot/services.py
@@ -22,6 +22,7 @@ BOT_DATA_KEY = "juno"
 CAPTURE_PAUSED_KEY = "capture_paused"
 TELEGRAM_LIMIT = 4000
 _URL_ONLY = re.compile(r"^https?://\S+$", re.IGNORECASE)
+_SLACK_HOST = re.compile(r"(^|\.)slack\.com$", re.IGNORECASE)
 
 
 @dataclass
@@ -61,6 +62,18 @@ def single_http_url(text: str) -> str | None:
     if _URL_ONLY.match(stripped):
         return stripped
     return None
+
+
+def is_slack_url(text: str) -> bool:
+    """True for slack.com links (opt-in forward into the upload space, not a workspace bot)."""
+    url = single_http_url(text) or (text or "").strip()
+    try:
+        host = urlparse(url).netloc.lower()
+    except ValueError:
+        return False
+    if host.startswith("www."):
+        host = host[4:]
+    return bool(_SLACK_HOST.search(host) or host.endswith(".slack.com") or host == "slack.com")
 
 
 def is_forwarded(message: Any) -> bool:
@@ -400,7 +413,7 @@ async def related_upload_captures(
     return await related_captures(
         db,
         hits=browser_hits,
-        source_types=("upload", "telegram", "url", "api"),
+        source_types=("upload", "telegram", "url", "api", "slack"),
         limit=limit,
     )
 

--- a/apps/core/src/juno/config.py
+++ b/apps/core/src/juno/config.py
@@ -86,6 +86,9 @@ class Settings(BaseSettings):
     juno_drafts_smoke: bool = False
     juno_drafts_generator: str = "template"  # template (llm deferred to #109)
 
+    # M5 Slack (PRD §6.3): opt-in URL/doc forward into inbox space — not a workspace bot.
+    juno_slack_forward: bool = False
+
     def allowed_user_id_set(self) -> set[int]:
         if not self.allowed_telegram_user_ids.strip():
             return set()

--- a/apps/core/tests/test_bot.py
+++ b/apps/core/tests/test_bot.py
@@ -80,7 +80,7 @@ class FakePipeline:
         self.calls.append(("url", url, kwargs))
         return IngestResult(
             accepted=True,
-            source_type="telegram",
+            source_type=str(kwargs.get("source_type") or "telegram"),
             status="committed",
             capture_id=8,
             chunk_count=2,
@@ -333,6 +333,38 @@ async def test_url_and_forward_are_captured(allowed_settings):
     assert pipeline.calls[1][0] == "text"
     assert pipeline.calls[1][1] == "a forwarded note about ownership"
     assert "Captured #7" in fwd.message.reply_text.await_args.args[0]
+
+
+@pytest.mark.asyncio
+async def test_slack_url_requires_opt_in(allowed_settings):
+    from juno.bot.services import is_slack_url
+
+    assert is_slack_url("https://acme.slack.com/archives/C123/p1")
+    pipeline = FakePipeline()
+    svc = _svc(allowed_settings, pipeline=pipeline, app=create_app(allowed_settings))
+    update = _update(ALLOWED_ID, "https://acme.slack.com/archives/C123/p1")
+    await text_msg(update, _context(svc))
+    assert pipeline.calls == []
+    assert "Slack forward is off" in update.message.reply_text.await_args.args[0]
+
+
+@pytest.mark.asyncio
+async def test_slack_url_ingests_when_enabled(allowed_settings, db):
+    from juno.hitl.queue import KIND_MOBILE_BATCH, ReviewQueue
+
+    allowed_settings.juno_slack_forward = True
+    pipeline = FakePipeline()
+    svc = _svc(allowed_settings, db=db, pipeline=pipeline, app=create_app(allowed_settings, db=db))
+    update = _update(ALLOWED_ID, "https://acme.slack.com/archives/C123/p1")
+    await text_msg(update, _context(svc))
+    assert pipeline.calls[0][0] == "url"
+    assert pipeline.calls[0][2]["source_type"] == "slack"
+    reply = update.message.reply_text.await_args.args[0]
+    assert "Queued for /review" in reply
+    card = await ReviewQueue(db).next_open()
+    assert card is not None
+    assert card.kind == KIND_MOBILE_BATCH
+    assert "Slack" in card.payload["title"]
 
 
 @pytest.mark.asyncio

--- a/docs/adr/011-slack-forward.md
+++ b/docs/adr/011-slack-forward.md
@@ -1,0 +1,33 @@
+# ADR-11: Slack as opt-in link forward, not a workspace bot
+
+## Status
+
+Accepted (M5 / #112)
+
+## Date
+
+2026-09-05
+
+## Context
+
+PRD §6.3 lists Slack as a possible capture surface, but a live workspace listener is a **non-goal** (tokens, always-on bot, channel flood). Operators still want an occasional Slack thread or doc in the graph.
+
+Options:
+
+| Option | Summary | Why not |
+|--------|---------|---------|
+| **A. Slack Bolt / Events API daemon** | Real-time channel ingest | Second process or extra loop; contradicts [ADR-01](001-shared-event-loop.md) and M5 “not a live listener” |
+| **B. Drop-folder only** | Paste exports into `inbox/` | Already works; no Telegram convenience |
+| **C. Opt-in Telegram slack.com URLs** | Same ingest path as other links; `JUNO_SLACK_FORWARD` default **off**; HITL like mobile | **Chosen** |
+
+## Decision
+
+1. **No Slack bot, no Events API, no workspace token.** Slack.com hosts in a Telegram message are treated as URLs on the existing ingest pipeline (`source_type=slack`).
+2. **Default off.** Without `JUNO_SLACK_FORWARD=true`, the bot explains how to enable and does not fetch.
+3. When enabled, the capture still goes through `/review` as a sensitive batch (same HITL as mobile forwards). Trust dial `mobile` stays locked ([ADR-10](010-trust-dials.md)).
+4. Prefer Telegram-forward of the text or an `inbox/` drop when the operator does not want network fetch of Slack URLs.
+
+## Consequences
+
+- CI never needs Slack credentials.
+- Workspace-wide passive capture stays deferred past M5.

--- a/docs/next-work.md
+++ b/docs/next-work.md
@@ -198,12 +198,12 @@ Milestone: [M5: v2.0 Polish & Extensions](https://github.com/Anna-Hax/JUNO/miles
 | 4 | [#109](https://github.com/Anna-Hax/JUNO/issues/109) | Auto-drafted dev journal / README drafts — ✅ [session 52](sessions/52-session-journal-drafts.md) |
 | 5 | [#110](https://github.com/Anna-Hax/JUNO/issues/110) | Skill-gap tracking — ✅ [session 53](sessions/53-session-skill-gaps.md) |
 | 6 | [#111](https://github.com/Anna-Hax/JUNO/issues/111) | Trust dial — per-category auto-commit thresholds — ✅ [session 54](sessions/54-session-trust-dial.md) |
-| 7 | [#112](https://github.com/Anna-Hax/JUNO/issues/112) | Optional Slack forward into upload space |
+| 7 | [#112](https://github.com/Anna-Hax/JUNO/issues/112) | Optional Slack forward into upload space — ✅ [session 55](sessions/55-session-slack-forward.md) |
 | 8 | [#113](https://github.com/Anna-Hax/JUNO/issues/113) | Prune-with-confirm — retention / destructive graph cleanup |
 | 9 | [#114](https://github.com/Anna-Hax/JUNO/issues/114) | Module health — polish jobs freshness + respect /pause |
 | 10 | [#115](https://github.com/Anna-Hax/JUNO/issues/115) | M5 gate — polish tests, ADR, README, v2.0 release gate |
 
-**First coding task:** #106–#111 ✅. Next: optional Slack forward ([#112](https://github.com/Anna-Hax/JUNO/issues/112)).
+**First coding task:** #106–#112 ✅. Next: prune-with-confirm ([#113](https://github.com/Anna-Hax/JUNO/issues/113)).
 
 ### M5 design constraints (do not violate)
 
@@ -212,7 +212,7 @@ Milestone: [M5: v2.0 Polish & Extensions](https://github.com/Anna-Hax/JUNO/miles
 3. Schema changes = new Alembic revision ([ADR-03](adr/003-alembic.md)).
 4. Vectors only via the serve-process `VectorStore` after ingest ([ADR-04](adr/004-chroma-collections.md)).
 5. Auto-generated artifacts stay HITL drafts until approve — never auto-publish ([#107](https://github.com/Anna-Hax/JUNO/issues/107), [#20](https://github.com/Anna-Hax/JUNO/issues/20) patterns).
-6. Destructive prune always requires confirm ([#113](https://github.com/Anna-Hax/JUNO/issues/113)). Slack is opt-in forward into the existing inbox — not a live workspace listener ([#112](https://github.com/Anna-Hax/JUNO/issues/112)).
+6. Destructive prune always requires confirm ([#113](https://github.com/Anna-Hax/JUNO/issues/113)). Slack is opt-in forward into the existing inbox — not a live workspace listener ([#112](https://github.com/Anna-Hax/JUNO/issues/112), [ADR-11](adr/011-slack-forward.md)).
 
 ### Explicitly **not** M5 (keep deferred)
 

--- a/docs/sessions/02-codebase-map.md
+++ b/docs/sessions/02-codebase-map.md
@@ -34,7 +34,7 @@ JUNO/
 | Jobs | `jobs/scheduler.py`, `jobs/registry.py`, `jobs/handlers.py`, `jobs/health.py`, `jobs/resurface.py` | AsyncIOScheduler + named cron registry (ADR-07) |
 | Drafts | `drafts/generate.py`, `drafts/kinds.py`, `drafts/flashcards.py`, `drafts/journal.py` | HITL journal/flashcard/doc; SRS after flashcard approve; IDE journal/README via `/drafts` (ADR-09) |
 | API | `api/__init__.py` | FastAPI routes + token + loopback middleware |
-| Bot | `bot/handlers.py`, `bot/services.py`, `bot/review.py` | Telegram allowlist, query, capture, pause/digest/status ([#18](https://github.com/Anna-Hax/JUNO/issues/18) / [#19](https://github.com/Anna-Hax/JUNO/issues/19)); HITL `/review` ([#20](https://github.com/Anna-Hax/JUNO/issues/20)) |
+| Bot | `bot/handlers.py`, `bot/services.py`, `bot/review.py` | Telegram allowlist, query, capture, pause/digest/status ([#18](https://github.com/Anna-Hax/JUNO/issues/18) / [#19](https://github.com/Anna-Hax/JUNO/issues/19)); HITL `/review` ([#20](https://github.com/Anna-Hax/JUNO/issues/20)); opt-in Slack.com links ([ADR-11](../adr/011-slack-forward.md)) |
 | Graph DB | `graph/db.py`, `graph/migrations.py`, `graph/ownership.py` | Engine, WAL, write queue, Alembic upgrade/stamp; export/wipe ([#23](https://github.com/Anna-Hax/JUNO/issues/23)) |
 | Vectors | `graph/vectors.py` | Persistent Chroma; one collection per embedding model ([ADR-04](../adr/004-chroma-collections.md)) |
 | Models | `models/__init__.py` | SQLAlchemy tables including `draft_artifacts` |

--- a/docs/sessions/55-session-slack-forward.md
+++ b/docs/sessions/55-session-slack-forward.md
@@ -1,0 +1,19 @@
+# Session 55 — Optional Slack forward (#112)
+
+**Date:** 2026-09-05  
+**Issue:** [#112](https://github.com/Anna-Hax/JUNO/issues/112)  
+**Branch:** `feat/slack-forward-112`
+
+## What changed
+
+- Opt-in `JUNO_SLACK_FORWARD` ingests slack.com links as `source_type=slack` into the existing upload path.
+- Not a workspace listener. Sensitive Slack batches still go through `/review`.
+- Default off. Recorded in [ADR-11](../adr/011-slack-forward.md).
+
+## Verify
+
+```powershell
+cd apps/core
+$env:EMBEDDING_BACKEND='stub'
+uv run pytest tests/test_bot.py -q
+```

--- a/docs/sessions/README.md
+++ b/docs/sessions/README.md
@@ -60,6 +60,7 @@ Living notes for what was implemented, how GitHub is set up, and what to do next
 | [52-session-journal-drafts.md](52-session-journal-drafts.md) | **#109** — IDE journal / README drafts |
 | [53-session-skill-gaps.md](53-session-skill-gaps.md) | **#110** — Skill-gap tracking |
 | [54-session-trust-dial.md](54-session-trust-dial.md) | **#111** — Trust dial |
+| [55-session-slack-forward.md](55-session-slack-forward.md) | **#112** — Optional Slack forward |
 | [v1.0-release-gate.md](../v1.0-release-gate.md) | M1 checklist (all P0 closed) |
 | [v1.1-release-gate.md](../v1.1-release-gate.md) | M2 checklist (browser capture) |
 | [v1.2-release-gate.md](../v1.2-release-gate.md) | M3 checklist (IDE capture) |


### PR DESCRIPTION
## Summary
- Opt-in `JUNO_SLACK_FORWARD` ingests slack.com Telegram links as `source_type=slack` on the existing pipeline (not a workspace bot).
- Default stays off; when enabled, captures still go through `/review` like mobile batches.
- Records the choice in ADR-11.

## Linked issue
Closes #112

## Test plan
- [x] `uv run pytest tests/test_bot.py` (apps/core, stub embeddings)
- [x] `uv run ruff check src tests`
- [ ] CI lint-test (ubuntu + windows)