### PR TITLE
feat(hitl): require confirm before archiving old unused captures

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -50,6 +50,9 @@ EMBEDDING_BACKEND=sentence_transformers
 # M5 Slack — opt-in slack.com link ingest into the upload space (not a workspace bot)
 # JUNO_SLACK_FORWARD=false
 
+# M5 prune — unused captures older than N days become /prune HITL candidates (never silent delete)
+# JUNO_PRUNE_MIN_AGE_DAYS=90
+
 # IDE adapter (apps/ide) — HTTP client only; empty path = platform Cursor default
 # JUNO_CURSOR_VSCDB=
 # JUNO_CURSOR_WORKSPACE_STORAGE=

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Personal knowledge-graph agent: passively (and manually) capture what you read, 
 - **Browser extension** (`apps/extension`): MV3 loopback client ([ADR-05](docs/adr/005-browser-extension-client.md)); Spike S2 captures tabs → `POST /ingest`
 - **IDE adapter** (`apps/ide`): read-only Cursor `state.vscdb` client ([ADR-06](docs/adr/006-ide-adapter-client.md)); poll/watch posts chats + terminal errors → `POST /ingest` (runbook in [`apps/ide/README.md`](apps/ide/README.md))
 - **Inbox** (`inbox/`): drop `.txt` / `.md` / `.pdf` / `.url` (or a one-line http(s) text file). `juno serve` watches the folder; good files move to `inbox/.processed/`, unreadable PDFs to `inbox/.failed/`. Optional Slack.com links via Telegram when `JUNO_SLACK_FORWARD=true` (not a workspace bot; [ADR-11](docs/adr/011-slack-forward.md)).
-- **HITL** (`/review`): inline Approve / Reject / Skip for pending graph merges, sensitive batches, and auto-generated **drafts** (never auto-published; [ADR-09](docs/adr/009-draft-artifacts-hitl.md))
+- **HITL** (`/review`): inline Approve / Reject / Skip for pending graph merges, sensitive batches, auto-generated **drafts** (never auto-published; [ADR-09](docs/adr/009-draft-artifacts-hitl.md)), and **prune** (archive only after confirm; [ADR-12](docs/adr/012-prune-with-confirm.md))
 
 ## Prerequisites
 
@@ -39,6 +39,8 @@ Data ownership:
 
 ```powershell
 uv run juno export -o ../../data/backup.json
+# Selective archive is HITL only (never silent delete):
+uv run juno prune --confirm prune-selected
 # Stop juno serve first on Windows, then:
 uv run juno wipe --confirm wipe-all-data
 ```
@@ -46,7 +48,7 @@ uv run juno wipe --confirm wipe-all-data
 - API: `http://127.0.0.1:8787/health` (no token). `/status` `/ingest` `/search` need `Authorization: Bearer <JUNO_API_TOKEN>`. Serve refuses the example `change-me` token and any non-loopback `JUNO_API_HOST`.
 - Token-gated `GET /status` reports the live embedder (model / backend / dimensions) and LLM health (`llm_healthy`, `llm_provider`, `llm_model`). If Ollama is down, `llm_healthy` is false and answers stay retrieve-only.
 - Token-gated `GET /search?q=` returns citations + confidence (sourced answer when the LLM is healthy).
-- Bot runs only while this process (and PC) is on. Telegram queues updates ~24h; longer downtime can drop messages. Commands: `/start` `/help` `/digest today|week` `/jobs` `/pause` `/resume` `/status` `/review` `/cards` `/drafts journal|readme` `/gaps` `/trust`. Forward a message, send a link, attach a doc, or send a **voice note** to capture; other text queries the graph. Voice STT is opt-in ([ADR-08](docs/adr/008-voice-transcription.md)). New flashcards and journal/README drafts stay HITL until Approve; `/drafts` never writes git files unattended.
+- Bot runs only while this process (and PC) is on. Telegram queues updates ~24h; longer downtime can drop messages. Commands: `/start` `/help` `/digest today|week` `/jobs` `/pause` `/resume` `/status` `/review` `/cards` `/drafts journal|readme` `/gaps` `/trust` `/prune`. Forward a message, send a link, attach a doc, or send a **voice note** to capture; other text queries the graph. Voice STT is opt-in ([ADR-08](docs/adr/008-voice-transcription.md)). New flashcards and journal/README drafts stay HITL until Approve; `/drafts` never writes git files unattended. `/prune confirm` queues archive of old unused captures; Approve in `/review` is required.
 
 ### Tests
 

--- a/apps/core/src/juno/bot/handlers.py
+++ b/apps/core/src/juno/bot/handlers.py
@@ -38,11 +38,12 @@ HELP_TEXT = (
     "/pause — stop all ingest\n"
     "/resume — resume ingest (processes inbox backlog)\n"
     "/status — capture + module health\n"
-    "/review — HITL Approve/Reject/Skip (merges, IDE, mobile, resurfacing, drafts)\n"
+    "/review — HITL Approve/Reject/Skip (merges, IDE, mobile, resurfacing, drafts, prune)\n"
     "/cards — flashcards due (Again/Good); new cards stay drafts until /review\n"
     "/drafts journal|readme — queue an IDE journal or README draft (never writes files)\n"
     "/gaps — repeat IDE errors / unfinished reads (low-confidence stays in /review)\n"
-    "/trust — per-category auto-commit dials (mobile/drafts stay gated)\n"
+    "/trust — per-category auto-commit dials (mobile/drafts/prune stay gated)\n"
+    "/prune — list old/unused; /prune confirm queues HITL (never silent delete)\n"
     "Ask a question to search the graph.\n"
     "Forward a message, send a link, attach a doc, or send a voice note to capture.\n"
     "Slack.com links ingest only when JUNO_SLACK_FORWARD=true (not a workspace bot)."
@@ -196,6 +197,47 @@ async def trust_cmd(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
         await update.message.reply_text(str(exc))
         return
     await update.message.reply_text(dial.summary())
+
+
+async def prune_cmd(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+    if not update.message or not _authorized(update, context):
+        return
+    svc = _services(context)
+    if svc is None or svc.db is None:
+        await update.message.reply_text("Prune unavailable (database not attached).")
+        return
+    from juno.graph.prune import (
+        DEFAULT_MIN_AGE_DAYS,
+        format_candidates,
+        list_prune_candidates,
+        propose_prune,
+    )
+
+    days = int(
+        getattr(svc.settings, "juno_prune_min_age_days", DEFAULT_MIN_AGE_DAYS)
+        or DEFAULT_MIN_AGE_DAYS
+    )
+    candidates = await list_prune_candidates(svc.db, min_age_days=days)
+    args = [a.lower() for a in (context.args or [])]
+    if not args:
+        await update.message.reply_text(format_candidates(candidates, min_age_days=days))
+        return
+    if args != ["confirm"]:
+        await update.message.reply_text("Usage: /prune   or   /prune confirm")
+        return
+    if not candidates:
+        await update.message.reply_text(format_candidates(candidates, min_age_days=days))
+        return
+    card = await propose_prune(svc.db, candidates=candidates)
+    if card is None:
+        await update.message.reply_text(
+            "Those captures are already waiting in /review. Approve there; nothing was deleted."
+        )
+        return
+    await update.message.reply_text(
+        f"Queued prune #{card.id} for /review ({len(card.payload.get('capture_ids') or [])} "
+        "capture(s)). Approve archives; Reject leaves them. Not a wipe."
+    )
 
 
 async def pause_cmd(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:

--- a/apps/core/src/juno/bot/review.py
+++ b/apps/core/src/juno/bot/review.py
@@ -35,7 +35,7 @@ def review_queue_from_context(context: ContextTypes.DEFAULT_TYPE) -> ReviewQueue
         return queue
     svc = _services(context)
     if svc is not None and svc.db is not None:
-        queue = ReviewQueue(svc.db)
+        queue = ReviewQueue(svc.db, vectors=svc.vectors)
         context.application.bot_data["review"] = queue
         return queue
     return None
@@ -124,6 +124,11 @@ async def review_callback(update: Update, context: ContextTypes.DEFAULT_TYPE) ->
             text += " Draft confirmed; it was not published."
         elif result.card.kind == "draft" and decision == "reject":
             text += " Draft discarded; it was not published."
+        elif result.card.kind == "prune" and decision == "approve":
+            n = len(result.card.payload.get("capture_ids") or [])
+            text += f" Archived {n} capture(s); this is not a wipe."
+        elif result.card.kind == "prune" and decision == "reject":
+            text += " Captures left in the graph."
         elif decision == "skip":
             text += " Left in the queue."
 

--- a/apps/core/src/juno/bot/services.py
+++ b/apps/core/src/juno/bot/services.py
@@ -347,6 +347,7 @@ async def recent_captures(db: Database, *, since: datetime, limit: int = 20) -> 
         result = await session.execute(
             select(Capture)
             .where(Capture.captured_at >= since)
+            .where(Capture.status != "archived")
             .order_by(Capture.captured_at.desc())
             .limit(limit)
         )

--- a/apps/core/src/juno/cli.py
+++ b/apps/core/src/juno/cli.py
@@ -31,6 +31,29 @@ def main(argv: list[str] | None = None) -> None:
         help='Must be exactly "wipe-all-data"',
     )
 
+    prune_p = sub.add_parser(
+        "prune",
+        help="Queue HITL prune of old/unused captures (never silent delete)",
+    )
+    prune_p.add_argument(
+        "--days",
+        type=int,
+        default=None,
+        help="Minimum age in days for unused captures (default: JUNO_PRUNE_MIN_AGE_DAYS)",
+    )
+    prune_p.add_argument(
+        "-o",
+        "--export",
+        type=Path,
+        default=None,
+        help="Optional JSON export path written before queueing (full graph, same as juno export)",
+    )
+    prune_p.add_argument(
+        "--confirm",
+        default="",
+        help='Must be exactly "prune-selected" to queue /review; omit for dry-run',
+    )
+
     sub.add_parser("version", help="Print version")
 
     args = parser.parse_args(argv)
@@ -66,6 +89,10 @@ def main(argv: list[str] | None = None) -> None:
 
     if args.command == "wipe":
         asyncio.run(_wipe(args.confirm))
+        return
+
+    if args.command == "prune":
+        asyncio.run(_prune(days=args.days, confirm=args.confirm, export_path=args.export))
         return
 
     parser.print_help()
@@ -131,6 +158,73 @@ async def _wipe(confirm: str) -> None:
     print(f"Wiped {len(removed)} path(s); empty schema at {settings.sqlite_path}")
     for path in removed:
         print(f"  removed {path}")
+
+
+async def _prune(
+    days: int | None,
+    confirm: str,
+    export_path: Path | None,
+) -> None:
+    from juno.config import get_settings
+    from juno.graph.db import Database
+    from juno.graph.ownership import build_export_payload, write_export_file
+    from juno.graph.prune import (
+        DEFAULT_MIN_AGE_DAYS,
+        PRUNE_CONFIRM_PHRASE,
+        format_candidates,
+        list_prune_candidates,
+        propose_prune,
+    )
+    from juno.graph.vectors import VectorStore
+    from juno.llm.embedder import create_embedder
+
+    settings = get_settings()
+    age = settings.juno_prune_min_age_days or DEFAULT_MIN_AGE_DAYS
+    min_days = int(days if days is not None else age)
+    db = Database(settings)
+    await db.migrate()
+    vectors = None
+    try:
+        candidates = await list_prune_candidates(db, min_age_days=min_days)
+        print(format_candidates(candidates, min_age_days=min_days))
+        if not confirm:
+            print("Dry-run only. Re-run with --confirm prune-selected to queue HITL.")
+            return
+        if confirm != PRUNE_CONFIRM_PHRASE:
+            print(
+                f'Refuse prune queue without --confirm "{PRUNE_CONFIRM_PHRASE}" '
+                "(this still does not delete; Approve in /review archives).",
+                file=sys.stderr,
+            )
+            sys.exit(1)
+        exported = None
+        if export_path is not None:
+            try:
+                embedder = create_embedder(settings.embedding_backend, settings.embedding_model)
+            except Exception:
+                embedder = create_embedder("stub", settings.embedding_model)
+            vectors = VectorStore(settings, embedder)
+            payload = await build_export_payload(
+                settings, db=db, vectors=vectors, embedder=embedder
+            )
+            dest = write_export_file(payload, export_path)
+            exported = str(dest)
+            print(f"Export written to {dest}")
+        if not candidates:
+            return
+        card = await propose_prune(db, candidates=candidates, exported_path=exported)
+        if card is None:
+            print("Already queued in /review. Nothing deleted.")
+            return
+        print(
+            f"Queued prune review #{card.id} "
+            f"({len(card.payload.get('capture_ids') or [])} capture(s)). "
+            "Approve in Telegram /review to archive. Not a wipe."
+        )
+    finally:
+        if vectors is not None:
+            vectors.close()
+        await db.dispose()
 
 
 if __name__ == "__main__":

--- a/apps/core/src/juno/config.py
+++ b/apps/core/src/juno/config.py
@@ -89,6 +89,9 @@ class Settings(BaseSettings):
     # M5 Slack (PRD §6.3): opt-in URL/doc forward into inbox space — not a workspace bot.
     juno_slack_forward: bool = False
 
+    # M5 prune (ADR-12): unused captures older than this many days are HITL candidates.
+    juno_prune_min_age_days: int = 90
+
     def allowed_user_id_set(self) -> set[int]:
         if not self.allowed_telegram_user_ids.strip():
             return set()

--- a/apps/core/src/juno/graph/prune.py
+++ b/apps/core/src/juno/graph/prune.py
@@ -1,0 +1,228 @@
+"""Selective prune/archive with mandatory HITL — never silent delete (ADR-12 / #113)."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import UTC, datetime, timedelta
+from typing import Any
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from juno.graph.db import Database
+from juno.models import Capture, Chunk, Edge, ReviewItem
+
+PRUNE_CONFIRM_PHRASE = "prune-selected"
+STATUS_ARCHIVED = "archived"
+STATUS_FAILED = "failed"
+STATUS_COMMITTED = "committed"
+DEFAULT_MIN_AGE_DAYS = 90
+FAILED_MIN_AGE_DAYS = 7
+MAX_BATCH = 20
+UNUSED_MAX_CHARS = 120
+
+
+@dataclass(frozen=True)
+class PruneCandidate:
+    id: int
+    title: str | None
+    source_type: str
+    status: str
+    captured_at: datetime | None
+    reason: str
+
+    def label(self) -> str:
+        title = (self.title or "").strip() or "(untitled)"
+        if len(title) > 60:
+            title = title[:59].rstrip() + "…"
+        return f"#{self.id} [{self.source_type}/{self.status}] {self.reason} — {title}"
+
+
+def fingerprint(capture_ids: list[int]) -> str:
+    return ",".join(str(i) for i in sorted(capture_ids))
+
+
+def _has_highlights(raw: Any) -> bool:
+    if not isinstance(raw, dict):
+        return False
+    highlights = raw.get("highlights")
+    return isinstance(highlights, list) and len(highlights) > 0
+
+
+def _is_short(text: str | None) -> bool:
+    return len((text or "").strip()) <= UNUSED_MAX_CHARS
+
+
+async def list_prune_candidates(
+    db: Database,
+    *,
+    min_age_days: int = DEFAULT_MIN_AGE_DAYS,
+    now: datetime | None = None,
+    limit: int = MAX_BATCH,
+) -> list[PruneCandidate]:
+    """Old unused captures plus aged failed ingest rows. Never includes archived."""
+    when = now or datetime.now(UTC)
+    if when.tzinfo is None:
+        when = when.replace(tzinfo=UTC)
+    age_cut = when - timedelta(days=max(1, int(min_age_days)))
+    fail_cut = when - timedelta(days=FAILED_MIN_AGE_DAYS)
+
+    async def load(session: AsyncSession) -> list[PruneCandidate]:
+        used = {
+            int(eid)
+            for eid in (
+                await session.execute(
+                    select(Edge.evidence_capture_id).where(
+                        Edge.evidence_capture_id.is_not(None),
+                        Edge.status == "committed",
+                    )
+                )
+            ).scalars()
+            if eid is not None
+        }
+        rows = (
+            (
+                await session.execute(
+                    select(Capture)
+                    .where(Capture.status != STATUS_ARCHIVED)
+                    .order_by(Capture.captured_at.asc())
+                )
+            )
+            .scalars()
+            .all()
+        )
+        out: list[PruneCandidate] = []
+        for row in rows:
+            captured = row.captured_at
+            if captured is not None and captured.tzinfo is None:
+                captured = captured.replace(tzinfo=UTC)
+            if row.status == STATUS_FAILED:
+                if captured is None or captured > fail_cut:
+                    continue
+                out.append(
+                    PruneCandidate(
+                        id=row.id,
+                        title=row.title,
+                        source_type=row.source_type,
+                        status=row.status,
+                        captured_at=row.captured_at,
+                        reason="failed",
+                    )
+                )
+                if len(out) >= limit:
+                    break
+                continue
+            if row.status != STATUS_COMMITTED:
+                continue
+            if captured is None or captured > age_cut:
+                continue
+            if row.id in used or _has_highlights(row.raw_json):
+                continue
+            if not _is_short(row.text):
+                continue
+            out.append(
+                PruneCandidate(
+                    id=row.id,
+                    title=row.title,
+                    source_type=row.source_type,
+                    status=row.status,
+                    captured_at=row.captured_at,
+                    reason="old_unused",
+                )
+            )
+            if len(out) >= limit:
+                break
+        return out[:limit]
+
+    return await db.read(load)
+
+
+async def pending_prune_capture_ids(db: Database) -> set[int]:
+    from juno.hitl.queue import KIND_PRUNE, STATUS_DECIDED
+
+    async def load(session: AsyncSession) -> set[int]:
+        rows = (
+            (await session.execute(select(ReviewItem).where(ReviewItem.kind == KIND_PRUNE)))
+            .scalars()
+            .all()
+        )
+        ids: set[int] = set()
+        for row in rows:
+            if row.status == STATUS_DECIDED:
+                continue
+            payload = row.payload if isinstance(row.payload, dict) else {}
+            for raw in payload.get("capture_ids") or []:
+                try:
+                    ids.add(int(raw))
+                except (TypeError, ValueError):
+                    continue
+        return ids
+
+    return await db.read(load)
+
+
+def format_candidates(candidates: list[PruneCandidate], *, min_age_days: int) -> str:
+    if not candidates:
+        failed = FAILED_MIN_AGE_DAYS
+        return (
+            f"No prune candidates (old unused ≥{min_age_days}d, or failed ≥{failed}d). "
+            "Nothing will be deleted."
+        )
+    lines = [
+        (
+            f"Prune candidates ({len(candidates)}; "
+            f"age ≥{min_age_days}d unused, or failed ≥{FAILED_MIN_AGE_DAYS}d):"
+        ),
+        *[f"• {c.label()}" for c in candidates],
+        (
+            "Nothing is deleted until /review Approve "
+            "(or `juno prune --confirm prune-selected` then Approve)."
+        ),
+        "Optional backup: `juno export` first. Distinct from `juno wipe`.",
+    ]
+    return "\n".join(lines)
+
+
+async def propose_prune(
+    db: Database,
+    *,
+    candidates: list[PruneCandidate],
+    exported_path: str | None = None,
+) -> Any:
+    """Queue HITL prune. Does not archive. Duplicate pending ids are skipped."""
+    from juno.hitl.queue import KIND_PRUNE, ReviewQueue
+
+    pending = await pending_prune_capture_ids(db)
+    fresh = [c for c in candidates if c.id not in pending]
+    if not fresh:
+        return None
+    ids = [c.id for c in fresh]
+    return await ReviewQueue(db).enqueue(
+        kind=KIND_PRUNE,
+        confidence=0.3,
+        payload={
+            "capture_ids": ids,
+            "titles": [c.label() for c in fresh],
+            "fingerprint": fingerprint(ids),
+            "exported_path": exported_path,
+            "archived": False,
+            "reason": "Selective prune — Approve archives these captures; Reject leaves them.",
+        },
+    )
+
+
+async def apply_prune_captures(session: AsyncSession, capture_ids: list[int]) -> list[str]:
+    """Archive captures in-session. Returns chroma ids to drop after the write commits."""
+    chroma_ids: list[str] = []
+    for raw_id in capture_ids:
+        cap = await session.get(Capture, int(raw_id))
+        if cap is None or cap.status == STATUS_ARCHIVED:
+            continue
+        cap.status = STATUS_ARCHIVED
+        chunks = (
+            (await session.execute(select(Chunk).where(Chunk.capture_id == cap.id))).scalars().all()
+        )
+        for chunk in chunks:
+            if chunk.chroma_id:
+                chroma_ids.append(chunk.chroma_id)
+    return chroma_ids

--- a/apps/core/src/juno/hitl/queue.py
+++ b/apps/core/src/juno/hitl/queue.py
@@ -21,6 +21,7 @@ KIND_MOBILE_BATCH = "mobile_batch"
 KIND_RESURFACE = "resurface"
 KIND_DRAFT = "draft"
 KIND_SKILL_GAP = "skill_gap"
+KIND_PRUNE = "prune"
 STATUS_PENDING = "pending"
 STATUS_SKIPPED = "skipped"
 STATUS_DECIDED = "decided"
@@ -114,6 +115,20 @@ class ReviewCard:
             lines.append(
                 "Approve if this is a real struggle; Reject to ignore (Juno will not nag)."
             )
+        elif self.kind == KIND_PRUNE:
+            ids = self.payload.get("capture_ids") or []
+            count = len(ids) if isinstance(ids, list) else 0
+            lines.append(f"Prune {count} capture(s) (archive, not wipe).")
+            titles = self.payload.get("titles") or []
+            if isinstance(titles, list):
+                lines.extend(str(t) for t in titles[:8])
+            reason = self.payload.get("reason")
+            if reason:
+                lines.append(str(reason))
+            exported = self.payload.get("exported_path")
+            if exported:
+                lines.append(f"Export saved: {exported}")
+            lines.append("Approve archives these rows and drops their vectors. Reject leaves them.")
         else:
             preview = str(self.payload)[:500]
             if preview:
@@ -132,8 +147,9 @@ class DecideResult:
 class ReviewQueue:
     """Persist HITL items and apply merge payloads only on approve."""
 
-    def __init__(self, db: Database) -> None:
+    def __init__(self, db: Database, vectors: Any | None = None) -> None:
         self.db = db
+        self.vectors = vectors
 
     async def enqueue(
         self,
@@ -394,6 +410,14 @@ class ReviewQueue:
             )
 
         result = await self.db.write(write)
+        chroma_ids = list((result.card.payload or {}).get("chroma_ids") or [])
+        if (
+            result.applied
+            and result.card.kind == KIND_PRUNE
+            and chroma_ids
+            and self.vectors is not None
+        ):
+            await self.vectors.delete_async(chroma_ids)
         if not result.already_decided and result.card.decision == "approve" and result.applied:
             from juno.hitl.trust import record_success
 
@@ -494,6 +518,16 @@ async def _apply(session: AsyncSession, row: ReviewItem) -> bool:
         row.payload = payload
         await _set_draft_artifact(session, payload, confirmed=True)
         return True
+    if row.kind == KIND_PRUNE:
+        from juno.graph.prune import apply_prune_captures
+
+        ids = [int(x) for x in (row.payload or {}).get("capture_ids") or []]
+        chroma_ids = await apply_prune_captures(session, ids)
+        payload = dict(row.payload or {})
+        payload["archived"] = True
+        payload["chroma_ids"] = chroma_ids
+        row.payload = payload
+        return True
     if row.kind != KIND_MERGE:
         return False
     edge_id = (row.payload or {}).get("edge_id")
@@ -519,6 +553,11 @@ async def _reject(session: AsyncSession, row: ReviewItem) -> None:
         payload["published"] = False
         row.payload = payload
         await _set_draft_artifact(session, payload, confirmed=False)
+        return
+    if row.kind == KIND_PRUNE:
+        payload = dict(row.payload or {})
+        payload["archived"] = False
+        row.payload = payload
         return
     if row.kind != KIND_MERGE:
         return

--- a/apps/core/src/juno/hitl/trust.py
+++ b/apps/core/src/juno/hitl/trust.py
@@ -1,4 +1,4 @@
-"""Per-category trust dials (PRD §8 P2). Mobile and drafts stay gated."""
+"""Per-category trust dials (PRD §8 P2). Mobile, drafts, and prune stay gated."""
 
 from __future__ import annotations
 
@@ -9,8 +9,8 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from juno.graph.db import Database
 from juno.models import AppSetting
 
-CATEGORIES = ("merge", "browser", "ide_error", "mobile", "drafts")
-LOCKED = frozenset({"mobile", "drafts"})
+CATEGORIES = ("merge", "browser", "ide_error", "mobile", "drafts", "prune")
+LOCKED = frozenset({"mobile", "drafts", "prune"})
 DEFAULT_THRESHOLD = 5
 HIGH_CONFIDENCE = 0.8
 
@@ -110,7 +110,7 @@ def format_trust(dials: list[TrustDial]) -> str:
     lines = ["Trust dials (per category, not a global switch):"]
     lines.extend(f"• {d.summary()}" for d in dials)
     lines.append("Toggle: /trust merge|browser|ide_error on|off")
-    lines.append("mobile and drafts stay gated.")
+    lines.append("mobile, drafts, and prune stay gated.")
     return "\n".join(lines)
 
 

--- a/apps/core/src/juno/rag/engine.py
+++ b/apps/core/src/juno/rag/engine.py
@@ -142,6 +142,8 @@ async def retrieve(
     sourced: list[SourcedHit] = []
     for hit in hits:
         chunk, capture = by_chroma.get(hit.id, (None, None))
+        if capture is not None and capture.status == "archived":
+            continue
         meta = hit.metadata or {}
         text = (chunk.text if chunk is not None else None) or hit.text or ""
         sourced.append(

--- a/apps/core/src/juno/runtime.py
+++ b/apps/core/src/juno/runtime.py
@@ -26,6 +26,7 @@ from juno.bot.handlers import (
     help_cmd,
     jobs_cmd,
     pause_cmd,
+    prune_cmd,
     resume_cmd,
     start_cmd,
     status_cmd,
@@ -71,6 +72,7 @@ def build_telegram_application(settings: Settings) -> Application | None:
     app.add_handler(CommandHandler("drafts", drafts_cmd))
     app.add_handler(CommandHandler("gaps", gaps_cmd))
     app.add_handler(CommandHandler("trust", trust_cmd))
+    app.add_handler(CommandHandler("prune", prune_cmd))
     app.add_handler(CallbackQueryHandler(review_callback, pattern=r"^rev:"))
     app.add_handler(CallbackQueryHandler(cards_callback, pattern=r"^srs:"))
     app.add_handler(MessageHandler(filters.VOICE, voice_msg))
@@ -181,7 +183,7 @@ def attach_lifespan(fastapi_app: FastAPI) -> FastAPI:
         ptb: Application | None = app.state.ptb
         if ptb is not None:
             ptb.bot_data["settings"] = settings
-            ptb.bot_data["review"] = ReviewQueue(db)
+            ptb.bot_data["review"] = ReviewQueue(db, vectors=getattr(app.state, "vectors", None))
             ptb.bot_data[BOT_DATA_KEY] = BotServices(
                 settings=settings,
                 db=db,

--- a/apps/core/tests/test_bot.py
+++ b/apps/core/tests/test_bot.py
@@ -14,6 +14,7 @@ from juno.bot.handlers import (
     help_cmd,
     jobs_cmd,
     pause_cmd,
+    prune_cmd,
     resume_cmd,
     start_cmd,
     status_cmd,
@@ -259,6 +260,7 @@ def test_build_telegram_application_registers_commands(allowed_settings):
         "drafts",
         "gaps",
         "trust",
+        "prune",
     }
 
 
@@ -296,6 +298,7 @@ async def test_start_and_help_reply_for_allowlisted_user(allowed_settings):
     assert "/drafts" in body
     assert "/gaps" in body
     assert "/trust" in body
+    assert "/prune" in body
     assert "Approve" in body
 
 
@@ -365,6 +368,43 @@ async def test_slack_url_ingests_when_enabled(allowed_settings, db):
     assert card is not None
     assert card.kind == KIND_MOBILE_BATCH
     assert "Slack" in card.payload["title"]
+
+
+@pytest.mark.asyncio
+async def test_prune_confirm_queues_hitl(allowed_settings, db):
+    from datetime import UTC, datetime, timedelta
+
+    from sqlalchemy.ext.asyncio import AsyncSession
+
+    from juno.graph.vectors import VectorStore
+    from juno.hitl.queue import KIND_PRUNE, ReviewQueue
+    from juno.ingest.pipeline import IngestPipeline
+    from juno.llm.embedder import StubEmbedder
+    from juno.models import Capture
+
+    allowed_settings.juno_prune_min_age_days = 90
+    vectors = VectorStore(allowed_settings, StubEmbedder())
+    pipe = IngestPipeline(db, vectors=vectors)
+    result = await pipe.ingest_text("old dust", source_type="upload", title="dust")
+
+    async def age(session: AsyncSession) -> None:
+        cap = await session.get(Capture, result.capture_id)
+        assert cap is not None
+        cap.captured_at = datetime.now(UTC) - timedelta(days=100)
+
+    await db.write(age)
+    svc = _svc(allowed_settings, db=db, vectors=vectors)
+    listed = _update(ALLOWED_ID, "/prune")
+    await prune_cmd(listed, _context(svc))
+    preview = listed.message.reply_text.await_args.args[0]
+    assert "Nothing is deleted" in preview
+    queued = _update(ALLOWED_ID, "/prune confirm")
+    await prune_cmd(queued, _context(svc, args=["confirm"]))
+    assert "Queued prune" in queued.message.reply_text.await_args.args[0]
+    card = await ReviewQueue(db).next_open()
+    assert card is not None
+    assert card.kind == KIND_PRUNE
+    assert result.capture_id in card.payload["capture_ids"]
 
 
 @pytest.mark.asyncio

--- a/apps/core/tests/test_prune.py
+++ b/apps/core/tests/test_prune.py
@@ -1,0 +1,145 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from juno.graph.db import Database
+from juno.graph.ownership import WIPE_CONFIRM_PHRASE
+from juno.graph.prune import (
+    PRUNE_CONFIRM_PHRASE,
+    STATUS_ARCHIVED,
+    list_prune_candidates,
+    propose_prune,
+)
+from juno.graph.vectors import VectorStore
+from juno.hitl.queue import KIND_PRUNE, ReviewQueue
+from juno.ingest.pipeline import IngestPipeline
+from juno.llm.embedder import StubEmbedder
+from juno.models import Capture
+from juno.rag.engine import retrieve
+
+
+@pytest.fixture
+async def db(settings):
+    database = Database(settings)
+    await database.migrate()
+    yield database
+    await database.dispose()
+
+
+@pytest.fixture
+def vectors(settings):
+    return VectorStore(settings, StubEmbedder())
+
+
+@pytest.fixture
+def pipeline(db, vectors):
+    return IngestPipeline(db, vectors=vectors)
+
+
+async def _set_captured_at(db: Database, capture_id: int, *, days_ago: int) -> None:
+    when = datetime.now(UTC) - timedelta(days=days_ago)
+
+    async def write(session: AsyncSession) -> None:
+        cap = await session.get(Capture, capture_id)
+        assert cap is not None
+        cap.captured_at = when
+
+    await db.write(write)
+
+
+async def _status(db: Database, capture_id: int) -> str | None:
+    async def load(session: AsyncSession) -> str | None:
+        cap = await session.get(Capture, capture_id)
+        return None if cap is None else cap.status
+
+    return await db.read(load)
+
+
+async def _insert_failed(db: Database) -> int:
+    async def write(session: AsyncSession) -> int:
+        cap = Capture(
+            source_type="upload",
+            title="bad pdf",
+            text="",
+            status="failed",
+            error_reason="unreadable",
+        )
+        session.add(cap)
+        await session.flush()
+        return cap.id
+
+    return await db.write(write)
+
+
+def test_prune_confirm_is_not_wipe():
+    assert PRUNE_CONFIRM_PHRASE == "prune-selected"
+    assert PRUNE_CONFIRM_PHRASE != WIPE_CONFIRM_PHRASE
+
+
+@pytest.mark.asyncio
+async def test_candidates_are_old_unused_or_failed_not_highlighted(db, pipeline):
+    old = await pipeline.ingest_text("short unused note", source_type="upload", title="dust")
+    keep_hl = await pipeline.ingest_text("also short", source_type="upload", title="quoted")
+    fresh = await pipeline.ingest_text("fresh unused", source_type="upload", title="today")
+    failed_id = await _insert_failed(db)
+
+    async def mark_highlights(session: AsyncSession) -> None:
+        cap = await session.get(Capture, keep_hl.capture_id)
+        assert cap is not None
+        cap.raw_json = {"highlights": ["keep this"]}
+
+    await db.write(mark_highlights)
+    await _set_captured_at(db, old.capture_id, days_ago=100)
+    await _set_captured_at(db, keep_hl.capture_id, days_ago=100)
+    await _set_captured_at(db, failed_id, days_ago=10)
+
+    found = await list_prune_candidates(db, min_age_days=90)
+    ids = {c.id for c in found}
+    assert old.capture_id in ids
+    assert failed_id in ids
+    assert keep_hl.capture_id not in ids
+    assert fresh.capture_id not in ids
+
+
+@pytest.mark.asyncio
+async def test_approve_archives_and_drops_vectors_reject_does_not(db, vectors, pipeline):
+    old = await pipeline.ingest_text("prune me please", source_type="upload", title="stale")
+    await _set_captured_at(db, old.capture_id, days_ago=120)
+    assert vectors.count() >= 1
+    before = vectors.count()
+
+    candidates = await list_prune_candidates(db, min_age_days=90)
+    card = await propose_prune(db, candidates=candidates)
+    assert card is not None
+    assert card.kind == KIND_PRUNE
+    assert card.status == "pending"
+    assert await _status(db, old.capture_id) == "committed"
+
+    rejected = await ReviewQueue(db, vectors=vectors).decide(card.id, "reject")
+    assert rejected.applied is False
+    assert await _status(db, old.capture_id) == "committed"
+    assert vectors.count() == before
+
+    again = await propose_prune(db, candidates=candidates)
+    assert again is not None
+    approved = await ReviewQueue(db, vectors=vectors).decide(again.id, "approve")
+    assert approved.applied is True
+    assert approved.card.payload.get("archived") is True
+    assert await _status(db, old.capture_id) == STATUS_ARCHIVED
+    hits = await retrieve("prune me please", vectors=vectors, db=db)
+    assert hits == []
+    assert vectors.count() == 0
+
+
+@pytest.mark.asyncio
+async def test_duplicate_pending_prune_is_not_requeued(db, pipeline):
+    old = await pipeline.ingest_text("dup prune", source_type="upload", title="dup")
+    await _set_captured_at(db, old.capture_id, days_ago=100)
+    candidates = await list_prune_candidates(db, min_age_days=90)
+    first = await propose_prune(db, candidates=candidates)
+    second = await propose_prune(db, candidates=candidates)
+    assert first is not None
+    assert second is None

--- a/apps/core/tests/test_trust.py
+++ b/apps/core/tests/test_trust.py
@@ -22,8 +22,11 @@ async def test_mobile_and_drafts_stay_gated(db):
         await set_auto(db, "mobile", True)
     with pytest.raises(ValueError, match="gated"):
         await set_auto(db, "drafts", True)
+    with pytest.raises(ValueError, match="gated"):
+        await set_auto(db, "prune", True)
     assert await should_auto_commit(db, "mobile", 0.99) is False
     assert await should_auto_commit(db, "drafts", 0.99) is False
+    assert await should_auto_commit(db, "prune", 0.99) is False
 
 
 @pytest.mark.asyncio

--- a/docs/adr/010-trust-dials.md
+++ b/docs/adr/010-trust-dials.md
@@ -15,8 +15,8 @@ PRD §8 P2: as the agent earns confidence in a category, that category's gate ca
 ## Decision
 
 1. Store dials in `settings` (`trust.{category}.successes` / `.auto` / `.threshold`). No extra table.
-2. Categories: `merge`, `browser`, `ide_error`, `mobile`, `drafts`.
-3. **`mobile` and `drafts` are locked** — `/trust mobile on` is rejected; `should_auto_commit` is always false.
+2. Categories: `merge`, `browser`, `ide_error`, `mobile`, `drafts`, `prune`.
+3. **`mobile`, `drafts`, and `prune` are locked** — `/trust mobile on` is rejected; `should_auto_commit` is always false.
 4. Five successful Approve taps on `merge` or `ide_error` turns auto-commit **on** for that category. High-confidence (`>= 0.8`) merges then commit without a pending `/review` card (audit row still stored as decided).
 5. Operator can `/trust merge|browser|ide_error on|off`. `/status` lists current dials.
 
@@ -24,3 +24,4 @@ PRD §8 P2: as the agent earns confidence in a category, that category's gate ca
 
 - Early graphs stay HITL-heavy; a month of good merge reviews can loosen only merges.
 - Draft auto-publish remains forbidden ([ADR-09](009-draft-artifacts-hitl.md)).
+- Selective prune stays confirm-only ([ADR-12](012-prune-with-confirm.md)).

--- a/docs/adr/012-prune-with-confirm.md
+++ b/docs/adr/012-prune-with-confirm.md
@@ -1,0 +1,36 @@
+# ADR-12: Prune is HITL archive, never silent delete
+
+## Status
+
+Accepted (M5 / #113)
+
+## Date
+
+2026-09-05
+
+## Context
+
+PRD §8 P0 / open question on retention: low-value captures (old unused notes, failed ingest) should be cleanable without a full `juno wipe` ([#23](https://github.com/Anna-Hax/JUNO/issues/23)). Silent or scheduled delete would fight the HITL layer ([ADR-09](009-draft-artifacts-hitl.md), [ADR-10](010-trust-dials.md)).
+
+Options:
+
+| Option | Summary | Why not |
+|--------|---------|---------|
+| **A. Cron auto-delete** | Age out after N days | Silent destructive write; violates “never silent delete” |
+| **B. `juno wipe` only** | Nuclear option already exists | Too coarse; operators lose the whole graph |
+| **C. HITL prune → archive** | List candidates; queue `kind=prune`; Approve sets `status=archived` and drops Chroma ids | **Chosen** |
+
+## Decision
+
+1. **Propose ≠ destroy.** `/prune` and `juno prune` only list or enqueue. Archive happens solely on `/review` Approve.
+2. **CLI confirm queues, it does not delete.** `juno prune --confirm prune-selected` is distinct from `wipe-all-data`. Wrong phrase refuses the queue.
+3. **Archive, don’t wipe.** SQLite rows stay (`status=archived`) so export can still see them; vectors for those chunks are deleted ([ADR-04](004-chroma-collections.md)). Retrieval skips archived captures.
+4. **Trust dial `prune` is locked** — no auto-commit ([ADR-10](010-trust-dials.md)).
+5. Optional `juno prune --export PATH --confirm prune-selected` writes a full graph export first.
+6. Writes go through `Database.write()` ([ADR-02](002-sqlite-write-queue.md)). No extra Alembic table.
+
+## Consequences
+
+- Failed ingest older than 7 days and unused committed captures older than `JUNO_PRUNE_MIN_AGE_DAYS` (default 90) are candidates.
+- Highlighted or graph-linked captures are not unused.
+- Full disk wipe remains `juno wipe --confirm wipe-all-data`.

--- a/docs/next-work.md
+++ b/docs/next-work.md
@@ -199,11 +199,11 @@ Milestone: [M5: v2.0 Polish & Extensions](https://github.com/Anna-Hax/JUNO/miles
 | 5 | [#110](https://github.com/Anna-Hax/JUNO/issues/110) | Skill-gap tracking — ✅ [session 53](sessions/53-session-skill-gaps.md) |
 | 6 | [#111](https://github.com/Anna-Hax/JUNO/issues/111) | Trust dial — per-category auto-commit thresholds — ✅ [session 54](sessions/54-session-trust-dial.md) |
 | 7 | [#112](https://github.com/Anna-Hax/JUNO/issues/112) | Optional Slack forward into upload space — ✅ [session 55](sessions/55-session-slack-forward.md) |
-| 8 | [#113](https://github.com/Anna-Hax/JUNO/issues/113) | Prune-with-confirm — retention / destructive graph cleanup |
+| 8 | [#113](https://github.com/Anna-Hax/JUNO/issues/113) | Prune-with-confirm — retention / destructive graph cleanup — ✅ [session 56](sessions/56-session-prune-confirm.md) |
 | 9 | [#114](https://github.com/Anna-Hax/JUNO/issues/114) | Module health — polish jobs freshness + respect /pause |
 | 10 | [#115](https://github.com/Anna-Hax/JUNO/issues/115) | M5 gate — polish tests, ADR, README, v2.0 release gate |
 
-**First coding task:** #106–#112 ✅. Next: prune-with-confirm ([#113](https://github.com/Anna-Hax/JUNO/issues/113)).
+**First coding task:** #106–#113 ✅. Next: module health polish ([#114](https://github.com/Anna-Hax/JUNO/issues/114)).
 
 ### M5 design constraints (do not violate)
 
@@ -212,7 +212,7 @@ Milestone: [M5: v2.0 Polish & Extensions](https://github.com/Anna-Hax/JUNO/miles
 3. Schema changes = new Alembic revision ([ADR-03](adr/003-alembic.md)).
 4. Vectors only via the serve-process `VectorStore` after ingest ([ADR-04](adr/004-chroma-collections.md)).
 5. Auto-generated artifacts stay HITL drafts until approve — never auto-publish ([#107](https://github.com/Anna-Hax/JUNO/issues/107), [#20](https://github.com/Anna-Hax/JUNO/issues/20) patterns).
-6. Destructive prune always requires confirm ([#113](https://github.com/Anna-Hax/JUNO/issues/113)). Slack is opt-in forward into the existing inbox — not a live workspace listener ([#112](https://github.com/Anna-Hax/JUNO/issues/112), [ADR-11](adr/011-slack-forward.md)).
+6. Destructive prune always requires confirm ([#113](https://github.com/Anna-Hax/JUNO/issues/113), [ADR-12](adr/012-prune-with-confirm.md)). Slack is opt-in forward into the existing inbox — not a live workspace listener ([#112](https://github.com/Anna-Hax/JUNO/issues/112), [ADR-11](adr/011-slack-forward.md)).
 
 ### Explicitly **not** M5 (keep deferred)
 

--- a/docs/sessions/02-codebase-map.md
+++ b/docs/sessions/02-codebase-map.md
@@ -29,26 +29,26 @@ JUNO/
 | Module | File(s) | Role |
 |--------|---------|------|
 | Config | `config.py` | pydantic-settings from `.env` |
-| CLI | `cli.py` | `juno serve` / `db-init` / `export` / `wipe` / `version` |
+| CLI | `cli.py` | `juno serve` / `db-init` / `export` / `prune` / `wipe` / `version` |
 | Runtime | `runtime.py` | Shared asyncio: uvicorn + PTB + inbox watcher + jobs scheduler lifespan |
 | Jobs | `jobs/scheduler.py`, `jobs/registry.py`, `jobs/handlers.py`, `jobs/health.py`, `jobs/resurface.py` | AsyncIOScheduler + named cron registry (ADR-07) |
 | Drafts | `drafts/generate.py`, `drafts/kinds.py`, `drafts/flashcards.py`, `drafts/journal.py` | HITL journal/flashcard/doc; SRS after flashcard approve; IDE journal/README via `/drafts` (ADR-09) |
 | API | `api/__init__.py` | FastAPI routes + token + loopback middleware |
 | Bot | `bot/handlers.py`, `bot/services.py`, `bot/review.py` | Telegram allowlist, query, capture, pause/digest/status ([#18](https://github.com/Anna-Hax/JUNO/issues/18) / [#19](https://github.com/Anna-Hax/JUNO/issues/19)); HITL `/review` ([#20](https://github.com/Anna-Hax/JUNO/issues/20)); opt-in Slack.com links ([ADR-11](../adr/011-slack-forward.md)) |
-| Graph DB | `graph/db.py`, `graph/migrations.py`, `graph/ownership.py` | Engine, WAL, write queue, Alembic upgrade/stamp; export/wipe ([#23](https://github.com/Anna-Hax/JUNO/issues/23)) |
+| Graph DB | `graph/db.py`, `graph/migrations.py`, `graph/ownership.py`, `graph/prune.py` | Engine, WAL, write queue, Alembic upgrade/stamp; export/wipe ([#23](https://github.com/Anna-Hax/JUNO/issues/23)); HITL prune/archive ([ADR-12](../adr/012-prune-with-confirm.md)) |
 | Vectors | `graph/vectors.py` | Persistent Chroma; one collection per embedding model ([ADR-04](../adr/004-chroma-collections.md)) |
 | Models | `models/__init__.py` | SQLAlchemy tables including `draft_artifacts` |
 | Alembic | `alembic/` + `alembic.ini` | Head `0003` (`flashcards`) after `0002` / `0001` ([ADR-03](../adr/003-alembic.md)) |
 | LLM | `llm/embedder.py`, `llm/chat.py`, `llm/transcribe.py` | MiniLM (optional extra) + stub embedder; Ollama / OpenAI-compat / offline chat; opt-in voice STT (ADR-08) |
 | Ingest | `ingest/extractors.py`, `chunking.py`, `pipeline.py`, `watcher.py` | File/URL extract, chunk, persist, inbox watch ([#16](https://github.com/Anna-Hax/JUNO/issues/16)) |
 | RAG | `rag/engine.py`, `rag/gaps.py` | Vector retrieve, sourced answers ([#17](https://github.com/Anna-Hax/JUNO/issues/17)); skill-gap flags ([#110](https://github.com/Anna-Hax/JUNO/issues/110)) |
-| HITL | `hitl/queue.py`, `hitl/trust.py` | Review queue; per-category trust dials (ADR-10) |
+| HITL | `hitl/queue.py`, `hitl/trust.py` | Review queue; per-category trust dials (ADR-10); prune locked (ADR-12) |
 
 ### Entry points
 
 - `uv run juno serve` → `runtime.main_sync()`
 - `uv run juno db-init` → `Database.migrate()` (Alembic `upgrade head`, or stamp legacy `create_all` DBs)
-- Tests: `test_foundation.py`, `test_migrations.py`, `test_ingest.py`, `test_vectors.py`, `test_embedder.py`, `test_chat.py`, `test_rag.py`, `test_bot.py`, `test_review.py`, `test_bot_review.py`, `test_api.py`, `test_write_queue.py`, `test_integration.py`, `test_export.py`, `test_jobs.py`, `test_transcribe.py`, `test_drafts.py`, `test_flashcards.py`, `test_journal.py`, `test_gaps.py`
+- Tests: `test_foundation.py`, `test_migrations.py`, `test_ingest.py`, `test_vectors.py`, `test_embedder.py`, `test_chat.py`, `test_rag.py`, `test_bot.py`, `test_review.py`, `test_bot_review.py`, `test_api.py`, `test_write_queue.py`, `test_integration.py`, `test_export.py`, `test_jobs.py`, `test_transcribe.py`, `test_drafts.py`, `test_flashcards.py`, `test_journal.py`, `test_gaps.py`, `test_prune.py`
 
 ### Dependencies
 

--- a/docs/sessions/56-session-prune-confirm.md
+++ b/docs/sessions/56-session-prune-confirm.md
@@ -1,0 +1,20 @@
+# Session 56 — Prune-with-confirm (#113)
+
+**Date:** 2026-09-05  
+**Issue:** [#113](https://github.com/Anna-Hax/JUNO/issues/113)  
+**Branch:** `feat/prune-confirm-113`
+
+## What changed
+
+- `/prune` lists old unused / aged failed captures. `/prune confirm` queues HITL `kind=prune`.
+- Approve archives rows and drops their Chroma ids. Reject leaves them. Never a silent delete; not `juno wipe`.
+- CLI `juno prune` is dry-run unless `--confirm prune-selected`. Optional `--export` before queueing.
+- Trust category `prune` is locked. Recorded in [ADR-12](../adr/012-prune-with-confirm.md).
+
+## Verify
+
+```powershell
+cd apps/core
+$env:EMBEDDING_BACKEND='stub'
+uv run pytest tests/test_prune.py tests/test_trust.py tests/test_bot.py -q
+```

--- a/docs/sessions/README.md
+++ b/docs/sessions/README.md
@@ -61,6 +61,7 @@ Living notes for what was implemented, how GitHub is set up, and what to do next
 | [53-session-skill-gaps.md](53-session-skill-gaps.md) | **#110** — Skill-gap tracking |
 | [54-session-trust-dial.md](54-session-trust-dial.md) | **#111** — Trust dial |
 | [55-session-slack-forward.md](55-session-slack-forward.md) | **#112** — Optional Slack forward |
+| [56-session-prune-confirm.md](56-session-prune-confirm.md) | **#113** — Prune-with-confirm |
 | [v1.0-release-gate.md](../v1.0-release-gate.md) | M1 checklist (all P0 closed) |
 | [v1.1-release-gate.md](../v1.1-release-gate.md) | M2 checklist (browser capture) |
 | [v1.2-release-gate.md](../v1.2-release-gate.md) | M3 checklist (IDE capture) |


### PR DESCRIPTION
## Summary
- `/prune` lists old unused or aged failed captures; `/prune confirm` queues HITL `kind=prune` (nothing is deleted yet).
- Approve archives those rows and drops their Chroma ids; Reject leaves them. Distinct from `juno wipe`.
- CLI dry-run unless `--confirm prune-selected`; optional `--export` first. Trust category `prune` stays locked (ADR-12).

## Linked issue
Closes #113

## Test plan
- [x] `uv run pytest` (apps/core, stub embeddings) — 196 passed
- [x] `uv run ruff check src tests`
- [ ] CI lint-test (ubuntu + windows)