### PR TITLE
feat(jobs): record polish flashcard and draft ticks on module_health

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -41,6 +41,9 @@ EMBEDDING_BACKEND=sentence_transformers
 # JUNO_JOBS_DIGEST_WEEKLY_CRON=0 7 * * mon
 # JUNO_JOBS_RESURFACING=true
 # JUNO_JOBS_RESURFACING_CRON=0 * * * *
+# M5 polish — flashcard + draft generation on the serve loop; /pause skips
+# JUNO_JOBS_POLISH=true
+# JUNO_JOBS_POLISH_CRON=0 8 * * *
 
 # M5 drafts (ADR-09) — template journal snippet through /review; never auto-publish
 # JUNO_DRAFTS_GENERATOR=template

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Personal knowledge-graph agent: passively (and manually) capture what you read, 
 
 ## Architecture (v1)
 
-- **Python core** (`apps/core`): FastAPI on `127.0.0.1` + Telegram long-polling in one shared asyncio event loop ([ADR-01](docs/adr/001-shared-event-loop.md)); APScheduler jobs on that same loop ([ADR-07](docs/adr/007-proactive-jobs-shared-loop.md)); voice STT stays opt-in ([ADR-08](docs/adr/008-voice-transcription.md))
+- **Python core** (`apps/core`): FastAPI on `127.0.0.1` + Telegram long-polling in one shared asyncio event loop ([ADR-01](docs/adr/001-shared-event-loop.md)); APScheduler jobs on that same loop ([ADR-07](docs/adr/007-proactive-jobs-shared-loop.md)) including polish flashcard/draft ticks; voice STT stays opt-in ([ADR-08](docs/adr/008-voice-transcription.md))
 - **SQLite + write queue** for the graph ([ADR-02](docs/adr/002-sqlite-write-queue.md)); **Alembic** for schema changes ([ADR-03](docs/adr/003-alembic.md))
 - **Chroma** for vectors — persistent client, one collection per embedding model ([ADR-04](docs/adr/004-chroma-collections.md)); **stub embedder** in CI
 - **Browser extension** (`apps/extension`): MV3 loopback client ([ADR-05](docs/adr/005-browser-extension-client.md)); Spike S2 captures tabs → `POST /ingest`

--- a/apps/core/src/juno/bot/handlers.py
+++ b/apps/core/src/juno/bot/handlers.py
@@ -34,7 +34,7 @@ HELP_TEXT = (
     "/start — hello\n"
     "/help — this message\n"
     "/digest today|week — recent captures\n"
-    "/jobs — scheduled digest / resurfacing on|off\n"
+    "/jobs — scheduled digest / resurfacing / polish on|off\n"
     "/pause — stop all ingest\n"
     "/resume — resume ingest (processes inbox backlog)\n"
     "/status — capture + module health\n"
@@ -112,7 +112,9 @@ async def jobs_cmd(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
         await update.message.reply_text(format_jobs_status(svc.app))
         return
     if len(args) != 2 or args[0] not in TOGGLEABLE_JOBS or args[1] not in {"on", "off"}:
-        await update.message.reply_text("Usage: /jobs   or   /jobs daily|weekly|resurface on|off")
+        await update.message.reply_text(
+            "Usage: /jobs   or   /jobs daily|weekly|resurface|polish on|off"
+        )
         return
     job_id = TOGGLEABLE_JOBS[args[0]]
     msg = await set_cron_job_enabled(svc.app, job_id, enabled=args[1] == "on")
@@ -250,7 +252,7 @@ async def pause_cmd(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
     await svc.set_paused(True)
     await update.message.reply_text(
         "Capture paused. Inbox, API /ingest, Telegram capture, "
-        "and scheduled digest pushes are stopped."
+        "scheduled digest/resurface pushes, and draft/flashcard generation are stopped."
     )
 
 

--- a/apps/core/src/juno/config.py
+++ b/apps/core/src/juno/config.py
@@ -81,6 +81,8 @@ class Settings(BaseSettings):
     juno_jobs_digest_weekly_cron: str = "0 7 * * mon"
     juno_jobs_resurfacing: bool = True
     juno_jobs_resurfacing_cron: str = "0 * * * *"
+    juno_jobs_polish: bool = True
+    juno_jobs_polish_cron: str = "0 8 * * *"
 
     # M5 drafts (ADR-09): template HITL artifacts; never auto-publish.
     juno_drafts_smoke: bool = False

--- a/apps/core/src/juno/drafts/__init__.py
+++ b/apps/core/src/juno/drafts/__init__.py
@@ -1,5 +1,6 @@
 """Auto-generated draft artifacts (M5). Stay HITL until approve; never auto-publish."""
 
+from juno.drafts.flashcards import queue_highlight_flashcards
 from juno.drafts.generate import (
     enqueue_doc_draft,
     enqueue_flashcard_draft,

--- a/apps/core/src/juno/drafts/generate.py
+++ b/apps/core/src/juno/drafts/generate.py
@@ -146,16 +146,20 @@ async def enqueue_doc_draft(
 
 async def maybe_enqueue_smoke_draft(app: Any) -> ReviewCard | None:
     """Spike S5: one draft at serve start when JUNO_DRAFTS_SMOKE is on."""
+    from juno.jobs.health import record_polish_health
+
     settings = getattr(app.state, "settings", None)
     if settings is None or not bool(getattr(settings, "juno_drafts_smoke", False)):
         return None
+    db: Database | None = getattr(app.state, "db", None)
     if bool(getattr(app.state, "capture_paused", False)):
         logger.info("drafts smoke skipped — capture paused")
+        await record_polish_health(db, detail="drafts smoke skipped (paused)", ok=True)
         return None
-    db: Database | None = getattr(app.state, "db", None)
     if db is None:
         return None
     generator = getattr(settings, "juno_drafts_generator", GENERATOR_TEMPLATE)
     card = await enqueue_journal_draft(db, generator=generator)
     logger.info("drafts smoke queued review #%s (kind=%s)", card.id, card.kind)
+    await record_polish_health(db, detail=f"drafts smoke queued #{card.id}", ok=True)
     return card

--- a/apps/core/src/juno/jobs/__init__.py
+++ b/apps/core/src/juno/jobs/__init__.py
@@ -3,6 +3,7 @@
 from juno.jobs.registry import (
     DIGEST_DAILY_JOB_ID,
     DIGEST_WEEKLY_JOB_ID,
+    POLISH_JOB_ID,
     RESURFACING_JOB_ID,
     TOGGLEABLE_JOBS,
     JobSpec,
@@ -28,6 +29,7 @@ from juno.jobs.scheduler import (
 __all__ = [
     "DIGEST_DAILY_JOB_ID",
     "DIGEST_WEEKLY_JOB_ID",
+    "POLISH_JOB_ID",
     "RESURFACING_JOB_ID",
     "SMOKE_JOB_ID",
     "SMOKE_TEXT",

--- a/apps/core/src/juno/jobs/handlers.py
+++ b/apps/core/src/juno/jobs/handlers.py
@@ -86,3 +86,47 @@ async def resurfacing(app: Any) -> None:
         logger.exception("resurfacing failed")
         await record_jobs_health(db, detail="resurfacing", ok=False, error=str(exc))
         raise
+
+
+async def polish(app: Any) -> None:
+    """Generate HITL flashcard/journal drafts. No Telegram push; skip when paused."""
+    from sqlalchemy import func, select
+
+    from juno.drafts.flashcards import queue_highlight_flashcards
+    from juno.drafts.journal import queue_ide_journal_draft
+    from juno.drafts.kinds import DRAFT_KIND_JOURNAL, STATUS_PENDING
+    from juno.jobs.health import record_polish_health
+    from juno.models import DraftArtifact
+
+    db = getattr(app.state, "db", None) if app is not None else None
+    if db is None:
+        logger.info("polish skipped — database not attached")
+        return
+    try:
+        if app is not None and bool(getattr(app.state, "capture_paused", False)):
+            await record_polish_health(db, detail="polish skipped (paused)", ok=True)
+            return
+        cards = await queue_highlight_flashcards(db, paused=False)
+
+        async def pending_journals(session) -> int:
+            result = await session.execute(
+                select(func.count())
+                .select_from(DraftArtifact)
+                .where(DraftArtifact.kind == DRAFT_KIND_JOURNAL)
+                .where(DraftArtifact.status == STATUS_PENDING)
+            )
+            return int(result.scalar_one())
+
+        journal_n = 0
+        if await db.read(pending_journals) == 0:
+            queued = await queue_ide_journal_draft(db, paused=False)
+            journal_n = 1 if queued is not None else 0
+        await record_polish_health(
+            db,
+            detail=f"polish flashcards={len(cards)} journal={journal_n}",
+            ok=True,
+        )
+    except Exception as exc:  # noqa: BLE001
+        logger.exception("polish failed")
+        await record_polish_health(db, detail="polish", ok=False, error=str(exc))
+        raise

--- a/apps/core/src/juno/jobs/health.py
+++ b/apps/core/src/juno/jobs/health.py
@@ -1,4 +1,4 @@
-"""Persist scheduler freshness on module_health.jobs (ADR-02 writes)."""
+"""Persist scheduler freshness on module_health (ADR-02 writes)."""
 
 from __future__ import annotations
 
@@ -10,10 +10,12 @@ from juno.graph.db import Database
 from juno.models import ModuleHealth
 
 JOBS_MODULE = "jobs"
+POLISH_MODULE = "polish"
 
 
-async def record_jobs_health(
+async def record_named_health(
     db: Database | None,
+    module: str,
     *,
     detail: str,
     ok: bool = True,
@@ -23,9 +25,9 @@ async def record_jobs_health(
         return
 
     async def write(session: AsyncSession) -> None:
-        row = await session.get(ModuleHealth, JOBS_MODULE)
+        row = await session.get(ModuleHealth, module)
         if row is None:
-            row = ModuleHealth(module=JOBS_MODULE)
+            row = ModuleHealth(module=module)
             session.add(row)
         now = datetime.now(UTC)
         row.detail = detail
@@ -37,3 +39,23 @@ async def record_jobs_health(
             row.last_error = (error or "job failed")[:500]
 
     await db.write(write)
+
+
+async def record_jobs_health(
+    db: Database | None,
+    *,
+    detail: str,
+    ok: bool = True,
+    error: str | None = None,
+) -> None:
+    await record_named_health(db, JOBS_MODULE, detail=detail, ok=ok, error=error)
+
+
+async def record_polish_health(
+    db: Database | None,
+    *,
+    detail: str,
+    ok: bool = True,
+    error: str | None = None,
+) -> None:
+    await record_named_health(db, POLISH_MODULE, detail=detail, ok=ok, error=error)

--- a/apps/core/src/juno/jobs/registry.py
+++ b/apps/core/src/juno/jobs/registry.py
@@ -15,10 +15,12 @@ from juno.models import AppSetting
 DIGEST_DAILY_JOB_ID = "digest_daily"
 DIGEST_WEEKLY_JOB_ID = "digest_weekly"
 RESURFACING_JOB_ID = "resurfacing"
+POLISH_JOB_ID = "polish"
 TOGGLEABLE_JOBS = {
     "daily": DIGEST_DAILY_JOB_ID,
     "weekly": DIGEST_WEEKLY_JOB_ID,
     "resurface": RESURFACING_JOB_ID,
+    "polish": POLISH_JOB_ID,
 }
 
 
@@ -55,6 +57,12 @@ def builtin_job_specs(settings: Settings) -> tuple[JobSpec, ...]:
             enabled=settings.juno_jobs_resurfacing,
             timezone=tz,
         ),
+        JobSpec(
+            id=POLISH_JOB_ID,
+            crontab=settings.juno_jobs_polish_cron,
+            enabled=settings.juno_jobs_polish,
+            timezone=tz,
+        ),
     )
 
 
@@ -86,7 +94,7 @@ def apply_enabled_overrides(
 
 
 async def load_job_enabled_overrides(db: Database) -> dict[str, bool]:
-    keys = (DIGEST_DAILY_JOB_ID, DIGEST_WEEKLY_JOB_ID, RESURFACING_JOB_ID)
+    keys = (DIGEST_DAILY_JOB_ID, DIGEST_WEEKLY_JOB_ID, RESURFACING_JOB_ID, POLISH_JOB_ID)
 
     async def fn(session: AsyncSession) -> dict[str, bool]:
         out: dict[str, bool] = {}

--- a/apps/core/src/juno/jobs/scheduler.py
+++ b/apps/core/src/juno/jobs/scheduler.py
@@ -12,10 +12,11 @@ from zoneinfo import ZoneInfo
 from apscheduler.schedulers.asyncio import AsyncIOScheduler
 
 from juno.config import Settings
-from juno.jobs.handlers import digest_daily, digest_weekly, resurfacing
+from juno.jobs.handlers import digest_daily, digest_weekly, polish, resurfacing
 from juno.jobs.registry import (
     DIGEST_DAILY_JOB_ID,
     DIGEST_WEEKLY_JOB_ID,
+    POLISH_JOB_ID,
     RESURFACING_JOB_ID,
     JobSpec,
     apply_enabled_overrides,
@@ -31,6 +32,7 @@ _HANDLER_BY_ID = {
     DIGEST_DAILY_JOB_ID: digest_daily,
     DIGEST_WEEKLY_JOB_ID: digest_weekly,
     RESURFACING_JOB_ID: resurfacing,
+    POLISH_JOB_ID: polish,
 }
 
 
@@ -218,5 +220,5 @@ def format_jobs_status(app: Any) -> str:
         nxt = job.next_run_time
         when = nxt.strftime("%Y-%m-%d %H:%M %Z") if nxt is not None else "paused"
         lines.append(f"• {spec.id}: on → {when}  ({spec.crontab})")
-    lines.append("Toggle: /jobs daily|weekly|resurface on|off")
+    lines.append("Toggle: /jobs daily|weekly|resurface|polish on|off")
     return "\n".join(lines)

--- a/apps/core/src/juno/runtime.py
+++ b/apps/core/src/juno/runtime.py
@@ -44,7 +44,7 @@ from juno.hitl.queue import ReviewQueue
 from juno.ingest.pipeline import IngestPipeline
 from juno.ingest.watcher import InboxWatcher
 from juno.jobs import load_job_enabled_overrides, start_jobs, stop_jobs
-from juno.jobs.health import record_jobs_health
+from juno.jobs.health import record_jobs_health, record_polish_health
 from juno.llm.chat import ChatProvider, create_chat_provider
 from juno.llm.embedder import Embedder, create_embedder
 from juno.llm.transcribe import create_transcriber
@@ -203,6 +203,7 @@ def attach_lifespan(fastapi_app: FastAPI) -> FastAPI:
             await record_jobs_health(db, detail="scheduler started", ok=True)
         else:
             await record_jobs_health(db, detail="scheduler disabled", ok=True)
+        await record_polish_health(db, detail="polish waiting for first tick", ok=True)
         await maybe_enqueue_smoke_draft(app)
 
         yield

--- a/apps/core/tests/test_bot.py
+++ b/apps/core/tests/test_bot.py
@@ -512,9 +512,10 @@ async def test_status_reports_pause_and_health(allowed_settings, db):
     app.state.llm_healthy = False
     app.state.embedder = SimpleNamespace(model_id="stub-hash-v1")
     vectors = FakeVectors()
-    from juno.jobs.health import record_jobs_health
+    from juno.jobs.health import record_jobs_health, record_polish_health
 
     await record_jobs_health(db, detail="digest_daily skipped (paused)", ok=True)
+    await record_polish_health(db, detail="polish skipped (paused)", ok=True)
     svc = _svc(allowed_settings, db=db, app=app, vectors=vectors)
     update = _update(ALLOWED_ID, "/status")
     await status_cmd(update, _context(svc))
@@ -524,6 +525,7 @@ async def test_status_reports_pause_and_health(allowed_settings, db):
     assert "stub-hash-v1" in body
     assert "Serve-down" in body
     assert "jobs:" in body
+    assert "polish:" in body
     assert "paused" in body
 
 

--- a/apps/core/tests/test_jobs.py
+++ b/apps/core/tests/test_jobs.py
@@ -12,6 +12,7 @@ from juno.config import Settings
 from juno.jobs import (
     DIGEST_DAILY_JOB_ID,
     DIGEST_WEEKLY_JOB_ID,
+    POLISH_JOB_ID,
     RESURFACING_JOB_ID,
     SMOKE_JOB_ID,
     builtin_job_specs,
@@ -117,11 +118,12 @@ async def test_start_jobs_smoke_registers_one_shot(settings: Settings):
 def test_builtin_registry_defaults_without_telegram(settings: Settings):
     specs = builtin_job_specs(settings)
     ids = [spec.id for spec in specs]
-    assert ids == [DIGEST_DAILY_JOB_ID, DIGEST_WEEKLY_JOB_ID, RESURFACING_JOB_ID]
+    assert ids == [DIGEST_DAILY_JOB_ID, DIGEST_WEEKLY_JOB_ID, RESURFACING_JOB_ID, POLISH_JOB_ID]
     assert enabled_job_ids(specs) == [
         DIGEST_DAILY_JOB_ID,
         DIGEST_WEEKLY_JOB_ID,
         RESURFACING_JOB_ID,
+        POLISH_JOB_ID,
     ]
     daily = next(spec for spec in specs if spec.id == DIGEST_DAILY_JOB_ID)
     assert daily.crontab == "0 7 * * *"
@@ -132,6 +134,7 @@ def test_disabled_job_is_not_added_to_scheduler(settings: Settings):
     settings.juno_jobs_digest_daily = False
     settings.juno_jobs_digest_weekly = False
     settings.juno_jobs_resurfacing = False
+    settings.juno_jobs_polish = False
     scheduler = create_scheduler("UTC")
     added = register_job_specs(scheduler, builtin_job_specs(settings), app=None)
     assert added == []
@@ -145,6 +148,7 @@ def test_register_job_specs_without_starting_or_telegram(settings: Settings):
     assert DIGEST_DAILY_JOB_ID in added
     assert DIGEST_WEEKLY_JOB_ID in added
     assert RESURFACING_JOB_ID in added
+    assert POLISH_JOB_ID in added
     assert scheduler.get_job(DIGEST_DAILY_JOB_ID) is not None
     assert scheduler.running is False
 
@@ -161,12 +165,14 @@ async def test_start_jobs_registers_enabled_cron_jobs(settings: Settings):
     settings.juno_jobs_smoke = False
     settings.juno_jobs_digest_weekly = False
     settings.juno_jobs_resurfacing = False
+    settings.juno_jobs_polish = False
     app = SimpleNamespace(state=SimpleNamespace(settings=settings, ptb=None, capture_paused=False))
     scheduler = start_jobs(app)
     try:
         assert scheduler.get_job(DIGEST_DAILY_JOB_ID) is not None
         assert scheduler.get_job(DIGEST_WEEKLY_JOB_ID) is None
         assert scheduler.get_job(RESURFACING_JOB_ID) is None
+        assert scheduler.get_job(POLISH_JOB_ID) is None
     finally:
         stop_jobs(app)
 
@@ -243,12 +249,54 @@ async def test_digest_pause_records_jobs_module_health(settings: Settings):
         await db.dispose()
 
 
+@pytest.mark.asyncio
+async def test_polish_pause_skips_generation_and_records_health(settings: Settings):
+    from fastapi.testclient import TestClient
+
+    from juno.api import create_app
+    from juno.graph.db import Database
+    from juno.jobs.handlers import polish
+    from juno.models import ModuleHealth
+
+    db = Database(settings)
+    await db.migrate()
+    bot = AsyncMock()
+    app = create_app(settings, db=db)
+    app.state.ptb = SimpleNamespace(bot=bot)
+    app.state.capture_paused = True
+    try:
+        await polish(app)
+
+        async def polish_row(session):
+            return await session.get(ModuleHealth, "polish")
+
+        health = await db.read(polish_row)
+        assert health is not None
+        assert health.last_success_at is not None
+        assert health.last_error is None
+        assert "paused" in (health.detail or "")
+
+        client = TestClient(app)
+        resp = client.get("/status", headers={"Authorization": "Bearer test-token"})
+        assert resp.status_code == 200
+        modules = {row["module"]: row for row in resp.json()["modules"]}
+        assert "polish" in modules
+        assert "paused" in (modules["polish"]["detail"] or "")
+        bot.send_message.assert_not_awaited()
+    finally:
+        await db.dispose()
+
+
 def test_apply_enabled_overrides(settings: Settings):
     from juno.jobs import apply_enabled_overrides
 
     specs = builtin_job_specs(settings)
     patched = apply_enabled_overrides(specs, {DIGEST_DAILY_JOB_ID: False})
-    assert enabled_job_ids(patched) == [DIGEST_WEEKLY_JOB_ID, RESURFACING_JOB_ID]
+    assert enabled_job_ids(patched) == [
+        DIGEST_WEEKLY_JOB_ID,
+        RESURFACING_JOB_ID,
+        POLISH_JOB_ID,
+    ]
 
 
 @pytest.mark.asyncio

--- a/docs/adr/007-proactive-jobs-shared-loop.md
+++ b/docs/adr/007-proactive-jobs-shared-loop.md
@@ -42,10 +42,10 @@ Concrete rules (`juno.jobs.scheduler`):
    - `JUNO_JOBS_ENABLED` (default `true`) — start the scheduler at all
    - `JUNO_JOBS_TIMEZONE` (default `UTC`) — cron/date interpretation
    - `JUNO_JOBS_SMOKE` (default `false`) — Spike S4 one-shot Telegram line ~2s after start
-   - Per-job enable + 5-field crontab: `JUNO_JOBS_DIGEST_DAILY` / `_CRON` (default `true`, `0 7 * * *`), `JUNO_JOBS_DIGEST_WEEKLY` / `_CRON` (default `true`, `0 7 * * mon`), `JUNO_JOBS_RESURFACING` / `_CRON` (default `true`, `0 * * * *`)
+   - Per-job enable + 5-field crontab: `JUNO_JOBS_DIGEST_DAILY` / `_CRON` (default `true`, `0 7 * * *`), `JUNO_JOBS_DIGEST_WEEKLY` / `_CRON` (default `true`, `0 7 * * mon`), `JUNO_JOBS_RESURFACING` / `_CRON` (default `true`, `0 * * * *`), `JUNO_JOBS_POLISH` / `_CRON` (default `true`, `0 8 * * *`)
 6. Tests and CI must not require live Telegram: `builtin_job_specs` / `register_job_specs` import and register without a bot; keep `JUNO_JOBS_SMOKE` off unless an operator is proving the loop.
 
-Named jobs live in `juno.jobs.registry` (`digest_daily`, `digest_weekly`, `resurfacing`). Invalid crontab fails at serve start (`CronTrigger.from_crontab`). Digest push bodies land in [#88](https://github.com/Anna-Hax/JUNO/issues/88). Resurfacing ([#89](https://github.com/Anna-Hax/JUNO/issues/89)) pushes high-confidence “this came up again” notes and queues low-confidence suggestions as HITL `resurface`. `module_health.jobs` records scheduler freshness ([#94](https://github.com/Anna-Hax/JUNO/issues/94)).
+Named jobs live in `juno.jobs.registry` (`digest_daily`, `digest_weekly`, `resurfacing`, `polish`). Invalid crontab fails at serve start (`CronTrigger.from_crontab`). Digest push bodies land in [#88](https://github.com/Anna-Hax/JUNO/issues/88). Resurfacing ([#89](https://github.com/Anna-Hax/JUNO/issues/89)) pushes high-confidence “this came up again” notes and queues low-confidence suggestions as HITL `resurface`. `module_health.jobs` records digest/resurface freshness ([#94](https://github.com/Anna-Hax/JUNO/issues/94)). `module_health.polish` records flashcard/draft generation ticks ([#114](https://github.com/Anna-Hax/JUNO/issues/114)); `/pause` skips generation and does not push draft text.
 
 ## Consequences
 
@@ -72,6 +72,10 @@ Issue [#87](https://github.com/Anna-Hax/JUNO/issues/87): `builtin_job_specs` + `
 ## Module health (#94)
 
 Issue [#94](https://github.com/Anna-Hax/JUNO/issues/94): `module_health.jobs` is written through `Database.write()` on scheduler start and after each digest/resurfacing tick (including `/pause` skips). Last success/error shows on Telegram `/status` and `GET /status.modules`.
+
+## Polish jobs (#114)
+
+Issue [#114](https://github.com/Anna-Hax/JUNO/issues/114): named cron `polish` queues HITL flashcard drafts (and a journal draft if none is pending). It does **not** auto-publish or Telegram-push draft bodies. `/pause` records `module_health.polish` as skipped and generates nothing.
 
 ## What landed (M4)
 

--- a/docs/next-work.md
+++ b/docs/next-work.md
@@ -200,10 +200,10 @@ Milestone: [M5: v2.0 Polish & Extensions](https://github.com/Anna-Hax/JUNO/miles
 | 6 | [#111](https://github.com/Anna-Hax/JUNO/issues/111) | Trust dial — per-category auto-commit thresholds — ✅ [session 54](sessions/54-session-trust-dial.md) |
 | 7 | [#112](https://github.com/Anna-Hax/JUNO/issues/112) | Optional Slack forward into upload space — ✅ [session 55](sessions/55-session-slack-forward.md) |
 | 8 | [#113](https://github.com/Anna-Hax/JUNO/issues/113) | Prune-with-confirm — retention / destructive graph cleanup — ✅ [session 56](sessions/56-session-prune-confirm.md) |
-| 9 | [#114](https://github.com/Anna-Hax/JUNO/issues/114) | Module health — polish jobs freshness + respect /pause |
+| 9 | [#114](https://github.com/Anna-Hax/JUNO/issues/114) | Module health — polish jobs freshness + respect /pause — ✅ [session 57](sessions/57-session-polish-health.md) |
 | 10 | [#115](https://github.com/Anna-Hax/JUNO/issues/115) | M5 gate — polish tests, ADR, README, v2.0 release gate |
 
-**First coding task:** #106–#113 ✅. Next: module health polish ([#114](https://github.com/Anna-Hax/JUNO/issues/114)).
+**First coding task:** #106–#114 ✅. Next: M5 gate ([#115](https://github.com/Anna-Hax/JUNO/issues/115)).
 
 ### M5 design constraints (do not violate)
 

--- a/docs/sessions/02-codebase-map.md
+++ b/docs/sessions/02-codebase-map.md
@@ -31,7 +31,7 @@ JUNO/
 | Config | `config.py` | pydantic-settings from `.env` |
 | CLI | `cli.py` | `juno serve` / `db-init` / `export` / `prune` / `wipe` / `version` |
 | Runtime | `runtime.py` | Shared asyncio: uvicorn + PTB + inbox watcher + jobs scheduler lifespan |
-| Jobs | `jobs/scheduler.py`, `jobs/registry.py`, `jobs/handlers.py`, `jobs/health.py`, `jobs/resurface.py` | AsyncIOScheduler + named cron registry (ADR-07) |
+| Jobs | `jobs/scheduler.py`, `jobs/registry.py`, `jobs/handlers.py`, `jobs/health.py`, `jobs/resurface.py` | AsyncIOScheduler + named cron registry (ADR-07); `module_health.polish` for flashcard/draft ticks ([#114](https://github.com/Anna-Hax/JUNO/issues/114)) |
 | Drafts | `drafts/generate.py`, `drafts/kinds.py`, `drafts/flashcards.py`, `drafts/journal.py` | HITL journal/flashcard/doc; SRS after flashcard approve; IDE journal/README via `/drafts` (ADR-09) |
 | API | `api/__init__.py` | FastAPI routes + token + loopback middleware |
 | Bot | `bot/handlers.py`, `bot/services.py`, `bot/review.py` | Telegram allowlist, query, capture, pause/digest/status ([#18](https://github.com/Anna-Hax/JUNO/issues/18) / [#19](https://github.com/Anna-Hax/JUNO/issues/19)); HITL `/review` ([#20](https://github.com/Anna-Hax/JUNO/issues/20)); opt-in Slack.com links ([ADR-11](../adr/011-slack-forward.md)) |

--- a/docs/sessions/57-session-polish-health.md
+++ b/docs/sessions/57-session-polish-health.md
@@ -1,0 +1,19 @@
+# Session 57 — Polish jobs module health (#114)
+
+**Date:** 2026-09-05  
+**Issue:** [#114](https://github.com/Anna-Hax/JUNO/issues/114)  
+**Branch:** `feat/polish-health-114`
+
+## What changed
+
+- Named cron `polish` (default `0 8 * * *`) queues HITL flashcard drafts and a journal draft if none is pending.
+- `module_health.polish` last success/error shows on `/status` and `GET /status.modules`.
+- `/pause` skips generation and does not push draft text. ADR-07 updated.
+
+## Verify
+
+```powershell
+cd apps/core
+$env:EMBEDDING_BACKEND='stub'
+uv run pytest tests/test_jobs.py tests/test_bot.py -q
+```

--- a/docs/sessions/README.md
+++ b/docs/sessions/README.md
@@ -62,6 +62,7 @@ Living notes for what was implemented, how GitHub is set up, and what to do next
 | [54-session-trust-dial.md](54-session-trust-dial.md) | **#111** — Trust dial |
 | [55-session-slack-forward.md](55-session-slack-forward.md) | **#112** — Optional Slack forward |
 | [56-session-prune-confirm.md](56-session-prune-confirm.md) | **#113** — Prune-with-confirm |
+| [57-session-polish-health.md](57-session-polish-health.md) | **#114** — Polish jobs module health |
 | [v1.0-release-gate.md](../v1.0-release-gate.md) | M1 checklist (all P0 closed) |
 | [v1.1-release-gate.md](../v1.1-release-gate.md) | M2 checklist (browser capture) |
 | [v1.2-release-gate.md](../v1.2-release-gate.md) | M3 checklist (IDE capture) |


### PR DESCRIPTION
## Summary
- Named cron `polish` queues HITL flashcard drafts (and a journal draft if none is pending) on the shared serve loop.
- `module_health.polish` last success/error shows on Telegram `/status` and `GET /status.modules`.
- `/pause` skips generation and does not push draft text (ADR-07).

## Linked issue
Closes #114

## Test plan
- [x] `uv run pytest` (apps/core, stub embeddings) — 197 passed
- [x] `uv run ruff check src tests`
- [ ] CI lint-test (ubuntu + windows)