### PR TITLE
chore(release): add v2.0 gate checklist and bump version to 2.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Personal knowledge-graph agent: passively (and manually) capture what you read, code, and discuss — query it from **Telegram**. Local-first on your PC.
 
-**Status:** **v1.3 Proactive & mobile** (M4 complete) — scheduled Telegram digests and resurfacing on the shared asyncio loop, temporal queries, voice memos, and mobile HITL. Polish (M5) is next.
+**Status:** **v2.0 Polish** (M5 complete) — HITL drafts and flashcards, trust dials, opt-in Slack link forward, prune-with-confirm, polish jobs on the shared loop.
 
 ## Architecture (v1)
 

--- a/apps/core/pyproject.toml
+++ b/apps/core/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "juno"
-version = "1.3.0"
+version = "2.0.0"
 description = "Personal knowledge graph agent — local-first second brain via Telegram"
 requires-python = ">=3.12"
 dependencies = [

--- a/apps/core/src/juno/__init__.py
+++ b/apps/core/src/juno/__init__.py
@@ -1,3 +1,3 @@
 """Juno — personal knowledge graph agent."""
 
-__version__ = "1.3.0"
+__version__ = "2.0.0"

--- a/apps/core/uv.lock
+++ b/apps/core/uv.lock
@@ -1070,7 +1070,7 @@ wheels = [
 
 [[package]]
 name = "juno"
-version = "1.3.0"
+version = "2.0.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiosqlite" },

--- a/docs/adr/001-shared-event-loop.md
+++ b/docs/adr/001-shared-event-loop.md
@@ -7,7 +7,7 @@ Accepted (v1)
 ## Date
 
 2026-08-20 (M0 scaffold)  
-**Last reviewed:** 2026-09-05 (M5 Spike S5 / ADR-09)
+**Last reviewed:** 2026-09-05 (M5 gate / v2.0)
 
 ## Context
 
@@ -94,6 +94,6 @@ Operator may still tap `/start`, a short query, and `/status` in Telegram for fu
 
 ### Follow-ups (not M1)
 
-- **APScheduler** on this loop landed in M4 ([ADR-07](007-proactive-jobs-shared-loop.md); [#86](https://github.com/Anna-Hax/JUNO/issues/86)–[#89](https://github.com/Anna-Hax/JUNO/issues/89), [#94](https://github.com/Anna-Hax/JUNO/issues/94)).
+- **APScheduler** on this loop landed in M4 ([ADR-07](007-proactive-jobs-shared-loop.md); [#86](https://github.com/Anna-Hax/JUNO/issues/86)–[#89](https://github.com/Anna-Hax/JUNO/issues/89), [#94](https://github.com/Anna-Hax/JUNO/issues/94)). M5 polish ticks use the same scheduler ([#114](https://github.com/Anna-Hax/JUNO/issues/114)).
 - Keep documenting “no `run_polling()`” next to any new entrypoint so this ADR is not rediscovered the hard way.
 - IDE / Cursor capture is a **loopback HTTP client** ([ADR-06](006-ide-adapter-client.md)), not a second process or event loop.

--- a/docs/next-work.md
+++ b/docs/next-work.md
@@ -2,7 +2,7 @@
 
 **Last updated:** 2026-09-05  
 **Track issues on:** [https://github.com/Anna-Hax/JUNO/issues](https://github.com/Anna-Hax/JUNO/issues)  
-**Package:** `1.3.0` (M4 complete — M5 polish expanded; [`docs/v1.3-release-gate.md`](v1.3-release-gate.md))
+**Package:** `2.0.0` (M5 complete — [`docs/v2.0-release-gate.md`](v2.0-release-gate.md))
 
 Prefer one open issue ≈ one PR (`Closes #N`). This file is kept as-is across branch merges (`merge=ours`).
 
@@ -183,6 +183,12 @@ No blocking prep tickets (unlike Before M2’s Spike S1 / board / protection). M
 
 ---
 
+## M5 — **complete** (2026-09-05)
+
+Epic [#28](https://github.com/Anna-Hax/JUNO/issues/28) closed with this gate; milestone [M5: v2.0 Polish & Extensions](https://github.com/Anna-Hax/JUNO/milestone/11) complete. Gate: [`docs/v2.0-release-gate.md`](v2.0-release-gate.md). Package **2.0.0**.
+
+---
+
 ## Unlock M5 (planning)
 
 Epic: [#28](https://github.com/Anna-Hax/JUNO/issues/28) — *Epic: M5 v2.0 polish*.  
@@ -201,9 +207,9 @@ Milestone: [M5: v2.0 Polish & Extensions](https://github.com/Anna-Hax/JUNO/miles
 | 7 | [#112](https://github.com/Anna-Hax/JUNO/issues/112) | Optional Slack forward into upload space — ✅ [session 55](sessions/55-session-slack-forward.md) |
 | 8 | [#113](https://github.com/Anna-Hax/JUNO/issues/113) | Prune-with-confirm — retention / destructive graph cleanup — ✅ [session 56](sessions/56-session-prune-confirm.md) |
 | 9 | [#114](https://github.com/Anna-Hax/JUNO/issues/114) | Module health — polish jobs freshness + respect /pause — ✅ [session 57](sessions/57-session-polish-health.md) |
-| 10 | [#115](https://github.com/Anna-Hax/JUNO/issues/115) | M5 gate — polish tests, ADR, README, v2.0 release gate |
+| 10 | [#115](https://github.com/Anna-Hax/JUNO/issues/115) | M5 gate — polish tests, ADR, README, v2.0 release gate — ✅ [session 58](sessions/58-session-m5-gate.md) |
 
-**First coding task:** #106–#114 ✅. Next: M5 gate ([#115](https://github.com/Anna-Hax/JUNO/issues/115)).
+**First coding task:** #106–#115 ✅. M5 / epic [#28](https://github.com/Anna-Hax/JUNO/issues/28) complete. Gate: [`docs/v2.0-release-gate.md`](v2.0-release-gate.md).
 
 ### M5 design constraints (do not violate)
 

--- a/docs/sessions/58-session-m5-gate.md
+++ b/docs/sessions/58-session-m5-gate.md
@@ -1,0 +1,22 @@
+# Session 58 — M5 gate: v2.0 (#115)
+
+**Date:** 2026-09-05  
+**Issue:** [#115](https://github.com/Anna-Hax/JUNO/issues/115)  
+**Branch:** `feat/m5-gate-115`
+
+## What changed
+
+- [`docs/v2.0-release-gate.md`](../v2.0-release-gate.md) — M5 checklist; all #106–#114 PRs listed.
+- Package **2.0.0**. README + next-work mark M5 complete.
+- ADRs 09–12 already cover drafts, trust, Slack, prune; ADR-07 polish jobs.
+
+## Verify
+
+```powershell
+cd apps/core
+$env:EMBEDDING_BACKEND='stub'
+uv run pytest -q
+uv run juno version   # expect 2.0.0
+```
+
+CI must stay green with `JUNO_JOBS_SMOKE` off and `JUNO_SLACK_FORWARD` off (no live Telegram/Slack).

--- a/docs/sessions/README.md
+++ b/docs/sessions/README.md
@@ -63,9 +63,11 @@ Living notes for what was implemented, how GitHub is set up, and what to do next
 | [55-session-slack-forward.md](55-session-slack-forward.md) | **#112** — Optional Slack forward |
 | [56-session-prune-confirm.md](56-session-prune-confirm.md) | **#113** — Prune-with-confirm |
 | [57-session-polish-health.md](57-session-polish-health.md) | **#114** — Polish jobs module health |
+| [58-session-m5-gate.md](58-session-m5-gate.md) | **#115** — M5 gate + v2.0 |
 | [v1.0-release-gate.md](../v1.0-release-gate.md) | M1 checklist (all P0 closed) |
 | [v1.1-release-gate.md](../v1.1-release-gate.md) | M2 checklist (browser capture) |
 | [v1.2-release-gate.md](../v1.2-release-gate.md) | M3 checklist (IDE capture) |
 | [v1.3-release-gate.md](../v1.3-release-gate.md) | M4 checklist (proactive + mobile) |
+| [v2.0-release-gate.md](../v2.0-release-gate.md) | M5 checklist (polish) |
 
 Architecture decisions live in [`../adr/`](../adr/). Product requirements: [`../../personal-knowledge-graph-prd.md](../../personal-knowledge-graph-prd.md).

--- a/docs/v2.0-release-gate.md
+++ b/docs/v2.0-release-gate.md
@@ -1,0 +1,65 @@
+# v2.0 release gate (M5: Polish & Extensions)
+
+**Date:** 2026-09-05  
+**Milestone:** [M5: v2.0 Polish & Extensions](https://github.com/Anna-Hax/JUNO/milestone/11)  
+**Package version:** `2.0.0` (`apps/core`)  
+**Epic:** [#28](https://github.com/Anna-Hax/JUNO/issues/28)
+
+This checklist closes issue **#115**. Acceptance: **all M5 child issues closed** and CI green without live Telegram or Slack.
+
+---
+
+## M5 issues (#106–#115)
+
+| Issue | Capability | Status | PR |
+|-------|------------|--------|-----|
+| [#106](https://github.com/Anna-Hax/JUNO/issues/106) | Spike S5 — template draft through HITL | ✅ Closed | [#116](https://github.com/Anna-Hax/JUNO/pull/116) |
+| [#107](https://github.com/Anna-Hax/JUNO/issues/107) | Draft artifacts scaffold (never auto-publish) | ✅ Closed | [#117](https://github.com/Anna-Hax/JUNO/pull/117) |
+| [#108](https://github.com/Anna-Hax/JUNO/issues/108) | Flashcards / SRS from highlights | ✅ Closed | [#118](https://github.com/Anna-Hax/JUNO/pull/118) |
+| [#109](https://github.com/Anna-Hax/JUNO/issues/109) | IDE journal / README drafts | ✅ Closed | [#119](https://github.com/Anna-Hax/JUNO/pull/119) |
+| [#110](https://github.com/Anna-Hax/JUNO/issues/110) | Skill-gap tracking | ✅ Closed | [#120](https://github.com/Anna-Hax/JUNO/pull/120) |
+| [#111](https://github.com/Anna-Hax/JUNO/issues/111) | Trust dial (mobile/drafts/prune locked) | ✅ Closed | [#121](https://github.com/Anna-Hax/JUNO/pull/121) |
+| [#112](https://github.com/Anna-Hax/JUNO/issues/112) | Optional Slack.com link forward | ✅ Closed | [#122](https://github.com/Anna-Hax/JUNO/pull/122) |
+| [#113](https://github.com/Anna-Hax/JUNO/issues/113) | Prune-with-confirm | ✅ Closed | [#123](https://github.com/Anna-Hax/JUNO/pull/123) |
+| [#114](https://github.com/Anna-Hax/JUNO/issues/114) | Polish jobs + `module_health.polish` | ✅ Closed | [#124](https://github.com/Anna-Hax/JUNO/pull/124) |
+| [#115](https://github.com/Anna-Hax/JUNO/issues/115) | Tests, ADRs, this gate, package 2.0.0 | ✅ Closed | (this doc + PR) |
+
+**M5:** 10 / 10 closed.
+
+---
+
+## CI / quality gate
+
+- [x] `uv run pytest` — **197** tests including drafts, flashcards/SRS, trust dials, prune archive, polish job pause (stub embedder, mocked Telegram)
+- [x] `uv run ruff check` + format check
+- [x] No live Telegram or Slack (`JUNO_SLACK_FORWARD` default off; `JUNO_JOBS_SMOKE` off)
+- [x] PR hygiene (`Closes #N`, conventional title)
+
+---
+
+## Manual smoke (operator)
+
+1. `uv run juno serve` with repo-root `.env`
+2. Telegram: `/drafts journal`, `/cards`, `/trust`, `/prune`, `/status` shows `polish` + `jobs`
+3. Optional: `JUNO_SLACK_FORWARD=true` then send a slack.com URL; confirm `/review` (leave off otherwise)
+4. `juno prune` dry-run; never silent delete. `juno wipe` remains the nuclear confirm phrase.
+
+---
+
+## What v2.0 means
+
+Phase 5 polish from the PRD:
+
+- Auto-generated journals, flashcards, and docs stay HITL drafts until Approve ([ADR-09](adr/009-draft-artifacts-hitl.md))
+- Per-category trust dials; mobile, drafts, and prune stay gated ([ADR-10](adr/010-trust-dials.md))
+- Slack is opt-in URL forward, not a workspace bot ([ADR-11](adr/011-slack-forward.md))
+- Selective prune archives only after `/review` Approve ([ADR-12](adr/012-prune-with-confirm.md))
+- Polish cron on the shared loop; `/pause` skips draft generation ([ADR-07](adr/007-proactive-jobs-shared-loop.md))
+
+**Not in v2.0:** live Slack listener, unattended writes into user git repos, rabbit-hole session narratives.
+
+---
+
+## Next
+
+M5 / epic #28 is the last planned v1 roadmap wave. Further work is operator-driven, not a new milestone in [`docs/next-work.md`](next-work.md).


### PR DESCRIPTION
## Summary
- Adds `docs/v2.0-release-gate.md` listing M5 issues #106–#115 and their PRs.
- Bumps `apps/core` to **2.0.0**. CI stays stub-embedder / mocked Telegram; Slack forward stays opt-in off.
- Marks the M5 board complete in next-work and README.

## Linked issue
Closes #115
Closes #28

## Test plan
- [x] `uv run juno version` → 2.0.0
- [x] `uv run pytest` subset (drafts/flashcards/trust/prune/foundation)
- [ ] CI lint-test (ubuntu + windows)